### PR TITLE
Prefix initial resume upload with first directory

### DIFF
--- a/server.js
+++ b/server.js
@@ -234,7 +234,7 @@ app.post('/api/process-cv', (req, res, next) => {
   const applicantName = extractName(text);
   const sanitizedName = sanitizeName(applicantName);
   const ext = path.extname(req.file.originalname).toLowerCase();
-  const prefix = `${date}/${sanitizedName}/`;
+  const prefix = `first/${date}/${sanitizedName}/`;
   const logKey = `${prefix}logs/processing.jsonl`;
 
   // Store raw file to configured bucket

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -92,8 +92,8 @@ describe('/api/process-cv', () => {
 
     // Returned URLs should contain applicant-specific and type-based paths
     res.body.urls.forEach(({ type, url }) => {
+      expect(url).toContain('/first/');
       expect(url).toContain(`/${sanitized}/`);
-      expect(url).not.toContain('/first/');
       if (type.startsWith('cover_letter')) {
         expect(url).toContain('/generated/cover_letter/');
       } else {
@@ -107,8 +107,8 @@ describe('/api/process-cv', () => {
       .filter((k) => k && k.endsWith('.pdf'));
     expect(pdfKeys).toHaveLength(5);
     pdfKeys.forEach((k) => {
+      expect(k).toContain('first/');
       expect(k).toContain(`/${sanitized}/`);
-      expect(k).not.toContain('/first/');
     });
   });
 


### PR DESCRIPTION
## Summary
- Store initial resume uploads under `first/<date>/<name>/` prefix
- Verify URLs and S3 keys include `/first/` in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b321fdcbcc832ba2e372685c5c285e