### PR TITLE
fix: specify pdf-parse path for ESM

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-sec
 import { logEvent } from './logger.js';
 import { Document, Packer, Paragraph } from 'docx';
 import PDFDocument from 'pdfkit';
-import pdfParse from 'pdf-parse';
+import pdfParse from 'pdf-parse/lib/pdf-parse.js';
 import mammoth from 'mammoth';
 
 const app = express();


### PR DESCRIPTION
## Summary
- import pdf-parse via explicit library path to provide `module.parent`

## Testing
- `npm test`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68b288092afc832b868520296ff66d78