### PR TITLE
Ensure bold headings across templates and add snapshot test

### DIFF
--- a/templates/cover_classic.html
+++ b/templates/cover_classic.html
@@ -5,7 +5,7 @@
   <title>Cover Letter</title>
   <style>
     body { font-family: 'Times New Roman', serif; margin: 60px; color: #000; line-height: 1.4; }
-    h1 { text-align: center; font-size: 28px; margin-bottom: 24px; text-transform: uppercase; }
+    h1 { text-align: center; font-size: 28px; margin-bottom: 24px; text-transform: uppercase; font-weight: bold; }
     p { margin: 0 0 14px; }
   </style>
 </head>

--- a/templates/cover_modern.html
+++ b/templates/cover_modern.html
@@ -5,7 +5,7 @@
   <title>Cover Letter</title>
   <style>
     body { font-family: 'Segoe UI', Tahoma, sans-serif; margin: 40px; color: #333; line-height: 1.6; }
-    h1 { color: #2a9d8f; margin-bottom: 20px; font-size: 32px; }
+    h1 { color: #2a9d8f; margin-bottom: 20px; font-size: 32px; font-weight: bold; }
     p { margin: 0 0 12px; }
   </style>
 </head>

--- a/tests/__snapshots__/boldHeadings.test.js.snap
+++ b/tests/__snapshots__/boldHeadings.test.js.snap
@@ -1,0 +1,156 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`headings are bold in HTML and PDF outputs: html 1`] = `
+"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Resume</title>
+  <style>
+    body { font-family: 'Segoe UI', Tahoma, sans-serif; margin: 40px; color: #333; line-height: 1.5; }
+    header { background: #2a9d8f; color: #fff; padding: 20px; margin-bottom: 20px; text-align: center; }
+    h1 { font-size: 32px; margin: 0 0 12px; }
+    h2 { font-size: 20px; margin: 24px 0 12px; border-bottom: 1px solid #2a9d8f; padding-bottom: 4px; font-weight: bold; }
+    section { margin-bottom: 16px; }
+    ul { list-style: none; margin: 0; padding: 0; }
+    li {
+      margin-bottom: 10px;
+      margin-left: 1.2em;
+      white-space: pre-wrap;
+      line-height: 1.5;
+      font-weight: 400;
+    }
+    .bullet, .edu-bullet {
+      display: inline-block;
+      width: 1.2em;
+      margin-left: -1.2em;
+      color: #2a9d8f;
+    }
+    .tab { display:inline-block; width:1.5em; }
+    .tab + p { margin-top: 0; }
+    strong { font-weight: bold; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Jane Doe</h1>
+  </header>
+  
+  <section>
+    <h2>Skills</h2>
+    {{#if items}}
+      <ul>
+        {{#each items}}
+          <li>{{{this}}}</li>
+        
+  <section>
+    <h2>Work Experience</h2>
+    {{#if items}}
+      <ul>
+        {{#each items}}
+          <li>{{{this}}}</li>
+        
+  <section>
+    <h2>Education</h2>
+    {{#if items}}
+      <ul>
+        {{#each items}}
+          <li>{{{this}}}</li>
+        
+      </ul>
+    {{/if}}
+  </section>
+  {{/each}}
+</body>
+</html>
+"
+`;
+
+exports[`headings are bold in HTML and PDF outputs: pdf 1`] = `
+{
+  "content": "1 0 0 -1 0 792 cm
+/DeviceRGB cs
+0.12156862745098039 0.23529411764705882 0.36470588235294116 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 727.64 Tm
+/F2 20 Tf
+[<4a616e6520446f65> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB cs
+0.12156862745098039 0.23529411764705882 0.36470588235294116 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 692.148 Tm
+/F2 14 Tf
+[<536b696c6c73> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.2901960784313726 0.3333333333333333 0.40784313725490196 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 660.924 Tm
+/F1 12 Tf
+[<9520> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 57.536 660.924 Tm
+/F1 12 Tf
+[<54> 120 <657374696e67> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.12156862745098039 0.23529411764705882 0.36470588235294116 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 615.744 Tm
+/F2 14 Tf
+[<57> 60 <6f726b20457870657269656e6365> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 584.52 Tm
+/F1 12 Tf
+[<496e66> 30 <6f72> -25 <6d6174696f6e206e6f742070726f> 15 <7669646564> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.12156862745098039 0.23529411764705882 0.36470588235294116 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 539.34 Tm
+/F2 14 Tf
+[<456475636174696f6e> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 508.116 Tm
+/F1 12 Tf
+[<496e66> 30 <6f72> -25 <6d6174696f6e206e6f742070726f> 15 <7669646564> 0] TJ
+ET
+Q
+",
+  "fontMap": {
+    "F1": "Helvetica",
+    "F2": "Helvetica-Bold",
+  },
+}
+`;

--- a/tests/boldHeadings.test.js
+++ b/tests/boldHeadings.test.js
@@ -1,0 +1,82 @@
+import { jest } from '@jest/globals';
+import { generatePdf, parseContent } from '../server.js';
+import puppeteer from 'puppeteer';
+import fs from 'fs/promises';
+import path from 'path';
+import Handlebars from '../lib/handlebars.js';
+import zlib from 'zlib';
+
+// Helper to convert token arrays into HTML strings, mirroring server logic
+function tokensToHtml(tokens) {
+  return tokens
+    .map((t) => {
+      const text = t.text || '';
+      if (t.type === 'link') return `<a href="${t.href}">${text}</a>`;
+      if (t.style === 'bolditalic') return `<strong><em>${text}</em></strong>`;
+      if (t.style === 'bold') return `<strong>${text}</strong>`;
+      if (t.style === 'italic') return `<em>${text}</em>`;
+      if (t.type === 'newline') return '<br>';
+      if (t.type === 'tab') return '<span class="tab"></span>';
+      if (t.type === 'bullet') return '<span class="bullet">•</span>';
+      return text;
+    })
+    .join('');
+}
+
+test('headings are bold in HTML and PDF outputs', async () => {
+  const input = 'Jane Doe\n# Skills\n- Testing';
+  const data = parseContent(input);
+
+  // Render HTML using the modern template
+  const tplSrc = await fs.readFile(path.resolve('templates', 'modern.html'), 'utf8');
+  const htmlData = {
+    ...data,
+    sections: data.sections.map((sec) => ({
+      ...sec,
+      items: sec.items.map(tokensToHtml)
+    }))
+  };
+  const html = Handlebars.compile(tplSrc)(htmlData);
+  expect(html).toMatchSnapshot('html');
+
+  // Force PDFKit fallback by failing to launch Puppeteer
+  const launchSpy = jest
+    .spyOn(puppeteer, 'launch')
+    .mockRejectedValue(new Error('no browser'));
+  const pdfBuffer = await generatePdf(input, 'modern');
+  launchSpy.mockRestore();
+
+  // Map PDF font identifiers to BaseFont names
+  const pdfStr = pdfBuffer.toString('latin1');
+  // Build object map from indirect object definitions
+  const objects = Object.fromEntries(
+    pdfStr
+      .split('endobj')
+      .map((chunk) => {
+        const id = chunk.match(/(\d+) 0 obj/);
+        const base = chunk.match(/BaseFont \/([^\s]+)/);
+        return id && base ? [id[1], base[1]] : null;
+      })
+      .filter(Boolean)
+  );
+  const fontMap = {};
+  const fontRefs = [...pdfStr.matchAll(/\/F(\d+) (\d+) 0 R/g)];
+  for (const [, id, obj] of fontRefs) {
+    const base = objects[obj];
+    if (base) fontMap[`F${id}`] = base;
+  }
+
+  // Extract and decompress first content stream
+  const start = pdfBuffer.indexOf(Buffer.from('stream')) + 6;
+  const nl = pdfBuffer.indexOf('\n', start) + 1;
+  const end = pdfBuffer.indexOf(Buffer.from('endstream'), nl);
+  let content = pdfBuffer.slice(nl, end);
+  try {
+    content = zlib.inflateSync(content).toString();
+  } catch {
+    content = content.toString();
+  }
+
+  expect({ fontMap, content }).toMatchSnapshot('pdf');
+});
+


### PR DESCRIPTION
## Summary
- Explicitly set bold font-weight on cover letter template headings
- Add snapshot test verifying bold headings in rendered HTML and PDF fallback
- Confirm PDFKit fallback maps section headings to bold fonts

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_68b4f03af820832bb46323ea7ec19859