### PR TITLE
Support single-asterisk italics in markdown

### DIFF
--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -63,6 +63,22 @@ describe('generatePdf and parsing', () => {
     );
   });
 
+  test('single asterisk italic and bullet handling', () => {
+    const data = prepareTemplateData(
+      'Jane Doe\n* This has *italic* text'
+    );
+    const [tokens] = data.sections[0].items;
+    expect(tokens.map((t) => t.text).join('')).toBe(
+      'This has italic text'
+    );
+    expect(tokens).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ text: 'italic', style: 'italic' })
+      ])
+    );
+    tokens.forEach((t) => expect(t.text).not.toContain('*'));
+  });
+
   test('parseContent detects links', () => {
     const tokens = parseContent(
       'Check [OpenAI](https://openai.com) and https://example.com'
@@ -110,7 +126,7 @@ describe('generatePdf and parsing', () => {
     const raw = buffer.toString();
     expect(raw).toContain('https://www.linkedin.com/in/johndoe');
     expect(raw).toContain('https://github.com/johndoe');
-    expect(raw).not.toContain('<a');
+    expect(raw).not.toMatch(/<a[\s>]/);
   });
 
 });


### PR DESCRIPTION
## Summary
- parseLine treats *italic* syntax as italic and removes stray asterisks
- strip leading bullet asterisks before tokenization
- add tests for single-asterisk markdown and refine PDF anchor check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3bff1f198832b87a9e21ba6b97637