### PR TITLE
Standardize certification heading and prune empty sections

### DIFF
--- a/server.js
+++ b/server.js
@@ -508,10 +508,19 @@ function parseEmphasis(segment) {
 
 
 function normalizeHeading(heading = '') {
-  return String(heading)
+  const base = String(heading)
     .trim()
     .replace(/[-–—:.;,!?]+$/g, '')
     .trim();
+  const lower = base.toLowerCase().replace(/\s+/g, ' ');
+  if (
+    /^certifications?$/.test(lower) ||
+    /^trainings?$/.test(lower) ||
+    /^trainings?\s*[\/&]\s*certifications?$/.test(lower)
+  ) {
+    return 'Certification';
+  }
+  return base;
 }
 
 
@@ -651,7 +660,7 @@ function ensureRequiredSections(
   });
 
   // Certifications section
-  const certHeading = 'Certifications';
+  const certHeading = 'Certification';
   let certSection = data.sections.find(
     (s) => normalizeHeading(s.heading).toLowerCase() === certHeading.toLowerCase()
   );
@@ -885,6 +894,7 @@ function parseContent(text, options = {}) {
       rest
     );
     ensured.sections = mergeDuplicateSections(ensured.sections);
+    ensured.sections = pruneEmptySections(ensured.sections);
     return ensured;
   } catch {
     const lines = text.split(/\r?\n/);

--- a/tests/ensureRequiredSections.test.js
+++ b/tests/ensureRequiredSections.test.js
@@ -55,9 +55,10 @@ describe('ensureRequiredSections certifications merging', () => {
       linkedinCertifications
     });
     const certSection = ensured.sections.find(
-      (s) => s.heading === 'Certifications'
+      (s) => s.heading === 'Certification'
     );
     expect(certSection).toBeTruthy();
+    expect(certSection.heading).toBe('Certification');
     expect(certSection.items).toHaveLength(2);
     certSection.items.forEach((tokens) => {
       expect(tokens[0].type).toBe('bullet');

--- a/tests/parseContent.test.js
+++ b/tests/parseContent.test.js
@@ -291,6 +291,36 @@ describe('parseContent duplicate section merging', () => {
   });
 });
 
+describe('parseContent certification normalization and pruning', () => {
+  test('standardizes certification headings and merges duplicates', () => {
+    const input = [
+      'Jane Doe',
+      '# Trainings',
+      '- AWS',
+      '# Certifications',
+      '- GCP',
+      '# TRAININGS/ CERTIFICATION',
+      '- Azure'
+    ].join('\n');
+    const data = parseContent(input, { skipRequiredSections: true });
+    const cert = data.sections.find((s) => s.heading === 'Certification');
+    expect(cert).toBeTruthy();
+    const items = cert.items.map((tokens) =>
+      tokens.filter((t) => t.text).map((t) => t.text).join('')
+    );
+    expect(items).toEqual(['AWS', 'GCP', 'Azure']);
+    const headings = data.sections.map((s) => s.heading);
+    expect(headings.filter((h) => h === 'Certification')).toHaveLength(1);
+  });
+
+  test('prunes empty certification sections', () => {
+    const input = ['Jane Doe', '# Certifications', '-   ', '# Skills', '- JS'].join('\n');
+    const data = parseContent(input, { skipRequiredSections: true });
+    const cert = data.sections.find((s) => s.heading === 'Certification');
+    expect(cert).toBeUndefined();
+  });
+});
+
 describe('parseContent defaultHeading option', () => {
   test('omits summary heading when defaultHeading is empty', () => {
     const input = 'Jane Doe\nThis is a cover letter paragraph.';


### PR DESCRIPTION
## Summary
- Normalize section headings such as "Trainings" and "Certifications" to the canonical "Certification" name.
- Prune empty sections again after enforcing required sections to ensure no blank headings remain.
- Expand tests to cover certification heading normalization and pruning behavior.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4ccbe6074832b928b3e0bcbdeb7b2