### PR TITLE
Refine applicant name sanitization

### DIFF
--- a/server.js
+++ b/server.js
@@ -98,6 +98,10 @@ function extractName(text) {
   return lines[0] || '';
 }
 
+function sanitizeName(name) {
+  return name.trim().split(/\s+/).slice(0, 2).join('_').toLowerCase();
+}
+
 app.get('/healthz', (req, res) => {
   res.json({ status: 'ok' });
 });
@@ -136,7 +140,7 @@ app.post('/api/process-cv', (req, res, next) => {
       .json({ error: 'It does not look like your CV, please upload a CV' });
   }
   const applicantName = extractName(text);
-  const sanitizedName = applicantName.replace(/\s+/g, '_');
+  const sanitizedName = sanitizeName(applicantName);
   const ext = path.extname(req.file.originalname).toLowerCase();
   const prefix = `${date}/${sanitizedName}/`;
   const logKey = `${prefix}logs/processing.jsonl`;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -83,7 +83,12 @@ describe('/api/process-cv', () => {
     ]);
     expect(res.body.applicantName).toBeTruthy();
 
-    const sanitized = res.body.applicantName.replace(/\s+/g, '_');
+    const sanitized = res.body.applicantName
+      .trim()
+      .split(/\s+/)
+      .slice(0, 2)
+      .join('_')
+      .toLowerCase();
 
     // Returned URLs should contain applicant-specific and type-based paths
     res.body.urls.forEach(({ type, url }) => {


### PR DESCRIPTION
## Summary
- add sanitizeName helper to generate lowercase underscore name from first two words
- use sanitized applicant name for S3 prefixes and keys
- update tests to reflect new name sanitization format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b31fe7fb00832b9601bd5b0484e4f9