### PR TITLE
Merge existing work experience entries chronologically

### DIFF
--- a/tests/ensureRequiredSections.test.js
+++ b/tests/ensureRequiredSections.test.js
@@ -1,0 +1,29 @@
+import { ensureRequiredSections, parseLine } from '../server.js';
+
+describe('ensureRequiredSections work experience merging', () => {
+  test('appends missing roles and sorts chronologically', () => {
+    const existingToken = parseLine('- Engineer at Acme (2020 – 2021)');
+    const data = { sections: [{ heading: 'Work Experience', items: [existingToken] }] };
+    const resumeExperience = [
+      { company: 'Beta', title: 'Developer', startDate: '2019', endDate: '2020' }
+    ];
+    const ensured = ensureRequiredSections(data, { resumeExperience });
+    const items = ensured.sections[0].items;
+    expect(items).toHaveLength(2);
+    const lines = items.map((tokens) =>
+      tokens.map((t) => t.text || '').join('').trim()
+    );
+    expect(lines[0]).toBe('Engineer at Acme (2020 – 2021)');
+    expect(lines[1]).toBe('Developer at Beta (2019 – 2020)');
+  });
+
+  test('does not duplicate existing roles', () => {
+    const existingToken = parseLine('- Engineer at Acme (2020 – 2021)');
+    const data = { sections: [{ heading: 'Work Experience', items: [existingToken] }] };
+    const resumeExperience = [
+      { company: 'Acme', title: 'Engineer', startDate: '2020', endDate: '2021' }
+    ];
+    const ensured = ensureRequiredSections(data, { resumeExperience });
+    expect(ensured.sections[0].items).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- parse existing work experience items to extract company, title, and dates, then merge with resume and LinkedIn data
- export `ensureRequiredSections` and add tests for deduping and chronological sort

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4bcd9ac0c832b819e7ee7685b8cb1