### PR TITLE
Sanitize cover letters and strip bracket placeholders

### DIFF
--- a/tests/removeGuidanceLines.test.js
+++ b/tests/removeGuidanceLines.test.js
@@ -17,4 +17,10 @@ describe('removeGuidanceLines', () => {
     const output = removeGuidanceLines(input);
     expect(output).toBe(['Professional Summary', 'Final line'].join('\n'));
   });
+
+  test('removes bracketed phrases within lines', () => {
+    const input = ['Hello [World]', 'Keep [Placeholder] text'].join('\n');
+    const output = removeGuidanceLines(input);
+    expect(output).toBe(['Hello', 'Keep text'].join('\n'));
+  });
 });

--- a/tests/sanitizeGeneratedText.test.js
+++ b/tests/sanitizeGeneratedText.test.js
@@ -12,4 +12,21 @@ describe('sanitizeGeneratedText', () => {
     const output = sanitizeGeneratedText(input, { skipRequiredSections: true });
     expect(output).toBe(['John Doe', '# Experience', 'Did things'].join('\n'));
   });
+
+  test('removes bracketed placeholders within cover letters', () => {
+    const input = [
+      'Dear [Hiring Manager],',
+      'I am excited about the [Position Title] role.',
+      'Sincerely,',
+      'John Doe'
+    ].join('\n');
+
+    const output = sanitizeGeneratedText(input, {
+      skipRequiredSections: true,
+      defaultHeading: ''
+    });
+    expect(output).toBe(
+      ['Dear ,', 'I am excited about the role.', 'Sincerely,', 'John Doe'].join('\n')
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Remove bracketed placeholders and extra whitespace when cleaning generated text
- Sanitize cover letters before PDF generation in `/api/process-cv`
- Add tests ensuring bracketed phrases are removed from resumes and cover letters

## Testing
- `npm test tests/removeGuidanceLines.test.js tests/sanitizeGeneratedText.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4fbe9b364832bbddd5972a9a5385f