### PR TITLE
Default selectTemplates to ucmo and contrasting style

### DIFF
--- a/server.js
+++ b/server.js
@@ -126,10 +126,14 @@ function selectTemplates({
     if (!coverTemplate2 && clTemplates[1]) coverTemplate2 = clTemplates[1];
   }
   if (!template1 && !template2) {
-    // Randomly pick from contrasting pairs when no templates are specified
-    const pair =
-      CONTRASTING_PAIRS[Math.floor(Math.random() * CONTRASTING_PAIRS.length)];
-    [template1, template2] = pair;
+    // Default to the classic "ucmo" template paired with a contrasting style
+    template1 = 'ucmo';
+    const candidates = CV_TEMPLATES.filter(
+      (t) => t !== 'ucmo' && CV_TEMPLATE_GROUPS[t] !== CV_TEMPLATE_GROUPS['ucmo']
+    );
+    template2 =
+      candidates[Math.floor(Math.random() * candidates.length)] ||
+      CV_TEMPLATES[0];
   } else {
     template1 = template1 || defaultCvTemplate;
     if (!template2) {

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -5,7 +5,8 @@ import {
   CV_TEMPLATES,
   CL_TEMPLATES,
   selectTemplates,
-  CONTRASTING_PAIRS
+  CONTRASTING_PAIRS,
+  CV_TEMPLATE_GROUPS
 } from '../server.js';
 import puppeteer from 'puppeteer';
 import pdfParse from 'pdf-parse/lib/pdf-parse.js';
@@ -102,17 +103,13 @@ describe('generatePdf and parsing', () => {
     }
   );
 
-  test('selectTemplates picks contrasting defaults', () => {
+  test('selectTemplates defaults to ucmo and contrasting style', () => {
     const { template1, template2, coverTemplate1, coverTemplate2 } = selectTemplates();
-    const contrasting = CONTRASTING_PAIRS.some(
-      ([a, b]) =>
-        (template1 === a && template2 === b) ||
-        (template1 === b && template2 === a)
-    );
-    expect(contrasting).toBe(true);
-    expect(coverTemplate1).not.toBe(coverTemplate2);
-    expect(CV_TEMPLATES).toContain(template1);
+    expect(template1).toBe('ucmo');
+    expect(template2).not.toBe('ucmo');
+    expect(CV_TEMPLATE_GROUPS[template2]).not.toBe(CV_TEMPLATE_GROUPS['ucmo']);
     expect(CV_TEMPLATES).toContain(template2);
+    expect(coverTemplate1).not.toBe(coverTemplate2);
     expect(CL_TEMPLATES).toContain(coverTemplate1);
     expect(CL_TEMPLATES).toContain(coverTemplate2);
   });


### PR DESCRIPTION
## Summary
- Ensure selectTemplates defaults to the classic `ucmo` template paired with a contrasting style when none are specified
- Add unit test confirming the default pairing uses `ucmo` with a template from a different style group

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f5586d30832b9835947517ac6177