### PR TITLE
Filter bracketed guidance lines

### DIFF
--- a/server.js
+++ b/server.js
@@ -878,7 +878,7 @@ function parseAiJson(text) {
 
 function removeGuidanceLines(text = '') {
   const guidanceRegex =
-    /^\s*\([^)]*\)\s*$|\b(?:consolidate relevant experience|add other relevant experience|list key skills)\b/i;
+    /^\s*(?:\([^)]*\)|\[[^\]]*\])\s*$|\b(?:consolidate relevant experience|add other relevant experience|list key skills|previous roles summarized|for brevity)\b/i;
   return text
     .split(/\r?\n/)
     .filter((line) => !guidanceRegex.test(line))
@@ -1241,5 +1241,6 @@ export {
   extractEducation,
   TEMPLATE_IDS,
   selectTemplates,
-  removeGuidanceLines
+  removeGuidanceLines,
+  sanitizeGeneratedText
 };

--- a/tests/removeGuidanceLines.test.js
+++ b/tests/removeGuidanceLines.test.js
@@ -5,8 +5,11 @@ describe('removeGuidanceLines', () => {
     const input = [
       'Professional Summary',
       '(Tailor this section)',
+      '[Customize this section]',
       'Add other relevant experience',
+      'Previous roles summarized above.',
       'List key skills.',
+      'Details omitted for brevity.',
       'Consolidate relevant experience',
       'Final line'
     ].join('\n');

--- a/tests/sanitizeGeneratedText.test.js
+++ b/tests/sanitizeGeneratedText.test.js
@@ -1,0 +1,15 @@
+import { sanitizeGeneratedText } from '../server.js';
+
+describe('sanitizeGeneratedText', () => {
+  test('removes bracketed guidance lines', () => {
+    const input = [
+      'John Doe',
+      '[Optional note]',
+      '# Experience',
+      '- Did things'
+    ].join('\n');
+
+    const output = sanitizeGeneratedText(input, { skipRequiredSections: true });
+    expect(output).toBe(['John Doe', '# Experience', 'Did things'].join('\n'));
+  });
+});


### PR DESCRIPTION
## Summary
- strip guidance lines enclosed in brackets and phrases like "previous roles summarized" or "for brevity"
- export and test sanitizeGeneratedText for bracketed guidance
- extend removeGuidanceLines tests with new patterns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b499b313e8832b94b7114b32d76683