### PR TITLE
Use alternate glyph for Education bullets

### DIFF
--- a/server.js
+++ b/server.js
@@ -885,7 +885,12 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
             if (t.style === 'italic') return `<em>${text}</em>`;
             if (t.type === 'newline') return '<br>';
             if (t.type === 'tab') return '<span class="tab"></span>';
-            if (t.type === 'bullet') return '<span class="bullet">•</span>';
+            if (t.type === 'bullet') {
+              if (sec.heading === 'Education') {
+                return '<span class="edu-bullet">–</span>';
+              }
+              return '<span class="bullet">•</span>';
+            }
             if (t.type === 'jobsep') return '';
             return text;
           })
@@ -914,6 +919,7 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
         italic: 'Helvetica-Oblique',
         headingColor: '#1f3c5d',
         bullet: '•',
+        eduBullet: '–',
         bulletColor: '#4a5568',
         textColor: '#333',
         lineGap: 6,
@@ -925,6 +931,7 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
         italic: 'Helvetica-Oblique',
         headingColor: '#1f3c5d',
         bullet: '•',
+        eduBullet: '–',
         bulletColor: '#4a5568',
         textColor: '#333',
         lineGap: 6,
@@ -936,6 +943,7 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
         italic: 'Times-Italic',
         headingColor: '#1f3c5d',
         bullet: '•',
+        eduBullet: '–',
         bulletColor: '#4a5568',
         textColor: '#333',
         lineGap: 6,
@@ -947,6 +955,7 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
         italic: 'Helvetica-Oblique',
         headingColor: '#1f3c5d',
         bullet: '•',
+        eduBullet: '–',
         bulletColor: '#4a5568',
         textColor: '#333',
         lineGap: 6,
@@ -958,6 +967,7 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
         italic: 'Helvetica-Oblique',
         headingColor: '#1f3c5d',
         bullet: '•',
+        eduBullet: '–',
         bulletColor: '#4a5568',
         textColor: '#333',
         lineGap: 6,
@@ -1016,9 +1026,13 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
           doc.font(style.font).fontSize(12);
           tokens.forEach((t, idx) => {
             if (t.type === 'bullet') {
+              const glyph =
+                sec.heading === 'Education'
+                  ? style.eduBullet || style.bullet
+                  : style.bullet;
               doc
                 .fillColor(style.bulletColor)
-                .text(`${style.bullet} `, { continued: true, lineGap: style.lineGap })
+                .text(`${glyph} `, { continued: true, lineGap: style.lineGap })
                 .fillColor(style.textColor);
               return;
             }

--- a/templates/2025.css
+++ b/templates/2025.css
@@ -72,7 +72,7 @@ li {
   font-weight: 400;
 }
 
-.bullet {
+.bullet, .edu-bullet {
   display: inline-block;
   width: 1.2em;
   margin-left: -1.2em;

--- a/templates/modern.html
+++ b/templates/modern.html
@@ -17,7 +17,7 @@
       line-height: 1.5;
       font-weight: 400;
     }
-    .bullet {
+    .bullet, .edu-bullet {
       display: inline-block;
       width: 1.2em;
       margin-left: -1.2em;

--- a/templates/professional.html
+++ b/templates/professional.html
@@ -17,7 +17,7 @@
       line-height: 1.5;
       font-weight: 400;
     }
-    .bullet {
+    .bullet, .edu-bullet {
       display: inline-block;
       width: 1.2em;
       margin-left: -1.2em;

--- a/templates/ucmo.html
+++ b/templates/ucmo.html
@@ -16,7 +16,7 @@
       line-height: 1.5;
       font-weight: 400;
     }
-    .bullet {
+    .bullet, .edu-bullet {
       display: inline-block;
       width: 1.2em;
       margin-left: -1.2em;

--- a/templates/vibrant.html
+++ b/templates/vibrant.html
@@ -17,7 +17,7 @@
       line-height:1.5;
       font-weight: 400;
     }
-    .bullet {
+    .bullet, .edu-bullet {
       display: inline-block;
       width: 1.2em;
       margin-left: -1.2em;

--- a/tests/__snapshots__/generatePdf.test.js.snap
+++ b/tests/__snapshots__/generatePdf.test.js.snap
@@ -82,7 +82,7 @@ li {
   font-weight: 400;
 }
 
-.bullet {
+.bullet, .edu-bullet {
   display: inline-block;
   width: 1.2em;
   margin-left: -1.2em;

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -250,6 +250,19 @@ describe('generatePdf and parsing', () => {
     expect(rendered).not.toMatch(/[-–]/);
   });
 
+  test('education section uses alternate bullet glyph', () => {
+    const input = 'Jane Doe\n# Education\n- Bachelor of Science';
+    const data = parseContent(input);
+    const edu = data.sections.find((s) => s.heading === 'Education');
+    const rendered = edu.items[0]
+      .map((t) => {
+        if (t.type === 'bullet') return '<span class="edu-bullet">–</span>';
+        return t.text || '';
+      })
+      .join('');
+    expect(rendered).toBe('<span class="edu-bullet">–</span>Bachelor of Science');
+  });
+
   test('single asterisk italic and bullet handling', () => {
     const data = parseContent(
       'Jane Doe\n* This has *italic* text'


### PR DESCRIPTION
## Summary
- Render a different bullet glyph for the Education section
- Style `.edu-bullet` across resume templates and fallback PDF generation
- Test Education bullet glyph handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4be2424e4832bb37cee87e04c5864