### PR TITLE
feat: log outputs to DynamoDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.432.0",
     "@aws-sdk/client-secrets-manager": "^3.432.0",
+    "@aws-sdk/client-dynamodb": "^3.432.0",
     "@google/generative-ai": "^0.11.3",
     "axios": "^1.6.2",
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- add DynamoDB client dependency
- ensure ResumeForge table exists and store document URLs
- cover DynamoDB table creation and write paths with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4add5228c832bb5ffcfb8a2dd3278