### PR TITLE
Drop DOCX generation; use PDF only

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Minimal permissions required by the server:
 
 ## Upload Restrictions
 - Maximum file size: 5&nbsp;MB
-- Allowed file types: `.pdf`, `.docx`
+- Allowed file types: `.pdf`
 - Legacy `.doc` files are rejected.
 
 ## Edge Cases

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -86,11 +86,11 @@ function App() {
         {cvFile ? (
           <p className="text-purple-800">{cvFile.name}</p>
         ) : (
-          <p className="text-purple-700">Drag and drop your CV here, or click to select (PDF or DOCX, max 5MB)</p>
+          <p className="text-purple-700">Drag and drop your CV here, or click to select (PDF, max 5MB)</p>
         )}
         <input
           type="file"
-          accept=".pdf,.docx"
+          accept=".pdf"
           onChange={handleFileChange}
           className="hidden"
           id="cv-input"
@@ -125,10 +125,8 @@ function App() {
       <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4 w-full max-w-md">
         {outputFiles.map((file) => (
           <div key={file.type} className="p-4 bg-gradient-to-r from-white to-purple-50 rounded shadow text-center">
-            <p className="mb-2 font-semibold text-purple-800">Enhanced CV ({file.type.toUpperCase()})</p>
-            <a href={file.url} className="text-purple-700 hover:underline">
-              {file.type === 'pdf' ? 'Download PDF' : 'Download Word'}
-            </a>
+            <p className="mb-2 font-semibold text-purple-800">Enhanced CV (PDF)</p>
+            <a href={file.url} className="text-purple-700 hover:underline">Download PDF</a>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- remove DOCX cover letter generation and upload
- update frontend and docs to expect only PDF files

## Testing
- `npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d9279a6c832b8be50a2ddc9f3b28