### PR TITLE
Improve markdown emphasis parsing

### DIFF
--- a/tests/parseLine.test.js
+++ b/tests/parseLine.test.js
@@ -1,0 +1,19 @@
+import { parseLine } from '../server.js';
+
+describe('parseLine emphasis handling', () => {
+  test('handles nested emphasis markers', () => {
+    const tokens = parseLine('*italic **bold** more*');
+    const shapes = tokens.map(({ text, style }) => ({ text, style }));
+    expect(shapes).toEqual([
+      { text: 'italic ', style: 'italic' },
+      { text: 'bold', style: 'bolditalic' },
+      { text: ' more', style: 'italic' }
+    ]);
+  });
+
+  test('handles malformed emphasis markers gracefully', () => {
+    const tokens = parseLine('This *text **is not closed');
+    expect(tokens.map((t) => t.text).join('')).toBe('This text is not closed');
+    tokens.forEach((t) => expect(t.style).toBeUndefined());
+  });
+});


### PR DESCRIPTION
## Summary
- Replace fragile regex parsing with stack-based emphasis parser
- Strip stray asterisks from tokens and support bold-italic style
- Add unit tests for nested and malformed emphasis markers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d2d9bccc832b8fafa2bf2c656396