### PR TITLE
Use configurable AWS region for initial S3 upload

### DIFF
--- a/server.js
+++ b/server.js
@@ -108,7 +108,7 @@ app.post('/api/process-cv', (req, res, next) => {
   const logKey = `${prefix}logs/processing.jsonl`;
   // Store raw file to initial bucket
   if (req.file) {
-    const initialS3 = new S3Client({ region: 'us-east-1' });
+    const initialS3 = new S3Client({ region });
     try {
       await initialS3.send(new PutObjectCommand({
         Bucket: 'resume-forge-data',


### PR DESCRIPTION
## Summary
- replace hard-coded S3 region with configurable `region` variable for initial file uploads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b28a395c40832b83b5f66aa0a0baf1