### PR TITLE
Add certification extraction and merging

### DIFF
--- a/tests/ensureRequiredSections.test.js
+++ b/tests/ensureRequiredSections.test.js
@@ -27,3 +27,45 @@ describe('ensureRequiredSections work experience merging', () => {
     expect(ensured.sections[0].items).toHaveLength(1);
   });
 });
+
+describe('ensureRequiredSections certifications merging', () => {
+  test('merges and deduplicates certifications with hyperlinks', () => {
+    const data = { sections: [] };
+    const resumeCertifications = [
+      {
+        name: 'AWS Certified Developer',
+        provider: 'Amazon',
+        url: 'https://www.credly.com/badges/aws-dev'
+      }
+    ];
+    const linkedinCertifications = [
+      {
+        name: 'AWS Certified Developer',
+        provider: 'Amazon',
+        url: 'https://www.credly.com/badges/aws-dev'
+      },
+      {
+        name: 'PMP',
+        provider: 'PMI',
+        url: 'https://example.com/pmp'
+      }
+    ];
+    const ensured = ensureRequiredSections(data, {
+      resumeCertifications,
+      linkedinCertifications
+    });
+    const certSection = ensured.sections.find(
+      (s) => s.heading === 'Certifications'
+    );
+    expect(certSection).toBeTruthy();
+    expect(certSection.items).toHaveLength(2);
+    certSection.items.forEach((tokens) => {
+      expect(tokens[0].type).toBe('bullet');
+    });
+    const first = certSection.items[0];
+    const hasLink = first.some(
+      (t) => t.type === 'link' && t.href === 'https://www.credly.com/badges/aws-dev'
+    );
+    expect(hasLink).toBe(true);
+  });
+});

--- a/tests/extractCertifications.test.js
+++ b/tests/extractCertifications.test.js
@@ -1,0 +1,43 @@
+import { extractCertifications } from '../server.js';
+
+describe('extractCertifications', () => {
+  test('parses certification line with provider and credly link', () => {
+    const text = `Certifications\n- AWS Certified Developer (Amazon) https://www.credly.com/badges/abc`;
+    const certs = extractCertifications(text);
+    expect(certs).toEqual([
+      {
+        name: 'AWS Certified Developer',
+        provider: 'Amazon',
+        url: 'https://www.credly.com/badges/abc'
+      }
+    ]);
+  });
+
+  test('parses LinkedIn style objects', () => {
+    const src = [
+      {
+        name: 'PMP',
+        provider: 'PMI',
+        url: 'https://example.com/pmp'
+      },
+      {
+        certificateName: 'CKA',
+        issuingOrganization: 'CNCF',
+        credentialUrl: 'https://www.credly.com/cka'
+      }
+    ];
+    const certs = extractCertifications(src);
+    expect(certs).toEqual([
+      {
+        name: 'PMP',
+        provider: 'PMI',
+        url: 'https://example.com/pmp'
+      },
+      {
+        name: 'CKA',
+        provider: 'CNCF',
+        url: 'https://www.credly.com/cka'
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Parse certification entries from resume text or LinkedIn data with new `extractCertifications` helper.
- Merge and deduplicate certification info into a new `Certifications` section including hyperlinks.
- Pass certification data through parsing and PDF generation pipelines.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4c8dd79e4832b801c76465f284c43