### PR TITLE
Add Jest tests for API routes and utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node -e \"console.log('no tests')\"",
+    "test": "jest",
     "dev": "node server.js",
     "build": "echo 'No build step'"
   },
@@ -23,5 +23,14 @@
     "pdfkit": "^0.13.0",
     "puppeteer": "^22.9.0",
     "tiktoken": "^1.0.7"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "transform": {},
+    "extensionsToTreatAsEsm": [".js"]
   }
 }

--- a/server.js
+++ b/server.js
@@ -319,3 +319,4 @@ app.listen(port, () => {
 });
 
 export default app;
+export { extractText };

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,123 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+const mockS3Send = jest.fn().mockResolvedValue({});
+jest.unstable_mockModule('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(() => ({ send: mockS3Send })),
+  PutObjectCommand: jest.fn(),
+  GetObjectCommand: jest.fn()
+}));
+
+jest.unstable_mockModule('@aws-sdk/client-secrets-manager', () => ({
+  SecretsManagerClient: jest.fn(() => ({
+    send: jest.fn().mockResolvedValue({
+      SecretString: JSON.stringify({ BUCKET: 'test-bucket', OPENAI_API_KEY: 'test-key' })
+    })
+  })),
+  GetSecretValueCommand: jest.fn()
+}));
+
+jest.unstable_mockModule('../logger.js', () => ({
+  logEvent: jest.fn().mockResolvedValue(undefined)
+}));
+
+jest.unstable_mockModule('openai', () => ({
+  default: jest.fn(() => ({
+    chat: {
+      completions: {
+        create: jest.fn().mockResolvedValue({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({
+                  ats: 'ats',
+                  concise: 'concise',
+                  narrative: 'narrative',
+                  gov_plain: 'gov'
+                })
+              }
+            }
+          ]
+        })
+      }
+    }
+  }))
+}));
+
+jest.unstable_mockModule('axios', () => ({
+  default: { get: jest.fn().mockResolvedValue({ data: 'Job description' }) }
+}));
+
+jest.unstable_mockModule('pdf-parse/lib/pdf-parse.js', () => ({
+  default: jest.fn().mockResolvedValue({ text: 'Education\nExperience\nSkills' })
+}));
+
+jest.unstable_mockModule('mammoth', () => ({
+  default: {
+    extractRawText: jest.fn().mockResolvedValue({ value: 'Docx text' })
+  }
+}));
+
+const { default: app, extractText } = await import('../server.js');
+
+describe('health check', () => {
+  test('GET /healthz', async () => {
+    const res = await request(app).get('/healthz');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});
+
+describe('/api/process-cv', () => {
+  test('successful processing', async () => {
+    const res = await request(app)
+      .post('/api/process-cv')
+      .field('jobDescriptionUrl', 'http://example.com')
+      .attach('resume', Buffer.from('dummy'), 'resume.pdf');
+    expect(res.status).toBe(200);
+    expect(res.body.urls).toHaveLength(4);
+    expect(res.body.applicantName).toBeTruthy();
+  });
+
+  test('missing file', async () => {
+    const res = await request(app)
+      .post('/api/process-cv')
+      .field('jobDescriptionUrl', 'http://example.com');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('resume file required');
+  });
+
+  test('unsupported file type', async () => {
+    const res = await request(app)
+      .post('/api/process-cv')
+      .field('jobDescriptionUrl', 'http://example.com')
+      .attach('resume', Buffer.from('text'), 'resume.txt');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Only .pdf, .doc, .docx files are allowed');
+  });
+
+  test('missing job description URL', async () => {
+    const res = await request(app)
+      .post('/api/process-cv')
+      .attach('resume', Buffer.from('dummy'), 'resume.pdf');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('jobDescriptionUrl required');
+  });
+});
+
+describe('extractText', () => {
+  test('extracts text from pdf', async () => {
+    const file = { originalname: 'file.pdf', buffer: Buffer.from('') };
+    await expect(extractText(file)).resolves.toBe('Education\nExperience\nSkills');
+  });
+
+  test('extracts text from docx', async () => {
+    const file = { originalname: 'file.docx', buffer: Buffer.from('') };
+    await expect(extractText(file)).resolves.toBe('Docx text');
+  });
+
+  test('extracts text from txt', async () => {
+    const file = { originalname: 'file.txt', buffer: Buffer.from('plain') };
+    await expect(extractText(file)).resolves.toBe('plain');
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest testing framework
- add tests for /api/process-cv and /healthz endpoints
- include unit tests for extractText utility

## Testing
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e733e3f8832ba33272e0b9d32fc2