### PR TITLE
Handle bullet tokens and dash normalization

### DIFF
--- a/templates/2025.css
+++ b/templates/2025.css
@@ -66,15 +66,14 @@ li {
   /* preserve formatting for multi-line bullets */
   margin-bottom: 0.5rem;
   margin-left: 1.2em;
-  text-indent: -1.2em;
   white-space: pre-wrap;
   line-height: 1.5;
 }
 
-li::before {
-  content: '\2022';
+.bullet {
   display: inline-block;
   width: 1.2em;
+  margin-left: -1.2em;
   color: var(--accent);
 }
 

--- a/templates/modern.html
+++ b/templates/modern.html
@@ -13,14 +13,13 @@
     li {
       margin-bottom: 10px;
       margin-left: 1.2em;
-      text-indent: -1.2em;
       white-space: pre-wrap;
       line-height: 1.5;
     }
-    li::before {
-      content: '•';
+    .bullet {
       display: inline-block;
       width: 1.2em;
+      margin-left: -1.2em;
       color: #2a9d8f;
     }
     .tab { display:inline-block; width:1.5em; }

--- a/templates/professional.html
+++ b/templates/professional.html
@@ -13,14 +13,13 @@
     li {
       margin-bottom: 10px;
       margin-left: 1.2em;
-      text-indent: -1.2em;
       white-space: pre-wrap;
       line-height: 1.5;
     }
-    li::before {
-      content: '▹';
+    .bullet {
       display: inline-block;
       width: 1.2em;
+      margin-left: -1.2em;
       color: #1d3557;
     }
     .tab { display:inline-block; width:1.5em; }

--- a/templates/ucmo.html
+++ b/templates/ucmo.html
@@ -12,14 +12,13 @@
     li {
       margin-bottom: 10px;
       margin-left: 1.2em;
-      text-indent: -1.2em;
       white-space: pre-wrap;
       line-height: 1.5;
     }
-    li::before {
-      content: '\2013';
+    .bullet {
       display: inline-block;
       width: 1.2em;
+      margin-left: -1.2em;
       color: #990000;
     }
     .tab { display:inline-block; width:1.5em; }

--- a/templates/vibrant.html
+++ b/templates/vibrant.html
@@ -13,14 +13,13 @@
     li {
       margin-bottom: 10px;
       margin-left: 1.2em;
-      text-indent: -1.2em;
       white-space: pre-wrap;
       line-height:1.5;
     }
-    li::before {
-      content: '✱';
+    .bullet {
       display: inline-block;
       width: 1.2em;
+      margin-left: -1.2em;
       color: #4ecdc4;
     }
     .tab { display:inline-block; width:1.5em; }

--- a/tests/__snapshots__/generatePdf.test.js.snap
+++ b/tests/__snapshots__/generatePdf.test.js.snap
@@ -76,15 +76,14 @@ li {
   /* preserve formatting for multi-line bullets */
   margin-bottom: 0.5rem;
   margin-left: 1.2em;
-  text-indent: -1.2em;
   white-space: pre-wrap;
   line-height: 1.5;
 }
 
-li::before {
-  content: '\\2022';
+.bullet {
   display: inline-block;
   width: 1.2em;
+  margin-left: -1.2em;
   color: var(--accent);
 }
 

--- a/tests/parseLine.test.js
+++ b/tests/parseLine.test.js
@@ -17,13 +17,13 @@ describe('parseLine emphasis handling', () => {
     tokens.forEach((t) => expect(t.style).toBeUndefined());
   });
 
-  test('strips leading bullet before tokenization', () => {
-    const tokens = parseLine('* bullet *italic*');
-    const shapes = tokens.map(({ text, style }) => ({ text, style }));
-    expect(shapes).toEqual([
-      { text: 'bullet ', style: undefined },
-      { text: 'italic', style: 'italic' }
-    ]);
+  test.each(['- dash bullet', '– en dash bullet'])('emits bullet token for %s', (input) => {
+    const tokens = parseLine(input);
+    expect(tokens[0]).toMatchObject({ type: 'bullet' });
+    const text = tokens.slice(1).map((t) => t.text).join('');
+    const expected = input.replace(/^[\-*–]\s+/, '');
+    expect(text).toBe(expected);
+    expect(text).not.toMatch(/[-–]/);
   });
 
   test('handles combined bold and italic markers', () => {


### PR DESCRIPTION
## Summary
- add bullet tokens in parseLine and content parsing
- render bullet tokens as `•` in HTML and PDF outputs
- test for bullet token handling and ensure hyphens are stripped

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4864a9394832b8c4a877d448db30e