### PR TITLE
feat: add professional resume template with selection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ Minimal permissions required by the server:
 - Allowed file types: `.pdf`
 - Legacy `.doc` files are rejected.
 
+## Templates
+`/api/process-cv` accepts a `template` parameter (in the request body or query string) selecting the resume layout. Available values:
+- `modern` – clean sans-serif look (default)
+- `ucmo` – classic serif styling
+- `professional` – centered header with subtle dividers
+
+If omitted, `modern` is used.
+
+
 ## Edge Cases
 - **Name extraction fallback:** If the résumé text lacks a detectable name, the generated content defaults to a generic placeholder such as "Candidate".
 - **Job description scraping limitations:** The job description is retrieved with a simple HTTP GET request; dynamic or access-restricted pages may return empty or blocked content.

--- a/server.js
+++ b/server.js
@@ -332,6 +332,7 @@ app.post('/api/process-cv', (req, res, next) => {
   }
 
   const { jobDescriptionUrl } = req.body;
+  const templateId = req.body.template || req.query.template || 'modern';
   if (!req.file) {
     return res.status(400).json({ error: 'resume file required' });
   }
@@ -487,7 +488,7 @@ app.post('/api/process-cv', (req, res, next) => {
           ? 'cover_letter/'
           : '';
       const key = `${generatedPrefix}${subdir}${fileName}.pdf`;
-      const pdfBuffer = await generatePdf(text);
+      const pdfBuffer = await generatePdf(text, templateId);
       await s3.send(
         new PutObjectCommand({
           Bucket: bucket,

--- a/templates/professional.html
+++ b/templates/professional.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Resume</title>
+  <style>
+    body { font-family: 'Helvetica Neue', Arial, sans-serif; margin: 40px; color: #222; line-height: 1.4; }
+    header { text-align: center; border-bottom: 2px solid #555; margin-bottom: 30px; padding-bottom: 10px; }
+    h1 { font-size: 36px; margin: 0; }
+    h2 { font-size: 20px; color: #555; margin: 30px 0 10px; border-bottom: 1px solid #ccc; padding-bottom: 4px; }
+    section { margin-bottom: 16px; }
+    ul { margin: 0; padding-left: 20px; }
+    li { margin-bottom: 6px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>{{name}}</h1>
+  </header>
+  {{#each sections}}
+  <section>
+    {{#if heading}}<h2>{{heading}}</h2>{{/if}}
+    {{#if items}}
+      <ul>
+        {{#each items}}
+          <li>{{{this}}}</li>
+        {{/each}}
+      </ul>
+    {{/if}}
+  </section>
+  {{/each}}
+</body>
+</html>

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -25,7 +25,7 @@ describe('generatePdf and parsing', () => {
     );
   });
 
-  test.each(['modern', 'ucmo'])('generatePdf creates PDF from %s template', async (tpl) => {
+  test.each(['modern', 'ucmo', 'professional'])('generatePdf creates PDF from %s template', async (tpl) => {
     const buffer = await generatePdf('Jane Doe\n- Loves testing', tpl);
     expect(Buffer.isBuffer(buffer)).toBe(true);
     expect(buffer.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- add professional resume HTML template for polished layout
- expose `template` parameter so clients can select resume layout
- document available templates and expand tests to cover each template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b338c3e46c832badc7baca747ea402