### PR TITLE
Preserve spacing when joining parsed tokens

### DIFF
--- a/server.js
+++ b/server.js
@@ -196,7 +196,20 @@ function prepareTemplateData(text) {
   const name = lines.shift() || 'Resume';
   const items = lines.map((l) => {
     const cleaned = l.replace(/^[-*]\s*/, '');
-    return parseLine(cleaned);
+    const tokens = parseLine(cleaned);
+    // Ensure spacing between tokens matches original text
+    return tokens.reduce((acc, t, idx) => {
+      acc.push(t);
+      const next = tokens[idx + 1];
+      if (
+        next &&
+        !/\s$/.test(t.text) &&
+        !/^\s/.test(next.text)
+      ) {
+        acc.push({ type: 'paragraph', text: ' ' });
+      }
+      return acc;
+    }, []);
   });
   return { name, sections: [{ heading: 'Summary', items }] };
 }

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -50,6 +50,19 @@ describe('generatePdf and parsing', () => {
     italicTokens.forEach((t) => expect(t.text).not.toContain('_'));
   });
 
+  test('spacing is preserved across multiple tokens', () => {
+    const data = prepareTemplateData(
+      'Jane Doe\n- Visit [OpenAI](https://openai.com) and [GitHub](https://github.com)\n- Mix **bold** and _italic_ styles'
+    );
+    const [linkTokens, mixTokens] = data.sections[0].items;
+    expect(linkTokens.map((t) => t.text).join('')).toBe(
+      'Visit OpenAI and GitHub'
+    );
+    expect(mixTokens.map((t) => t.text).join('')).toBe(
+      'Mix bold and italic styles'
+    );
+  });
+
   test('parseContent detects links', () => {
     const tokens = parseContent(
       'Check [OpenAI](https://openai.com) and https://example.com'


### PR DESCRIPTION
## Summary
- ensure `prepareTemplateData` adds space tokens between adjacent segments so original spacing is preserved
- cover multiple links and formatted segments in tests to confirm spacing retention

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b336a97820832bbf9cb6122239e673