### PR TITLE
style: align bullets and tabs across templates

### DIFF
--- a/templates/2025.css
+++ b/templates/2025.css
@@ -65,21 +65,25 @@ ul {
 li {
   /* preserve formatting for multi-line bullets */
   margin-bottom: 0.5rem;
-  position: relative;
-  padding-left: 1.2em;
+  margin-left: 1.2em;
+  text-indent: -1.2em;
   white-space: pre-wrap;
   line-height: 1.5;
 }
 
 li::before {
   content: '\2022';
-  position: absolute;
-  left: 0;
+  display: inline-block;
+  width: 1.2em;
   color: var(--accent);
 }
 
 .tab {
   display: inline-block;
   width: 1.5em;
+}
+
+.tab + p {
+  margin-top: 0;
 }
 

--- a/templates/modern.html
+++ b/templates/modern.html
@@ -10,9 +10,21 @@
     h2 { font-size: 20px; margin: 24px 0 12px; border-bottom: 1px solid #2a9d8f; padding-bottom: 4px; }
     section { margin-bottom: 16px; }
     ul { list-style: none; margin: 0; padding: 0; }
-    li { margin-bottom: 10px; position: relative; padding-left: 1.2em; white-space: pre-wrap; line-height:1.5; }
-    li::before { content: '•'; position: absolute; left: 0; color: #2a9d8f; }
+    li {
+      margin-bottom: 10px;
+      margin-left: 1.2em;
+      text-indent: -1.2em;
+      white-space: pre-wrap;
+      line-height: 1.5;
+    }
+    li::before {
+      content: '•';
+      display: inline-block;
+      width: 1.2em;
+      color: #2a9d8f;
+    }
     .tab { display:inline-block; width:1.5em; }
+    .tab + p { margin-top: 0; }
   </style>
 </head>
 <body>

--- a/templates/professional.html
+++ b/templates/professional.html
@@ -10,9 +10,21 @@
     h2 { font-size: 20px; color: #1d3557; margin: 30px 0 16px; border-bottom: 1px solid #1d3557; padding-bottom: 4px; }
     section { margin-bottom: 16px; }
     ul { list-style: none; margin: 0; padding: 0; }
-    li { margin-bottom: 10px; position: relative; padding-left: 1.2em; white-space: pre-wrap; line-height:1.5; }
-    li::before { content: '▹'; position: absolute; left: 0; color: #1d3557; }
+    li {
+      margin-bottom: 10px;
+      margin-left: 1.2em;
+      text-indent: -1.2em;
+      white-space: pre-wrap;
+      line-height: 1.5;
+    }
+    li::before {
+      content: '▹';
+      display: inline-block;
+      width: 1.2em;
+      color: #1d3557;
+    }
     .tab { display:inline-block; width:1.5em; }
+    .tab + p { margin-top: 0; }
   </style>
 </head>
 <body>

--- a/templates/ucmo.html
+++ b/templates/ucmo.html
@@ -9,9 +9,21 @@
     h1 { font-size: 36px; margin: 0 0 12px; }
     h2 { font-size: 18px; margin: 30px 0 12px; background: #f2f2f2; padding: 6px 10px; color: #990000; }
     ul { list-style: none; padding-left: 0; margin: 0; }
-    li { margin-bottom: 10px; position: relative; padding-left: 1.2em; white-space: pre-wrap; line-height:1.5; }
-    li::before { content: '\2013'; position: absolute; left: 0; color: #990000; }
+    li {
+      margin-bottom: 10px;
+      margin-left: 1.2em;
+      text-indent: -1.2em;
+      white-space: pre-wrap;
+      line-height: 1.5;
+    }
+    li::before {
+      content: '\2013';
+      display: inline-block;
+      width: 1.2em;
+      color: #990000;
+    }
     .tab { display:inline-block; width:1.5em; }
+    .tab + p { margin-top: 0; }
   </style>
 </head>
 <body>

--- a/templates/vibrant.html
+++ b/templates/vibrant.html
@@ -10,9 +10,21 @@
     h2 { font-size: 20px; color: #ff6b6b; margin: 24px 0 12px; border-bottom: 2px solid #ff6b6b; padding-bottom: 4px; }
     section { margin-bottom: 16px; }
     ul { list-style: none; margin: 0; padding: 0; }
-    li { margin-bottom: 10px; position: relative; padding-left: 1.2em; white-space: pre-wrap; line-height:1.5; }
-    li::before { content: '✱'; position: absolute; left: 0; color: #4ecdc4; }
+    li {
+      margin-bottom: 10px;
+      margin-left: 1.2em;
+      text-indent: -1.2em;
+      white-space: pre-wrap;
+      line-height:1.5;
+    }
+    li::before {
+      content: '✱';
+      display: inline-block;
+      width: 1.2em;
+      color: #4ecdc4;
+    }
     .tab { display:inline-block; width:1.5em; }
+    .tab + p { margin-top: 0; }
   </style>
 </head>
 <body>

--- a/tests/__snapshots__/generatePdf.test.js.snap
+++ b/tests/__snapshots__/generatePdf.test.js.snap
@@ -75,22 +75,26 @@ ul {
 li {
   /* preserve formatting for multi-line bullets */
   margin-bottom: 0.5rem;
-  position: relative;
-  padding-left: 1.2em;
+  margin-left: 1.2em;
+  text-indent: -1.2em;
   white-space: pre-wrap;
   line-height: 1.5;
 }
 
 li::before {
   content: '\\2022';
-  position: absolute;
-  left: 0;
+  display: inline-block;
+  width: 1.2em;
   color: var(--accent);
 }
 
 .tab {
   display: inline-block;
   width: 1.5em;
+}
+
+.tab + p {
+  margin-top: 0;
 }
 
 </style></head>


### PR DESCRIPTION
## Summary
- use margin-left and text-indent for bullet alignment across templates
- ensure `.tab` elements render with consistent spacing
- update 2025 template snapshot

## Testing
- `npm test -- -u`
- Rendered templates `modern`, `professional`, `ucmo`, `vibrant`, and `2025` via Handlebars compile script

------
https://chatgpt.com/codex/tasks/task_e_68b46b54abac832b9c0983c26db673ab