### PR TITLE
feat: switch to openai and generate resume versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.432.0",
     "@aws-sdk/client-secrets-manager": "^3.432.0",
-    "@google/generative-ai": "^0.7.2",
+    "openai": "^4.28.4",
     "axios": "^1.6.2",
     "cors": "^2.8.5",
     "docx": "^8.0.2",


### PR DESCRIPTION
## Summary
- use OpenAI SDK with API key from env or secrets
- request two cover letters and two resume versions and parse JSON response
- adjust outputs, URLs, and tests for new keys

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3039cf5f0832b8675b1e84a138107