### PR TITLE
Ensure bullets for skills and certifications

### DIFF
--- a/server.js
+++ b/server.js
@@ -666,8 +666,14 @@ function ensureRequiredSections(
   );
   const existing = certSection
     ? certSection.items.map((tokens) => {
-        if (!tokens.some((t) => t.type === 'bullet')) {
-          tokens.unshift({ type: 'bullet' });
+        if (tokens[0]?.type !== 'bullet') {
+          const idx = tokens.findIndex((t) => t.type === 'bullet');
+          if (idx > -1) {
+            const [bullet] = tokens.splice(idx, 1);
+            tokens.unshift(bullet);
+          } else {
+            tokens.unshift({ type: 'bullet' });
+          }
         }
         const text = tokens
           .map((t) => t.text || t.href || '')
@@ -698,7 +704,7 @@ function ensureRequiredSections(
     if (cert.provider) line += ` - ${cert.provider}`;
     if (cert.url) line += ` ${cert.url}`;
     let tokens = parseLine(line);
-    if (!tokens.some((t) => t.type === 'bullet')) {
+    if (tokens[0]?.type !== 'bullet') {
       tokens.unshift({ type: 'bullet' });
     }
     certAdditions.push({ key, tokens });
@@ -761,12 +767,21 @@ function splitSkills(sections = []) {
         const skills = text.split(/[;,]/).map((s) => s.trim()).filter(Boolean);
         skills.forEach((skill) => {
           const skillTokens = parseLine(skill);
-          if (!skillTokens.some((t) => t.type === 'bullet')) {
+          if (skillTokens[0]?.type !== 'bullet') {
             skillTokens.unshift({ type: 'bullet' });
           }
           expanded.push(skillTokens);
         });
       } else {
+        if (tokens[0]?.type !== 'bullet') {
+          const idx = tokens.findIndex((t) => t.type === 'bullet');
+          if (idx > -1) {
+            const [bullet] = tokens.splice(idx, 1);
+            tokens.unshift(bullet);
+          } else {
+            tokens.unshift({ type: 'bullet' });
+          }
+        }
         expanded.push(tokens);
       }
     });
@@ -1871,6 +1886,7 @@ export {
   extractExperience,
   extractEducation,
   extractCertifications,
+  splitSkills,
   fetchLinkedInProfile,
   mergeResumeWithLinkedIn,
   TEMPLATE_IDS,

--- a/tests/ensureRequiredSections.test.js
+++ b/tests/ensureRequiredSections.test.js
@@ -69,4 +69,14 @@ describe('ensureRequiredSections certifications merging', () => {
     );
     expect(hasLink).toBe(true);
   });
+
+  test('prepends bullet to existing certification entries missing one', () => {
+    const data = {
+      sections: [{ heading: 'Certification', items: [parseLine('AWS Dev')] }]
+    };
+    const ensured = ensureRequiredSections(data, {});
+    const certSection = ensured.sections.find((s) => s.heading === 'Certification');
+    expect(certSection.items).toHaveLength(1);
+    expect(certSection.items[0][0].type).toBe('bullet');
+  });
 });

--- a/tests/splitSkills.test.js
+++ b/tests/splitSkills.test.js
@@ -1,0 +1,23 @@
+import { splitSkills, parseLine } from '../server.js';
+
+describe('splitSkills bullet handling', () => {
+  test('adds bullet to comma-separated skills', () => {
+    const sections = [{ heading: 'Skills', items: [parseLine('Python, Java')] }];
+    splitSkills(sections);
+    expect(sections[0].items).toHaveLength(2);
+    sections[0].items.forEach((tokens) => {
+      expect(tokens[0].type).toBe('bullet');
+    });
+  });
+
+  test('adds bullet to newline-separated skills', () => {
+    const sections = [
+      { heading: 'Skills', items: [parseLine('Python'), parseLine('Java')] }
+    ];
+    splitSkills(sections);
+    expect(sections[0].items).toHaveLength(2);
+    sections[0].items.forEach((tokens) => {
+      expect(tokens[0].type).toBe('bullet');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure splitSkills adds or moves bullet tokens to the start of every skill item
- Guarantee certification entries start with a bullet token during section normalization
- Add regression tests for skills and certification bullet handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4cdf6b590832b8eec4358dd221e08