### PR TITLE
Handle missing tiktoken module gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ Minimal permissions required by the server:
 1. Install dependencies in both the server and client directories:
    ```bash
    npm install
+   npm install tiktoken
    cd client && npm install
    ```
+   `tiktoken` is required for token counting and may require Node.js 18 or later.
 2. Provide the environment variables and AWS secret as shown above.
 3. Start the server:
    ```bash


### PR DESCRIPTION
## Summary
- use runtime `import()` to load `tiktoken` and log a helpful message if it is missing
- skip token counting when `tiktoken` is unavailable
- document `tiktoken` installation and platform requirements

## Testing
- `npm test`
- `npm install tiktoken` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e54ad570832b9e9f0891c1704de8