### PR TITLE
Parse LinkedIn experience details and merge JD title

### DIFF
--- a/tests/extractExperience.test.js
+++ b/tests/extractExperience.test.js
@@ -1,0 +1,45 @@
+import { jest } from '@jest/globals';
+
+const sampleHtml = `
+<section id="experience">
+  <li>
+    <h3>Engineer</h3>
+    <h4>Acme Corp</h4>
+    <span>Jan 2020 - Feb 2021</span>
+  </li>
+</section>
+`;
+
+jest.unstable_mockModule('axios', () => ({
+  default: { get: jest.fn().mockResolvedValue({ data: sampleHtml }) }
+}));
+
+const { extractExperience, fetchLinkedInProfile } = await import('../server.js');
+
+describe('extractExperience', () => {
+  test('parses company and dates from resume text', () => {
+    const text = 'Experience\n- Developer at Beta Corp (Mar 2018 - Apr 2019)\n';
+    expect(extractExperience(text)).toEqual([
+      {
+        company: 'Beta Corp',
+        title: 'Developer',
+        startDate: 'Mar 2018',
+        endDate: 'Apr 2019'
+      }
+    ]);
+  });
+});
+
+describe('fetchLinkedInProfile', () => {
+  test('extracts structured experience details', async () => {
+    const profile = await fetchLinkedInProfile('http://example.com');
+    expect(profile.experience).toEqual([
+      {
+        company: 'Acme Corp',
+        title: 'Engineer',
+        startDate: 'Jan 2020',
+        endDate: 'Feb 2021'
+      }
+    ]);
+  });
+});

--- a/tests/mergeResumeWithLinkedIn.test.js
+++ b/tests/mergeResumeWithLinkedIn.test.js
@@ -1,0 +1,15 @@
+import { mergeResumeWithLinkedIn } from '../server.js';
+
+describe('mergeResumeWithLinkedIn', () => {
+  test('overwrites most recent title with job title from JD', () => {
+    const resumeText = 'Resume';
+    const profile = {
+      experience: [
+        { company: 'Acme', title: 'Engineer', startDate: '2020', endDate: '2021' },
+        { company: 'Beta', title: 'Intern', startDate: '2019', endDate: '2020' }
+      ]
+    };
+    const merged = mergeResumeWithLinkedIn(resumeText, profile, 'Senior Engineer');
+    expect(merged).toContain('LinkedIn Experience: Senior Engineer at Acme (2020 - 2021); Intern at Beta (2019 - 2020)');
+  });
+});

--- a/tests/parseContent.test.js
+++ b/tests/parseContent.test.js
@@ -73,7 +73,9 @@ describe('parseContent summary reclassification', () => {
 describe('parseContent experience fallbacks', () => {
   test('uses resume experience when AI output lacks it', () => {
     const data = parseContent('Jane Doe\n# Skills\n- JS', {
-      resumeExperience: ['Did something']
+      resumeExperience: [
+        { title: 'Did something', company: '', startDate: '', endDate: '' }
+      ]
     });
     const work = data.sections.find((s) => s.heading === 'Work Experience');
     expect(work.items).toHaveLength(1);
@@ -82,7 +84,9 @@ describe('parseContent experience fallbacks', () => {
 
   test('uses linkedin experience when resume lacks it', () => {
     const data = parseContent('Jane Doe\n# Skills\n- JS', {
-      linkedinExperience: ['LinkedIn item']
+      linkedinExperience: [
+        { title: 'LinkedIn item', company: '', startDate: '', endDate: '' }
+      ]
     });
     const work = data.sections.find((s) => s.heading === 'Work Experience');
     expect(work.items).toHaveLength(1);


### PR DESCRIPTION
## Summary
- Parse company, role, and dates from LinkedIn profile data and resume text
- Merge LinkedIn data into resume, replacing latest role title with JD job title
- Annotate AI prompt with note that last role matched JD duties
- Add tests for experience parsing and title substitution

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b49bb3c7d0832bb638bf58676ca00e