### PR TITLE
Combine resume and LinkedIn experience with responsibilities

### DIFF
--- a/tests/extractExperience.test.js
+++ b/tests/extractExperience.test.js
@@ -17,14 +17,16 @@ jest.unstable_mockModule('axios', () => ({
 const { extractExperience, fetchLinkedInProfile } = await import('../server.js');
 
 describe('extractExperience', () => {
-  test('parses company and dates from resume text', () => {
-    const text = 'Experience\n- Developer at Beta Corp (Mar 2018 - Apr 2019)\n';
+  test('parses company, dates, and responsibilities from resume text', () => {
+    const text =
+      'Experience\n- Developer at Beta Corp (Mar 2018 - Apr 2019)\n  - Built API\n';
     expect(extractExperience(text)).toEqual([
       {
         company: 'Beta Corp',
         title: 'Developer',
         startDate: 'Mar 2018',
-        endDate: 'Apr 2019'
+        endDate: 'Apr 2019',
+        responsibilities: ['Built API']
       }
     ]);
   });

--- a/tests/mergeResumeWithLinkedIn.test.js
+++ b/tests/mergeResumeWithLinkedIn.test.js
@@ -10,6 +10,8 @@ describe('mergeResumeWithLinkedIn', () => {
       ]
     };
     const merged = mergeResumeWithLinkedIn(resumeText, profile, 'Senior Engineer');
-    expect(merged).toContain('LinkedIn Experience: Senior Engineer at Acme (2020 - 2021); Intern at Beta (2019 - 2020)');
+    expect(merged).toContain(
+      'LinkedIn Experience: Senior Engineer at Acme (2020 – 2021); Intern at Beta (2019 – 2020)'
+    );
   });
 });

--- a/tests/parseContent.test.js
+++ b/tests/parseContent.test.js
@@ -104,6 +104,32 @@ describe('parseContent experience fallbacks', () => {
     expect(work.items).toHaveLength(1);
     expect(work.items[0].map((t) => t.text).join('')).toBe('LinkedIn item');
   });
+  test('merges resume and LinkedIn experiences with dates and descriptions', () => {
+    const data = parseContent('Jane Doe\n# Skills\n- JS', {
+      resumeExperience: [
+        {
+          title: 'Developer',
+          company: 'Beta Corp',
+          startDate: 'Mar 2018',
+          endDate: 'Apr 2019',
+          responsibilities: ['Built things']
+        }
+      ],
+      linkedinExperience: [
+        {
+          title: 'Engineer',
+          company: 'Acme',
+          startDate: 'Jan 2020',
+          endDate: 'Feb 2021'
+        }
+      ],
+      jobTitle: 'Senior Engineer'
+    });
+    const work = data.sections.find((s) => s.heading === 'Work Experience');
+    expect(work.items).toHaveLength(2);
+    expect(work.items[0].map((t) => t.text).join('')).toBe('Senior Engineer at Acme (Jan 2020 – Feb 2021)');
+    expect(work.items[1].map((t) => t.text).join('')).toBe('Developer at Beta Corp (Mar 2018 – Apr 2019)Built things');
+  });
 });
 
 describe('parseContent education fallbacks', () => {


### PR DESCRIPTION
## Summary
- Merge resume and LinkedIn experience data, deduplicate entries, sort by date, and inject job title while formatting as bullets with date ranges and responsibilities
- Capture responsibilities from indented bullets in extractExperience
- Extend tests to cover merged experience, date formatting, and responsibilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4a9006a50832ba1142ee028c66971