### PR TITLE
Add template-based resume PDF generation with tests

### DIFF
--- a/lib/handlebars.js
+++ b/lib/handlebars.js
@@ -1,0 +1,32 @@
+export default {
+  compile(template) {
+    return (data) => {
+      let result = template;
+      // Replace simple variables like {{name}}
+      result = result.replace(/{{\s*name\s*}}/g, data.name || '');
+      // Handle sections loop
+      result = result.replace(/{{#each\s+sections}}([\s\S]*?){{\/each}}/, (_, sectionBlock) => {
+        return (data.sections || []).map((sec) => {
+          let block = sectionBlock;
+          // Conditional heading
+          block = block.replace(/{{#if\s+heading}}([\s\S]*?){{\/if}}/, (__, headingBlock) =>
+            sec.heading ? headingBlock.replace(/{{\s*heading\s*}}/g, sec.heading) : ''
+          );
+          // Conditional items with nested each
+          block = block.replace(/{{#if\s+items}}([\s\S]*?){{\/if}}/, (__, itemsBlock) => {
+            if (sec.items && sec.items.length) {
+              return itemsBlock.replace(/{{#each\s+items}}([\s\S]*?){{\/each}}/, (___, itemBlock) =>
+                sec.items
+                  .map((it) => itemBlock.replace(/{{{?\s*this\s*}?}}/g, it))
+                  .join('')
+              );
+            }
+            return '';
+          });
+          return block;
+        }).join('');
+      });
+      return result;
+    };
+  }
+};

--- a/templates/modern.html
+++ b/templates/modern.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Resume</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; color: #333; }
+    h1 { font-size: 32px; margin-bottom: 0; }
+    h2 { font-size: 20px; margin-top: 24px; border-bottom: 1px solid #ccc; padding-bottom: 4px; }
+    section { margin-bottom: 16px; }
+    ul { margin: 0; padding-left: 20px; }
+  </style>
+</head>
+<body>
+  <h1>{{name}}</h1>
+  {{#each sections}}
+  <section>
+    {{#if heading}}<h2>{{heading}}</h2>{{/if}}
+    {{#if items}}
+      <ul>
+        {{#each items}}
+          <li>{{{this}}}</li>
+        {{/each}}
+      </ul>
+    {{/if}}
+  </section>
+  {{/each}}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add modern HTML/CSS resume template and simple Handlebars-style renderer
- generate PDFs through Puppeteer with PDFKit fallback
- verify PDF creation in integration tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b32785b754832b91a1e539a345e7e0