### PR TITLE
Expand guidance line removal

### DIFF
--- a/server.js
+++ b/server.js
@@ -872,9 +872,11 @@ function parseAiJson(text) {
 }
 
 function removeGuidanceLines(text = '') {
+  const guidanceRegex =
+    /^\s*\([^)]*\)\s*$|\b(?:consolidate relevant experience|add other relevant experience|list key skills)\b/i;
   return text
     .split(/\r?\n/)
-    .filter((line) => !/consolidate relevant experience/i.test(line))
+    .filter((line) => !guidanceRegex.test(line))
     .join('\n');
 }
 
@@ -1231,5 +1233,6 @@ export {
   extractExperience,
   extractEducation,
   TEMPLATE_IDS,
-  selectTemplates
+  selectTemplates,
+  removeGuidanceLines
 };

--- a/tests/removeGuidanceLines.test.js
+++ b/tests/removeGuidanceLines.test.js
@@ -1,0 +1,17 @@
+import { removeGuidanceLines } from '../server.js';
+
+describe('removeGuidanceLines', () => {
+  test('removes guidance phrases and parenthetical lines', () => {
+    const input = [
+      'Professional Summary',
+      '(Tailor this section)',
+      'Add other relevant experience',
+      'List key skills.',
+      'Consolidate relevant experience',
+      'Final line'
+    ].join('\n');
+
+    const output = removeGuidanceLines(input);
+    expect(output).toBe(['Professional Summary', 'Final line'].join('\n'));
+  });
+});


### PR DESCRIPTION
## Summary
- broaden guidance line filtering to drop parenthetical lines and phrases like "Add other relevant experience" or "List key skills"
- export `removeGuidanceLines` for testing and add coverage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b48d675384832b8b4a13c345a7297d