### PR TITLE
Normalize emphasis parsing and add tests

### DIFF
--- a/tests/parseLine.test.js
+++ b/tests/parseLine.test.js
@@ -25,4 +25,16 @@ describe('parseLine emphasis handling', () => {
       { text: 'italic', style: 'italic' }
     ]);
   });
+
+  test('handles combined bold and italic markers', () => {
+    const tokens = parseLine('***both***');
+    const shapes = tokens.map(({ text, style }) => ({ text, style }));
+    expect(shapes).toEqual([{ text: 'both', style: 'bolditalic' }]);
+  });
+
+  test('normalizes malformed emphasis strings', () => {
+    const tokens = parseLine('Text with *mismatched _markers* inside_');
+    expect(tokens.map((t) => t.text).join('')).toBe('Text with mismatched markers inside');
+    tokens.forEach((t) => expect(t.style).toBeUndefined());
+  });
 });


### PR DESCRIPTION
## Summary
- normalize emphasis tokens in `parseLine` to drop empty paragraphs
- enhance `parseEmphasis` to handle single-asterisk italics and combined bold/italic markers while discarding unmatched markers
- add unit tests covering nested and malformed emphasis strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b408ac56b4832bbfe5dd6215e71178