### PR TITLE
Use resume and LinkedIn experience fallback

### DIFF
--- a/tests/parseContent.test.js
+++ b/tests/parseContent.test.js
@@ -31,3 +31,23 @@ describe('parseContent placeholders', () => {
   });
 });
 
+describe('parseContent experience fallbacks', () => {
+  test('uses resume experience when AI output lacks it', () => {
+    const data = parseContent('Jane Doe\n# Skills\n- JS', {
+      resumeExperience: ['Did something']
+    });
+    const work = data.sections.find((s) => s.heading === 'Work Experience');
+    expect(work.items).toHaveLength(1);
+    expect(work.items[0].map((t) => t.text).join('')).toBe('Did something');
+  });
+
+  test('uses linkedin experience when resume lacks it', () => {
+    const data = parseContent('Jane Doe\n# Skills\n- JS', {
+      linkedinExperience: ['LinkedIn item']
+    });
+    const work = data.sections.find((s) => s.heading === 'Work Experience');
+    expect(work.items).toHaveLength(1);
+    expect(work.items[0].map((t) => t.text).join('')).toBe('LinkedIn item');
+  });
+});
+


### PR DESCRIPTION
## Summary
- Extract experience bullets from resume text and LinkedIn data with a new helper
- Populate missing Work Experience sections using these bullets before falling back to placeholders
- Pass experience fallback options through content parsing and PDF generation
- Add tests covering resume and LinkedIn fallback behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b46cdad4f8832b9b3a97ab27d83907