### PR TITLE
Bold job entries and skills list parsing

### DIFF
--- a/templates/2025.css
+++ b/templates/2025.css
@@ -69,6 +69,7 @@ li {
   margin-left: 1.2em;
   white-space: pre-wrap;
   line-height: 1.5;
+  font-weight: 400;
 }
 
 .bullet {
@@ -85,5 +86,9 @@ li {
 
 .tab + p {
   margin-top: 0;
+}
+
+strong {
+  font-weight: 700;
 }
 

--- a/templates/modern.html
+++ b/templates/modern.html
@@ -7,7 +7,7 @@
     body { font-family: 'Segoe UI', Tahoma, sans-serif; margin: 40px; color: #333; line-height: 1.5; }
     header { background: #2a9d8f; color: #fff; padding: 20px; margin-bottom: 20px; text-align: center; }
     h1 { font-size: 32px; margin: 0 0 12px; }
-    h2 { font-size: 20px; margin: 24px 0 12px; border-bottom: 1px solid #2a9d8f; padding-bottom: 4px; }
+    h2 { font-size: 20px; margin: 24px 0 12px; border-bottom: 1px solid #2a9d8f; padding-bottom: 4px; font-weight: bold; }
     section { margin-bottom: 16px; }
     ul { list-style: none; margin: 0; padding: 0; }
     li {
@@ -15,6 +15,7 @@
       margin-left: 1.2em;
       white-space: pre-wrap;
       line-height: 1.5;
+      font-weight: 400;
     }
     .bullet {
       display: inline-block;
@@ -24,6 +25,7 @@
     }
     .tab { display:inline-block; width:1.5em; }
     .tab + p { margin-top: 0; }
+    strong { font-weight: bold; }
   </style>
 </head>
 <body>

--- a/templates/professional.html
+++ b/templates/professional.html
@@ -7,7 +7,7 @@
     body { font-family: 'Helvetica Neue', Arial, sans-serif; margin: 40px; color: #222; line-height: 1.5; }
     header { text-align: center; background: #1d3557; color: #fff; margin-bottom: 30px; padding: 20px 0; }
     h1 { font-size: 36px; margin: 0 0 12px; }
-    h2 { font-size: 20px; color: #1d3557; margin: 30px 0 16px; border-bottom: 1px solid #1d3557; padding-bottom: 4px; }
+    h2 { font-size: 20px; color: #1d3557; margin: 30px 0 16px; border-bottom: 1px solid #1d3557; padding-bottom: 4px; font-weight: bold; }
     section { margin-bottom: 16px; }
     ul { list-style: none; margin: 0; padding: 0; }
     li {
@@ -15,6 +15,7 @@
       margin-left: 1.2em;
       white-space: pre-wrap;
       line-height: 1.5;
+      font-weight: 400;
     }
     .bullet {
       display: inline-block;
@@ -24,6 +25,7 @@
     }
     .tab { display:inline-block; width:1.5em; }
     .tab + p { margin-top: 0; }
+    strong { font-weight: bold; }
   </style>
 </head>
 <body>

--- a/templates/ucmo.html
+++ b/templates/ucmo.html
@@ -7,13 +7,14 @@
     body { font-family: 'Times New Roman', serif; margin: 50px; color: #222; line-height: 1.5; }
     header { text-align: center; background: #990000; color: #fff; padding: 20px 0; margin-bottom: 20px; }
     h1 { font-size: 36px; margin: 0 0 12px; }
-    h2 { font-size: 18px; margin: 30px 0 12px; background: #f2f2f2; padding: 6px 10px; color: #990000; }
+    h2 { font-size: 18px; margin: 30px 0 12px; background: #f2f2f2; padding: 6px 10px; color: #990000; font-weight: bold; }
     ul { list-style: none; padding-left: 0; margin: 0; }
     li {
       margin-bottom: 10px;
       margin-left: 1.2em;
       white-space: pre-wrap;
       line-height: 1.5;
+      font-weight: 400;
     }
     .bullet {
       display: inline-block;
@@ -23,6 +24,7 @@
     }
     .tab { display:inline-block; width:1.5em; }
     .tab + p { margin-top: 0; }
+    strong { font-weight: bold; }
   </style>
 </head>
 <body>

--- a/templates/vibrant.html
+++ b/templates/vibrant.html
@@ -7,7 +7,7 @@
     body { font-family: 'Poppins', 'Segoe UI', sans-serif; margin: 40px; color: #333; line-height: 1.5; }
     header { background: #ff6b6b; color: #fff; padding: 20px; margin-bottom: 20px; text-align: center; }
     h1 { font-size: 36px; margin: 0 0 12px; }
-    h2 { font-size: 20px; color: #ff6b6b; margin: 24px 0 12px; border-bottom: 2px solid #ff6b6b; padding-bottom: 4px; }
+    h2 { font-size: 20px; color: #ff6b6b; margin: 24px 0 12px; border-bottom: 2px solid #ff6b6b; padding-bottom: 4px; font-weight: bold; }
     section { margin-bottom: 16px; }
     ul { list-style: none; margin: 0; padding: 0; }
     li {
@@ -15,6 +15,7 @@
       margin-left: 1.2em;
       white-space: pre-wrap;
       line-height:1.5;
+      font-weight: 400;
     }
     .bullet {
       display: inline-block;
@@ -24,6 +25,7 @@
     }
     .tab { display:inline-block; width:1.5em; }
     .tab + p { margin-top: 0; }
+    strong { font-weight: bold; }
   </style>
 </head>
 <body>

--- a/tests/__snapshots__/generatePdf.test.js.snap
+++ b/tests/__snapshots__/generatePdf.test.js.snap
@@ -79,6 +79,7 @@ li {
   margin-left: 1.2em;
   white-space: pre-wrap;
   line-height: 1.5;
+  font-weight: 400;
 }
 
 .bullet {
@@ -95,6 +96,10 @@ li {
 
 .tab + p {
   margin-top: 0;
+}
+
+strong {
+  font-weight: 700;
 }
 
 </style></head>

--- a/tests/parseContent.test.js
+++ b/tests/parseContent.test.js
@@ -65,8 +65,20 @@ describe('parseContent summary reclassification', () => {
     );
     expect(work.items).toHaveLength(1);
     expect(work.items[0].map((t) => t.text).join('')).toBe(
-      'Acme Corp | Developer | Jan 2020 - Present'
+      'Acme Corp Developer Jan 2020 - Present'
     );
+  });
+});
+
+describe('parseContent skills list handling', () => {
+  test('splits comma or semicolon separated skills into bullets', () => {
+    const input = 'Jane Doe\n# Skills\nJavaScript, Python; Go';
+    const data = parseContent(input);
+    const skills = data.sections.find((s) => s.heading === 'Skills');
+    const items = skills.items.map((tokens) =>
+      tokens.filter((t) => t.text).map((t) => t.text).join('')
+    );
+    expect(items).toEqual(['JavaScript', 'Python', 'Go']);
   });
 });
 

--- a/tests/parseLine.test.js
+++ b/tests/parseLine.test.js
@@ -37,4 +37,13 @@ describe('parseLine emphasis handling', () => {
     expect(tokens.map((t) => t.text).join('')).toBe('Text with mismatched markers inside');
     tokens.forEach((t) => expect(t.style).toBeUndefined());
   });
+
+  test('bolds job title and company before pipe', () => {
+    const tokens = parseLine('Software Engineer, Acme Corp | Jan 2020 - Present');
+    const text = tokens.map((t) => t.text || '').join('');
+    expect(text).toBe('Software Engineer, Acme Corp Jan 2020 - Present');
+    const bold = tokens.filter((t) => t.style === 'bold' || t.style === 'bolditalic');
+    expect(bold.map((t) => t.text).join('')).toBe('Software Engineer, Acme Corp');
+    expect(tokens.some((t) => t.type === 'jobsep')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Bold job titles and companies before pipes and ignore job separators in PDF/HTML output
- Split comma/semicolon separated skills into individual bullet items
- Ensure templates use bold section headings and normal-weight dates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a09e5d18832b935e9a73f4d6d96e