### PR TITLE
docs: expand README with configuration details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,66 @@
 # ResumeForge
+
+## Overview
+ResumeForge generates tailored cover letters by combining a candidate's résumé with a scraped job description. The service uses OpenAI for text generation and stores session artifacts in Amazon S3.
+
+## Environment Variables
+The server relies on the following environment variables:
+
+```json
+{
+  "AWS_REGION": "us-east-1",
+  "SECRET_ID": "your-secret-id",
+  "PORT": "3000"
+}
+```
+
+The AWS Secrets Manager secret referenced by `SECRET_ID` must contain:
+
+```json
+{
+  "OPENAI_API_KEY": "sk-...",
+  "S3_BUCKET": "resume-forge-data"
+}
+```
+
+## IAM Policy
+Minimal permissions required by the server:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["secretsmanager:GetSecretValue"],
+      "Resource": "arn:aws:secretsmanager:REGION:ACCOUNT_ID:secret:SECRET_ID"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:PutObject"],
+      "Resource": "arn:aws:s3:::S3_BUCKET/*"
+    }
+  ]
+}
+```
+
+## Local Development
+1. Install dependencies in both the server and client directories:
+   ```bash
+   npm install
+   cd client && npm install
+   ```
+2. Provide the environment variables and AWS secret as shown above.
+3. Start the server:
+   ```bash
+   npm run dev
+   ```
+4. In another terminal, start the client:
+   ```bash
+   cd client && npm run dev
+   ```
+
+## Edge Cases
+- **Name extraction fallback:** If the résumé text lacks a detectable name, the generated content defaults to a generic placeholder such as "Candidate".
+- **Job description scraping limitations:** The job description is retrieved with a simple HTTP GET request; dynamic or access-restricted pages may return empty or blocked content.
+


### PR DESCRIPTION
## Summary
- document required environment variables and corresponding Secrets Manager entries
- add minimal IAM policy and setup instructions for local development
- note edge cases around name extraction and job description scraping

## Testing
- `npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1c8bdb004832b898f31be33ee55ae