### PR TITLE
Handle HTTP errors before parsing JSON in client App

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -40,10 +40,18 @@ function App() {
         body: formData,
       })
 
-      const data = await response.json()
       if (!response.ok) {
-        throw new Error(data.error || 'Request failed')
+        const errorText = await response.text()
+        throw new Error(errorText || 'Request failed')
       }
+
+      const contentType = response.headers.get('content-type') || ''
+      if (!contentType.includes('application/json')) {
+        const text = await response.text()
+        throw new Error(text || 'Invalid JSON response')
+      }
+
+      const data = await response.json()
 
       setOutputFiles(data.urls || [])
     } catch (err) {


### PR DESCRIPTION
## Summary
- Check `response.ok` before parsing JSON in `handleSubmit`
- Provide text-based error messages on failed requests
- Validate response content type before calling `response.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b27f90d00c832b9c0e45ffd52bf296