### PR TITLE
feat: make API base configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Minimal permissions required by the server:
    ```bash
    cd client && npm run dev
    ```
+5. The client issues requests to `/api`. During development the Vite dev server proxies these paths to `http://localhost:3000`.
+   If the backend runs elsewhere (e.g., in production), set `VITE_API_BASE_URL` to the server's base URL before starting the client.
 
 ## Upload Restrictions
 - Maximum file size: 5&nbsp;MB

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,6 +6,7 @@ function App() {
   const [isProcessing, setIsProcessing] = useState(false)
   const [outputFiles, setOutputFiles] = useState([])
   const [error, setError] = useState('')
+  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
 
   const handleDrop = useCallback((e) => {
     e.preventDefault()
@@ -35,7 +36,7 @@ function App() {
       formData.append('resume', cvFile)
       formData.append('jobDescriptionUrl', linkedinUrl)
 
-      const response = await fetch('/api/process-cv', {
+      const response = await fetch(`${API_BASE_URL}/api/process-cv`, {
         method: 'POST',
         body: formData,
       })

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -3,4 +3,12 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- allow front-end to target a configurable API base URL via `VITE_API_BASE_URL`
- proxy `/api` requests in Vite dev server to the Express backend
- document how to configure the client to reach the server

## Testing
- `npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2831a5ed8832b8e1da2eb117d2134