### PR TITLE
Add backend JSONL logging for processing steps

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,33 @@
+import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+
+async function streamToString(stream) {
+  return await new Promise((resolve, reject) => {
+    const chunks = [];
+    stream.on('data', chunk => chunks.push(chunk));
+    stream.on('error', reject);
+    stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+  });
+}
+
+export async function logEvent({ s3, bucket, key, jobId, event, level = 'info', message }) {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    jobId,
+    event,
+    level
+  };
+  if (message) entry.message = message;
+
+  let existing = '';
+  try {
+    const res = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+    existing = await streamToString(res.Body);
+  } catch (err) {
+    if (err.name !== 'NoSuchKey' && err.$metadata?.httpStatusCode !== 404) {
+      throw err;
+    }
+  }
+
+  const body = existing + JSON.stringify(entry) + '\n';
+  await s3.send(new PutObjectCommand({ Bucket: bucket, Key: key, Body: body, ContentType: 'application/json' }));
+}

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ import axios from 'axios';
 import OpenAI from 'openai';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+import { logEvent } from './logger.js';
 
 const app = express();
 app.use(cors());
@@ -28,20 +29,31 @@ app.get('/healthz', (req, res) => {
 });
 
 app.post('/api/process-cv', upload.single('resume'), async (req, res) => {
+  const jobId = Date.now().toString();
+  const prefix = `sessions/${jobId}/`;
+  const logKey = `${prefix}logs/processing.jsonl`;
+  const s3 = new S3Client({ region });
+  let bucket;
+
   try {
+    const secrets = await getSecrets();
+    bucket = secrets.S3_BUCKET;
+    await logEvent({ s3, bucket, key: logKey, jobId, event: 'request_received' });
+
     const { jobDescriptionUrl } = req.body;
     if (!req.file) {
+      await logEvent({ s3, bucket, key: logKey, jobId, event: 'missing_resume', level: 'error', message: 'resume file required' });
       return res.status(400).json({ error: 'resume file required' });
     }
     if (!jobDescriptionUrl) {
+      await logEvent({ s3, bucket, key: logKey, jobId, event: 'missing_jobDescriptionUrl', level: 'error', message: 'jobDescriptionUrl required' });
       return res.status(400).json({ error: 'jobDescriptionUrl required' });
     }
 
     const { data: jobDescription } = await axios.get(jobDescriptionUrl);
+    await logEvent({ s3, bucket, key: logKey, jobId, event: 'fetched_job_description' });
 
-    const secrets = await getSecrets();
     const openai = new OpenAI({ apiKey: secrets.OPENAI_API_KEY });
-    const bucket = secrets.S3_BUCKET;
 
     const prompt = `Using the resume below and job description, craft a tailored cover letter.\nResume:\n${req.file.buffer.toString()}\nJob Description:\n${jobDescription}`;
     const completion = await openai.chat.completions.create({
@@ -49,9 +61,7 @@ app.post('/api/process-cv', upload.single('resume'), async (req, res) => {
       messages: [{ role: 'user', content: prompt }]
     });
     const coverLetter = completion.choices[0].message?.content ?? '';
-
-    const s3 = new S3Client({ region });
-    const prefix = `sessions/${Date.now()}/`;
+    await logEvent({ s3, bucket, key: logKey, jobId, event: 'generated_cover_letter' });
 
     await s3.send(new PutObjectCommand({
       Bucket: bucket,
@@ -59,22 +69,35 @@ app.post('/api/process-cv', upload.single('resume'), async (req, res) => {
       Body: req.file.buffer,
       ContentType: req.file.mimetype
     }));
+    await logEvent({ s3, bucket, key: logKey, jobId, event: 'uploaded_resume' });
+
     await s3.send(new PutObjectCommand({
       Bucket: bucket,
       Key: `${prefix}coverLetter.txt`,
       Body: coverLetter,
       ContentType: 'text/plain'
     }));
+    await logEvent({ s3, bucket, key: logKey, jobId, event: 'uploaded_cover_letter' });
+
     await s3.send(new PutObjectCommand({
       Bucket: bucket,
       Key: `${prefix}log.json`,
       Body: JSON.stringify({ jobDescriptionUrl }),
       ContentType: 'application/json'
     }));
+    await logEvent({ s3, bucket, key: logKey, jobId, event: 'uploaded_metadata' });
 
+    await logEvent({ s3, bucket, key: logKey, jobId, event: 'completed' });
     res.json({ coverLetter });
   } catch (err) {
     console.error('processing failed', err);
+    if (bucket) {
+      try {
+        await logEvent({ s3, bucket, key: logKey, jobId, event: 'error', level: 'error', message: err.message });
+      } catch (e) {
+        console.error('failed to log error', e);
+      }
+    }
     res.status(500).json({ error: 'processing failed' });
   }
 });


### PR DESCRIPTION
## Summary
- add S3 logEvent utility for ISO timestamped job-level entries
- log backend processing steps and errors to `logs/processing.jsonl`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ca3331a0832b97c91283412346b9