### PR TITLE
chore: update default AWS region

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The server relies on the following environment variables:
 
 ```json
 {
-  "AWS_REGION": "us-east-1",
+  "AWS_REGION": "ap-south-1",
   "SECRET_ID": "your-secret-id",
   "PORT": "3000",
   "ALLOW_DEV_PLAINTEXT": "0"

--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ const upload = multer({
 
 const uploadResume = upload.single('resume');
 
-const region = process.env.AWS_REGION || 'us-east-1';
+const region = process.env.AWS_REGION || 'ap-south-1';
 const secretsClient = new SecretsManagerClient({ region });
 
 let secretCache;


### PR DESCRIPTION
## Summary
- default AWS region now `ap-south-1`
- docs updated to match region change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2981022f4832ba117669fe212019d