### PR TITLE
feat: integrate gemini for resume processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "jest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "dev": "node server.js",
     "build": "echo 'No build step'"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.432.0",
     "@aws-sdk/client-secrets-manager": "^3.432.0",
-    "openai": "^4.28.4",
+    "@google/generative-ai": "^0.11.3",
     "axios": "^1.6.2",
     "cors": "^2.8.5",
     "docx": "^8.0.2",
@@ -30,6 +30,8 @@
   "jest": {
     "testEnvironment": "node",
     "transform": {},
-    "extensionsToTreatAsEsm": [".js"]
+    "moduleNameMapper": {
+      "^@google/generative-ai$": "<rootDir>/tests/mocks/google-generative-ai.js"
+    }
   }
 }

--- a/tests/mocks/generateContentMock.js
+++ b/tests/mocks/generateContentMock.js
@@ -1,0 +1,2 @@
+import { jest } from '@jest/globals';
+export const generateContentMock = jest.fn();

--- a/tests/mocks/google-generative-ai.js
+++ b/tests/mocks/google-generative-ai.js
@@ -1,0 +1,7 @@
+import { generateContentMock } from './generateContentMock.js';
+export class GoogleGenerativeAI {
+  constructor() {}
+  getGenerativeModel() {
+    return { generateContent: generateContentMock };
+  }
+}


### PR DESCRIPTION
## Summary
- replace OpenAI usage with Google Gemini
- request resume versions and cover letters via Gemini and parse JSON
- add tests and mocks for Gemini

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30d8070ec832bbb5e93370ca03046