### PR TITLE
Support separate resume templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,20 @@ Minimal permissions required by the server:
 - Legacy `.doc` files are rejected.
 
 ## Templates
-`/api/process-cv` accepts a `template` parameter (in the request body or query string) selecting the resume layout. Available values:
+`/api/process-cv` supports several template parameters for selecting the resume layout:
+
+- `template` – apply the same template to both generated CV versions.
+- `template1` and `template2` – specify different templates for each version.
+- `templates` – array of two template IDs, equivalent to providing `template1` and `template2`.
+
+Available template values:
 - `modern` – clean sans-serif look (default)
 - `ucmo` – classic serif styling
 - `professional` – centered header with subtle dividers
 - `vibrant` – bold color accents with contemporary typography
- - `2025` – responsive grid layout with modern Inter font, blue accents, and spacious margins
+- `2025` – responsive grid layout with modern Inter font, blue accents, and spacious margins
 
-If omitted, `modern` is used.
+Any missing or invalid ID falls back to `modern`.
 
 
 ## Edge Cases


### PR DESCRIPTION
## Summary
- allow `/api/process-cv` to accept `template1`, `template2`, or `templates` array and apply them per CV version
- document new template parameters in README
- add tests covering distinct templates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b429f07144832b82e6a6a61d495f72