### PR TITLE
Prune empty resume sections and ensure cover-letter cleanup

### DIFF
--- a/server.js
+++ b/server.js
@@ -560,6 +560,15 @@ function moveSummaryJobEntries(sections = []) {
   }
 }
 
+function pruneEmptySections(sections = []) {
+  return sections.filter((sec) => {
+    sec.items = (sec.items || []).filter((tokens) =>
+      tokens.some((t) => t.text && t.text.trim())
+    );
+    return sec.items.length > 0;
+  });
+}
+
 function parseContent(text, options = {}) {
   try {
     const data = JSON.parse(text);
@@ -604,7 +613,8 @@ function parseContent(text, options = {}) {
     });
     splitSkills(sections);
     moveSummaryJobEntries(sections);
-    return ensureRequiredSections({ name, sections }, options);
+    const prunedSections = pruneEmptySections(sections);
+    return ensureRequiredSections({ name, sections: prunedSections }, options);
   } catch {
     const lines = text.split(/\r?\n/);
     const name = normalizeName((lines.shift() || 'Resume').trim());
@@ -678,7 +688,8 @@ function parseContent(text, options = {}) {
     });
     splitSkills(sections);
     moveSummaryJobEntries(sections);
-    return ensureRequiredSections({ name, sections }, options);
+    const prunedSections = pruneEmptySections(sections);
+    return ensureRequiredSections({ name, sections: prunedSections }, options);
   }
 }
 

--- a/tests/parseContent.test.js
+++ b/tests/parseContent.test.js
@@ -128,3 +128,20 @@ describe('parseContent education fallbacks', () => {
   });
 });
 
+describe('parseContent empty section removal', () => {
+  test('omits sections with only whitespace items', () => {
+    const input = [
+      'Jane Doe',
+      '# Work Experience',
+      '-   ',
+      '# Skills',
+      '- JavaScript',
+      '# Empty',
+      '-   '
+    ].join('\n');
+    const data = parseContent(input, { skipRequiredSections: true });
+    const headings = data.sections.map((s) => s.heading);
+    expect(headings).toEqual(['Skills']);
+  });
+});
+

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -304,6 +304,8 @@ describe('/api/process-cv', () => {
           )
           .join('\n');
         if (options && options.skipRequiredSections) {
+          const headings = data.sections.map((s) => s.heading);
+          expect(headings).not.toContain('Work Experience');
           expect(combined).not.toContain('Information not provided');
         }
         return Promise.resolve(Buffer.from('pdf'));


### PR DESCRIPTION
## Summary
- Skip sections whose items are empty or whitespace-only during parsing
- Confirm cover letters omit Work Experience when no entries are provided
- Add regression tests covering empty section removal and cover-letter handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4a36f0600832bb48d771fde814b10