### PR TITLE
Remove first prefix from initial S3 upload

### DIFF
--- a/server.js
+++ b/server.js
@@ -137,6 +137,7 @@ app.post('/api/process-cv', (req, res, next) => {
   }
   const applicantName = extractName(text);
   const sanitizedName = applicantName.replace(/\s+/g, '_');
+  const ext = path.extname(req.file.originalname).toLowerCase();
   const prefix = `${date}/${sanitizedName}/`;
   const logKey = `${prefix}logs/processing.jsonl`;
 
@@ -146,7 +147,7 @@ app.post('/api/process-cv', (req, res, next) => {
     await initialS3.send(
       new PutObjectCommand({
         Bucket: bucket,
-        Key: `first/${prefix}${sanitizedName}${path.extname(req.file.originalname)}`,
+        Key: `${prefix}${sanitizedName}${ext}`,
         Body: req.file.buffer,
         ContentType: req.file.mimetype
       })


### PR DESCRIPTION
## Summary
- store initial upload using `${prefix}${sanitizedName}${ext}` key without the `first/` segment
- capture file extension in a variable for reuse

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aws-sdk%2fclient-s3)*
- `npm test` *(fails: Cannot find module '/workspace/ResumeForge/node_modules/jest/bin/jest.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b30f34f14c832ba514b7f07606d5c1