### PR TITLE
feat: skip required sections for cover letters

### DIFF
--- a/server.js
+++ b/server.js
@@ -350,9 +350,14 @@ function ensureRequiredSections(
     resumeExperience = [],
     linkedinExperience = [],
     resumeEducation = [],
-    linkedinEducation = []
+    linkedinEducation = [],
+    skipRequiredSections = false
   } = {}
 ) {
+  if (skipRequiredSections) {
+    data.sections = data.sections.filter((s) => s.items && s.items.length);
+    return data;
+  }
   const required = ['Work Experience', 'Education'];
   required.forEach((heading) => {
     let section = data.sections.find(
@@ -1163,6 +1168,8 @@ app.post('/api/process-cv', (req, res, next) => {
               resumeEducation,
               linkedinEducation
             }
+          : name === 'cover_letter1' || name === 'cover_letter2'
+          ? { skipRequiredSections: true }
           : {};
       const pdfBuffer = await generatePdf(text, tpl, options);
       await s3.send(

--- a/tests/parseContent.test.js
+++ b/tests/parseContent.test.js
@@ -29,6 +29,22 @@ describe('parseContent placeholders', () => {
       'Information not provided'
     );
   });
+
+  test('omits required sections when skipRequiredSections is true', () => {
+    const data = parseContent('Jane Doe\n# Skills\n- JavaScript', {
+      skipRequiredSections: true
+    });
+    const headings = data.sections.map((s) => s.heading);
+    expect(headings).not.toContain('Work Experience');
+    expect(headings).not.toContain('Education');
+    data.sections.forEach((s) =>
+      s.items.forEach((tokens) => {
+        expect(tokens.map((t) => t.text).join('')).not.toBe(
+          'Information not provided'
+        );
+      })
+    );
+  });
 });
 
 describe('parseContent summary reclassification', () => {


### PR DESCRIPTION
## Summary
- add `skipRequiredSections` flag to parsing to drop empty Work Experience/Education sections
- use flag when generating cover letter PDFs so no placeholder text is emitted
- add tests ensuring cover letters omit `Information not provided`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b49120b580832ba5de406ea569f97f