### PR TITLE
Add education extraction and resume fallbacks

### DIFF
--- a/tests/extractEducation.test.js
+++ b/tests/extractEducation.test.js
@@ -1,0 +1,13 @@
+import { extractEducation } from '../server.js';
+
+describe('extractEducation', () => {
+  test('extracts bullet items from resume text', () => {
+    const text = 'Education\n- BSc Computer Science - MIT\n\nExperience';
+    expect(extractEducation(text)).toEqual(['BSc Computer Science - MIT']);
+  });
+
+  test('extracts from array inputs', () => {
+    const arr = ['Harvard University, MBA', 'MIT, BSc'];
+    expect(extractEducation(arr)).toEqual(arr);
+  });
+});

--- a/tests/parseContent.test.js
+++ b/tests/parseContent.test.js
@@ -51,3 +51,25 @@ describe('parseContent experience fallbacks', () => {
   });
 });
 
+describe('parseContent education fallbacks', () => {
+  test('uses resume education when AI output lacks it', () => {
+    const data = parseContent('Jane Doe\n# Skills\n- JS', {
+      resumeEducation: ['B.S. in CS - MIT']
+    });
+    const edu = data.sections.find((s) => s.heading === 'Education');
+    expect(edu.items).toHaveLength(1);
+    expect(edu.items[0].map((t) => t.text).join('')).toBe('B.S. in CS - MIT');
+  });
+
+  test('uses linkedin education when resume lacks it', () => {
+    const data = parseContent('Jane Doe\n# Skills\n- JS', {
+      linkedinEducation: ['Stanford University, BSc']
+    });
+    const edu = data.sections.find((s) => s.heading === 'Education');
+    expect(edu.items).toHaveLength(1);
+    expect(edu.items[0].map((t) => t.text).join('')).toBe(
+      'Stanford University, BSc'
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- parse education details from resumes and LinkedIn data with new `extractEducation`
- auto-populate missing Education section using resume/LinkedIn information
- extend coverage with tests for education extraction and fallbacks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b47db2bb00832ba530ef2f2953e4b6