### PR TITLE
Add labels for generated resume files

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -123,12 +123,32 @@ function App() {
       {error && <p className="mt-4 text-red-600">{error}</p>}
 
       <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4 w-full max-w-md">
-        {outputFiles.map((file) => (
-          <div key={file.type} className="p-4 bg-gradient-to-r from-white to-purple-50 rounded shadow text-center">
-            <p className="mb-2 font-semibold text-purple-800">Enhanced CV (PDF)</p>
-            <a href={file.url} className="text-purple-700 hover:underline">Download PDF</a>
-          </div>
-        ))}
+        {outputFiles.map((file) => {
+          let label
+          switch (file.type) {
+            case 'cover_letter1':
+              label = 'Cover Letter 1 (PDF)'
+              break
+            case 'cover_letter2':
+              label = 'Cover Letter 2 (PDF)'
+              break
+            case 'version1':
+              label = 'CV Version 1 (PDF)'
+              break
+            case 'version2':
+              label = 'CV Version 2 (PDF)'
+              break
+            default:
+              label = 'Download (PDF)'
+          }
+
+          return (
+            <div key={file.type} className="p-4 bg-gradient-to-r from-white to-purple-50 rounded shadow text-center">
+              <p className="mb-2 font-semibold text-purple-800">{label}</p>
+              <a href={file.url} className="text-purple-700 hover:underline">Download PDF</a>
+            </div>
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Switch on `file.type` to show descriptive labels for cover letters and CV versions before download links

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aws-sdk%2fclient-s3)*
- `npm test` *(fails: Cannot find module '/workspace/ResumeForge/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b31865e49c832bab52c5a6d5cc14be