### PR TITLE
Add spaced education bullets and align template styling

### DIFF
--- a/server.js
+++ b/server.js
@@ -1060,7 +1060,7 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
             if (t.type === 'tab') return '<span class="tab"></span>';
             if (t.type === 'bullet') {
               if (sec.heading === 'Education') {
-                return '<span class="edu-bullet">–</span>';
+                return '<span class="edu-bullet">–</span> ';
               }
               return '<span class="bullet">•</span> ';
             }

--- a/templates/2025.css
+++ b/templates/2025.css
@@ -72,7 +72,15 @@ li {
   font-weight: 400;
 }
 
-.bullet, .edu-bullet {
+.bullet {
+  display: inline-block;
+  width: 1.2em;
+  margin-left: -1.2em;
+  margin-right: 0.4em;
+  color: var(--bullet);
+}
+
+.edu-bullet {
   display: inline-block;
   width: 1.2em;
   margin-left: -1.2em;

--- a/templates/modern.html
+++ b/templates/modern.html
@@ -17,7 +17,14 @@
       line-height: 1.5;
       font-weight: 400;
     }
-    .bullet, .edu-bullet {
+    .bullet {
+      display: inline-block;
+      width: 1.2em;
+      margin-left: -1.2em;
+      margin-right: 0.4em;
+      color: #2a9d8f;
+    }
+    .edu-bullet {
       display: inline-block;
       width: 1.2em;
       margin-left: -1.2em;

--- a/templates/professional.html
+++ b/templates/professional.html
@@ -17,7 +17,14 @@
       line-height: 1.5;
       font-weight: 400;
     }
-    .bullet, .edu-bullet {
+    .bullet {
+      display: inline-block;
+      width: 1.2em;
+      margin-left: -1.2em;
+      margin-right: 0.4em;
+      color: #1d3557;
+    }
+    .edu-bullet {
       display: inline-block;
       width: 1.2em;
       margin-left: -1.2em;

--- a/templates/ucmo.html
+++ b/templates/ucmo.html
@@ -16,7 +16,14 @@
       line-height: 1.5;
       font-weight: 400;
     }
-    .bullet, .edu-bullet {
+    .bullet {
+      display: inline-block;
+      width: 1.2em;
+      margin-left: -1.2em;
+      margin-right: 0.4em;
+      color: #990000;
+    }
+    .edu-bullet {
       display: inline-block;
       width: 1.2em;
       margin-left: -1.2em;

--- a/templates/vibrant.html
+++ b/templates/vibrant.html
@@ -17,7 +17,14 @@
       line-height:1.5;
       font-weight: 400;
     }
-    .bullet, .edu-bullet {
+    .bullet {
+      display: inline-block;
+      width: 1.2em;
+      margin-left: -1.2em;
+      margin-right: 0.4em;
+      color: #4ecdc4;
+    }
+    .edu-bullet {
       display: inline-block;
       width: 1.2em;
       margin-left: -1.2em;

--- a/tests/__snapshots__/boldHeadings.test.js.snap
+++ b/tests/__snapshots__/boldHeadings.test.js.snap
@@ -20,7 +20,14 @@ exports[`all headings including Skills are bold in HTML and PDF outputs: html 1`
       line-height: 1.5;
       font-weight: 400;
     }
-    .bullet, .edu-bullet {
+    .bullet {
+      display: inline-block;
+      width: 1.2em;
+      margin-left: -1.2em;
+      margin-right: 0.4em;
+      color: #2a9d8f;
+    }
+    .edu-bullet {
       display: inline-block;
       width: 1.2em;
       margin-left: -1.2em;

--- a/tests/__snapshots__/generatePdf.test.js.snap
+++ b/tests/__snapshots__/generatePdf.test.js.snap
@@ -82,7 +82,15 @@ li {
   font-weight: 400;
 }
 
-.bullet, .edu-bullet {
+.bullet {
+  display: inline-block;
+  width: 1.2em;
+  margin-left: -1.2em;
+  margin-right: 0.4em;
+  color: var(--bullet);
+}
+
+.edu-bullet {
   display: inline-block;
   width: 1.2em;
   margin-left: -1.2em;
@@ -233,4 +241,132 @@ Work Experience
 Information not provided
 Education
 Information not provided"
+`;
+
+exports[`generatePdf and parsing education bullet PDF spacing snapshot: browser 1`] = `
+"1 0 0 -1 0 792 cm
+/DeviceRGB cs
+0.12156862745098039 0.23529411764705882 0.36470588235294116 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 727.64 Tm
+/F2 20 Tf
+[<4a616e6520446f65> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB cs
+0.12156862745098039 0.23529411764705882 0.36470588235294116 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 692.148 Tm
+/F2 14 Tf
+[<456475636174696f6e> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.2901960784313726 0.3333333333333333 0.40784313725490196 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 660.924 Tm
+/F1 12 Tf
+[<9620> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 70.016 660.924 Tm
+/F1 12 Tf
+[<42616368656c6f72206f6620536369656e6365> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.12156862745098039 0.23529411764705882 0.36470588235294116 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 615.744 Tm
+/F2 14 Tf
+[<57> 60 <6f726b20457870657269656e6365> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 584.52 Tm
+/F1 12 Tf
+[<496e66> 30 <6f72> -25 <6d6174696f6e206e6f742070726f> 15 <7669646564> 0] TJ
+ET
+Q"
+`;
+
+exports[`generatePdf and parsing education bullet PDF spacing snapshot: fallback 1`] = `
+"1 0 0 -1 0 792 cm
+/DeviceRGB cs
+0.12156862745098039 0.23529411764705882 0.36470588235294116 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 727.64 Tm
+/F2 20 Tf
+[<4a616e6520446f65> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB cs
+0.12156862745098039 0.23529411764705882 0.36470588235294116 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 692.148 Tm
+/F2 14 Tf
+[<456475636174696f6e> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.2901960784313726 0.3333333333333333 0.40784313725490196 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 660.924 Tm
+/F1 12 Tf
+[<9620> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 70.016 660.924 Tm
+/F1 12 Tf
+[<42616368656c6f72206f6620536369656e6365> 0] TJ
+ET
+Q
+/DeviceRGB cs
+0.12156862745098039 0.23529411764705882 0.36470588235294116 scn
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 615.744 Tm
+/F2 14 Tf
+[<57> 60 <6f726b20457870657269656e6365> 0] TJ
+ET
+Q
+q
+1 0 0 -1 0 792 cm
+BT
+1 0 0 1 50 584.52 Tm
+/F1 12 Tf
+[<496e66> 30 <6f72> -25 <6d6174696f6e206e6f742070726f> 15 <7669646564> 0] TJ
+ET
+Q"
 `;

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -254,17 +254,52 @@ describe('generatePdf and parsing', () => {
     expect(rendered).not.toMatch(/[-–]/);
   });
 
-  test('education section uses alternate bullet glyph', () => {
+  test('education section uses alternate bullet glyph with spacing', () => {
     const input = 'Jane Doe\n# Education\n- Bachelor of Science';
     const data = parseContent(input);
     const edu = data.sections.find((s) => s.heading === 'Education');
     const rendered = edu.items[0]
       .map((t) => {
-        if (t.type === 'bullet') return '<span class="edu-bullet">–</span>';
+        if (t.type === 'bullet') return '<span class="edu-bullet">–</span> ';
         return t.text || '';
       })
       .join('');
-    expect(rendered).toBe('<span class="edu-bullet">–</span>Bachelor of Science');
+    expect(rendered).toBe('<span class="edu-bullet">–</span> Bachelor of Science');
+  });
+
+  test('education bullet PDF spacing snapshot', async () => {
+    const input = 'Jane Doe\n# Education\n- Bachelor of Science';
+    const browserPdf = await generatePdf(input, 'modern');
+    const launchSpy = jest
+      .spyOn(puppeteer, 'launch')
+      .mockRejectedValue(new Error('no browser'));
+    const fallbackPdf = await generatePdf(input, 'modern');
+    launchSpy.mockRestore();
+    const extractText = async (pdf) => {
+      try {
+        return (await pdfParse(pdf)).text.trim();
+      } catch {
+        let idx = 0;
+        let text = '';
+        while ((idx = pdf.indexOf(Buffer.from('stream'), idx)) !== -1) {
+          const nl = pdf.indexOf('\n', idx) + 1;
+          const end = pdf.indexOf(Buffer.from('endstream'), nl);
+          let chunk = pdf.slice(nl, end);
+          try {
+            chunk = zlib.inflateSync(chunk).toString();
+          } catch {
+            chunk = chunk.toString();
+          }
+          text += chunk;
+          idx = end + 9;
+        }
+        return text.trim();
+      }
+    };
+    const browserText = await extractText(browserPdf);
+    const fallbackText = await extractText(fallbackPdf);
+    expect(browserText).toMatchSnapshot('browser');
+    expect(fallbackText).toMatchSnapshot('fallback');
   });
 
   test('single asterisk italic and bullet handling', () => {


### PR DESCRIPTION
## Summary
- ensure `generatePdf` emits spaced `edu-bullet` in Education sections
- style `.edu-bullet` in templates with same padding and color as standard bullets
- test Education bullets for correct spacing in HTML and PDF outputs

## Testing
- `npm test -- -u`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b50c014a74832bad05c78788e0f027