### PR TITLE
style: introduce vibrant gradient palette

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -56,21 +56,21 @@ function App() {
   const disabled = !linkedinUrl || !cvFile || isProcessing
 
   return (
-    <div className="min-h-screen bg-gray-100 flex flex-col items-center p-4">
-      <h1 className="text-3xl font-bold mb-4 text-center">Enhance Your CV</h1>
-      <p className="mb-6 text-center max-w-xl">
+    <div className="min-h-screen bg-gradient-to-r from-blue-200 to-purple-300 flex flex-col items-center p-4">
+      <h1 className="text-3xl font-bold mb-4 text-center text-purple-800">Enhance Your CV</h1>
+      <p className="mb-6 text-center max-w-xl text-indigo-800">
         Provide your LinkedIn profile and upload your CV to receive enhanced versions tailored to your job.
       </p>
 
       <div
-        className="w-full max-w-md p-6 border-2 border-dashed border-gray-400 rounded-md mb-4 text-center bg-white"
+        className="w-full max-w-md p-6 border-2 border-dashed border-blue-300 rounded-md mb-4 text-center bg-gradient-to-r from-white to-purple-50"
         onDragOver={(e) => e.preventDefault()}
         onDrop={handleDrop}
       >
         {cvFile ? (
-          <p>{cvFile.name}</p>
+          <p className="text-purple-800">{cvFile.name}</p>
         ) : (
-          <p className="text-gray-500">Drag and drop your CV here, or click to select (PDF or DOCX, max 5MB)</p>
+          <p className="text-purple-700">Drag and drop your CV here, or click to select (PDF or DOCX, max 5MB)</p>
         )}
         <input
           type="file"
@@ -79,7 +79,7 @@ function App() {
           className="hidden"
           id="cv-input"
         />
-        <label htmlFor="cv-input" className="block mt-2 text-blue-600 cursor-pointer">
+        <label htmlFor="cv-input" className="block mt-2 text-purple-700 cursor-pointer">
           Choose File
         </label>
       </div>
@@ -89,28 +89,28 @@ function App() {
         placeholder="Enter LinkedIn job URL"
         value={linkedinUrl}
         onChange={(e) => setLinkedinUrl(e.target.value)}
-        className="w-full max-w-md p-2 border rounded mb-4"
+        className="w-full max-w-md p-2 border border-purple-300 rounded mb-4"
       />
 
       <button
         onClick={handleSubmit}
         disabled={disabled}
-        className={`px-4 py-2 rounded text-white ${disabled ? 'bg-gray-400' : 'bg-blue-600 hover:bg-blue-700'}`}
+        className={`px-4 py-2 rounded text-white ${disabled ? 'bg-purple-300' : 'bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700'}`}
       >
         Enhance CV Now
       </button>
 
       {isProcessing && (
-        <div className="mt-4 animate-spin h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full"></div>
+        <div className="mt-4 animate-spin h-8 w-8 border-4 border-purple-500 border-t-transparent rounded-full"></div>
       )}
 
       {error && <p className="mt-4 text-red-600">{error}</p>}
 
       <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4 w-full max-w-md">
         {outputFiles.map((file) => (
-          <div key={file.type} className="p-4 bg-white rounded shadow text-center">
-            <p className="mb-2 font-semibold">Enhanced CV ({file.type.toUpperCase()})</p>
-            <a href={file.url} className="text-blue-600 hover:underline">
+          <div key={file.type} className="p-4 bg-gradient-to-r from-white to-purple-50 rounded shadow text-center">
+            <p className="mb-2 font-semibold text-purple-800">Enhanced CV ({file.type.toUpperCase()})</p>
+            <a href={file.url} className="text-purple-700 hover:underline">
               {file.type === 'pdf' ? 'Download PDF' : 'Download Word'}
             </a>
           </div>


### PR DESCRIPTION
## Summary
- add colorful gradient background and purple/blue accents
- harmonize file drop, button, and output card styles with new palette

## Testing
- `npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b27cf41430832b8783645f7595934f