### PR TITLE
Merge duplicate sections in parseContent

### DIFF
--- a/server.js
+++ b/server.js
@@ -560,6 +560,23 @@ function moveSummaryJobEntries(sections = []) {
   }
 }
 
+function mergeDuplicateSections(sections = []) {
+  const seen = new Map();
+  const result = [];
+  sections.forEach((sec) => {
+    const key = (sec.heading || '').toLowerCase();
+    if (seen.has(key)) {
+      const existing = seen.get(key);
+      existing.items = existing.items.concat(sec.items || []);
+    } else {
+      const copy = { ...sec, items: [...(sec.items || [])] };
+      seen.set(key, copy);
+      result.push(copy);
+    }
+  });
+  return result;
+}
+
 function pruneEmptySections(sections = []) {
   return sections.filter((sec) => {
     sec.items = (sec.items || []).filter((tokens) =>
@@ -613,7 +630,8 @@ function parseContent(text, options = {}) {
     });
     splitSkills(sections);
     moveSummaryJobEntries(sections);
-    const prunedSections = pruneEmptySections(sections);
+    const mergedSections = mergeDuplicateSections(sections);
+    const prunedSections = pruneEmptySections(mergedSections);
     return ensureRequiredSections({ name, sections: prunedSections }, options);
   } catch {
     const lines = text.split(/\r?\n/);
@@ -688,7 +706,8 @@ function parseContent(text, options = {}) {
     });
     splitSkills(sections);
     moveSummaryJobEntries(sections);
-    const prunedSections = pruneEmptySections(sections);
+    const mergedSections = mergeDuplicateSections(sections);
+    const prunedSections = pruneEmptySections(mergedSections);
     return ensureRequiredSections({ name, sections: prunedSections }, options);
   }
 }

--- a/tests/parseContent.test.js
+++ b/tests/parseContent.test.js
@@ -145,3 +145,43 @@ describe('parseContent empty section removal', () => {
   });
 });
 
+describe('parseContent duplicate section merging', () => {
+  test('merges markdown sections with same heading case-insensitively', () => {
+    const input = [
+      'Jane Doe',
+      '# Education',
+      '- B.S. in CS',
+      '# education',
+      '- M.S. in CS'
+    ].join('\n');
+    const data = parseContent(input, { skipRequiredSections: true });
+    const educationSections = data.sections.filter(
+      (s) => s.heading.toLowerCase() === 'education'
+    );
+    expect(educationSections).toHaveLength(1);
+    const items = educationSections[0].items.map((tokens) =>
+      tokens.filter((t) => t.text).map((t) => t.text).join('')
+    );
+    expect(items).toEqual(['B.S. in CS', 'M.S. in CS']);
+  });
+
+  test('merges JSON sections with same heading case-insensitively', () => {
+    const json = {
+      name: 'Jane',
+      sections: [
+        { heading: 'Education', items: ['B.S. in CS'] },
+        { heading: 'education', items: ['M.S. in CS'] }
+      ]
+    };
+    const data = parseContent(JSON.stringify(json), { skipRequiredSections: true });
+    const educationSections = data.sections.filter(
+      (s) => s.heading.toLowerCase() === 'education'
+    );
+    expect(educationSections).toHaveLength(1);
+    const items = educationSections[0].items.map((tokens) =>
+      tokens.filter((t) => t.text).map((t) => t.text).join('')
+    );
+    expect(items).toEqual(['B.S. in CS', 'M.S. in CS']);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `mergeDuplicateSections` helper to combine sections with identical headings
- use the helper in `parseContent` prior to pruning
- test that duplicate Education sections merge into one

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a7de3cd0832b9c2b4ddf17610091