### PR TITLE
feat: switch to gemini

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,12 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1",
-    "openai": "^4.0.0",
+    "@google/generative-ai": "^0.7.2",
     "pdf-parse": "^1.1.1",
     "mammoth": "^1.6.0",
     "docx": "^8.0.2",
     "pdfkit": "^0.13.0",
-    "puppeteer": "^22.9.0",
-    "tiktoken": "^1.0.7"
+    "puppeteer": "^22.9.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- replace OpenAI with Google Generative AI gemini-2.5-pro model
- drop tiktoken token counting and related logic
- adjust configuration to use GEMINI_API_KEY

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@google%2fgenerative-ai)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e9d9e1b0832b90e76d48a00635d2