### PR TITLE
Improve bullet spacing in HTML and PDF outputs

### DIFF
--- a/server.js
+++ b/server.js
@@ -1033,7 +1033,7 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
               if (sec.heading === 'Education') {
                 return '<span class="edu-bullet">–</span>';
               }
-              return '<span class="bullet">•</span>';
+              return '<span class="bullet">•</span> ';
             }
             if (t.type === 'jobsep') return '';
             return text;
@@ -1177,6 +1177,7 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
               doc
                 .fillColor(style.bulletColor)
                 .text(`${glyph} `, { continued: true, lineGap: style.lineGap })
+                .text('', { continued: true })
                 .fillColor(style.textColor);
               return;
             }

--- a/templates/2025.css
+++ b/templates/2025.css
@@ -76,6 +76,7 @@ li {
   display: inline-block;
   width: 1.2em;
   margin-left: -1.2em;
+  margin-right: 0.4em;
   color: var(--bullet);
 }
 

--- a/templates/modern.html
+++ b/templates/modern.html
@@ -21,6 +21,7 @@
       display: inline-block;
       width: 1.2em;
       margin-left: -1.2em;
+      margin-right: 0.4em;
       color: #2a9d8f;
     }
     .tab { display:inline-block; width:1.5em; }

--- a/templates/professional.html
+++ b/templates/professional.html
@@ -21,6 +21,7 @@
       display: inline-block;
       width: 1.2em;
       margin-left: -1.2em;
+      margin-right: 0.4em;
       color: #1d3557;
     }
     .tab { display:inline-block; width:1.5em; }

--- a/templates/ucmo.html
+++ b/templates/ucmo.html
@@ -20,6 +20,7 @@
       display: inline-block;
       width: 1.2em;
       margin-left: -1.2em;
+      margin-right: 0.4em;
       color: #990000;
     }
     .tab { display:inline-block; width:1.5em; }

--- a/templates/vibrant.html
+++ b/templates/vibrant.html
@@ -21,6 +21,7 @@
       display: inline-block;
       width: 1.2em;
       margin-left: -1.2em;
+      margin-right: 0.4em;
       color: #4ecdc4;
     }
     .tab { display:inline-block; width:1.5em; }

--- a/tests/__snapshots__/boldHeadings.test.js.snap
+++ b/tests/__snapshots__/boldHeadings.test.js.snap
@@ -24,6 +24,7 @@ exports[`headings are bold in HTML and PDF outputs: html 1`] = `
       display: inline-block;
       width: 1.2em;
       margin-left: -1.2em;
+      margin-right: 0.4em;
       color: #2a9d8f;
     }
     .tab { display:inline-block; width:1.5em; }
@@ -106,7 +107,7 @@ Q
 q
 1 0 0 -1 0 792 cm
 BT
-1 0 0 1 57.536 660.924 Tm
+1 0 0 1 65.072 660.924 Tm
 /F1 12 Tf
 [<54> 120 <657374696e67> 0] TJ
 ET

--- a/tests/__snapshots__/generatePdf.test.js.snap
+++ b/tests/__snapshots__/generatePdf.test.js.snap
@@ -86,6 +86,7 @@ li {
   display: inline-block;
   width: 1.2em;
   margin-left: -1.2em;
+  margin-right: 0.4em;
   color: var(--bullet);
 }
 
@@ -138,4 +139,98 @@ strong {
 </body>
 </html>
 "
+`;
+
+exports[`generatePdf and parsing bullet list HTML spacing snapshot 1`] = `"<span class="bullet">•</span> First bullet"`;
+
+exports[`generatePdf and parsing bullet list PDF spacing snapshot: browser 1`] = `
+"1 0 0 -1 0 792 cm
+/DeviceRGB cs
+0.12156862745098039 0.23529411764705882 0.36470588235294116 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 727.64 Tm
+/F2 20 Tf
+[<4a616e6520446f65> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB cs
+0.12156862745098039 0.23529411764705882 0.36470588235294116 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 692.148 Tm
+/F2 14 Tf
+[<53756d6d6172> -10 <79> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.2901960784313726 0.3333333333333333 0.40784313725490196 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 660.924 Tm
+/F1 12 Tf
+[<9520> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 65.072 660.924 Tm
+/F1 12 Tf
+[<46697273742062> 20 <756c6c6574> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.12156862745098039 0.23529411764705882 0.36470588235294116 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 615.744 Tm
+/F2 14 Tf
+[<57> 60 <6f726b20457870657269656e6365> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 584.52 Tm
+/F1 12 Tf
+[<496e66> 30 <6f72> -25 <6d6174696f6e206e6f742070726f> 15 <7669646564> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.12156862745098039 0.23529411764705882 0.36470588235294116 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 539.34 Tm
+/F2 14 Tf
+[<456475636174696f6e> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 508.116 Tm
+/F1 12 Tf
+[<496e66> 30 <6f72> -25 <6d6174696f6e206e6f742070726f> 15 <7669646564> 0] TJ
+ET
+Q"
+`;
+
+exports[`generatePdf and parsing bullet list PDF spacing snapshot: fallback 1`] = `
+"Jane Doe
+Summary
+• First bullet
+Work Experience
+Information not provided
+Education
+Information not provided"
 `;

--- a/tests/boldHeadings.test.js
+++ b/tests/boldHeadings.test.js
@@ -17,7 +17,7 @@ function tokensToHtml(tokens) {
       if (t.style === 'italic') return `<em>${text}</em>`;
       if (t.type === 'newline') return '<br>';
       if (t.type === 'tab') return '<span class="tab"></span>';
-      if (t.type === 'bullet') return '<span class="bullet">•</span>';
+      if (t.type === 'bullet') return '<span class="bullet">•</span> ';
       return text;
     })
     .join('');


### PR DESCRIPTION
## Summary
- Ensure HTML bullets render with a trailing space for better spacing
- Add margin-right to bullet styles across resume templates
- Maintain spacing in PDFKit fallback after bullet glyphs and add snapshot tests for HTML & PDF bullet lists

## Testing
- `npm test tests/generatePdf.test.js -- -u`
- `npm test tests/boldHeadings.test.js -- -u`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4fe53b984832bbdc45a9c6f03e9f6