### PR TITLE
Improve certification extraction and cleanup

### DIFF
--- a/tests/ensureRequiredSections.test.js
+++ b/tests/ensureRequiredSections.test.js
@@ -121,4 +121,28 @@ describe('ensureRequiredSections certifications merging', () => {
     expect(certSection.items).toHaveLength(1);
     expect(certSection.items[0][0].type).toBe('bullet');
   });
+
+  test('deduplicates existing certification entries', () => {
+    const data = {
+      sections: [
+        {
+          heading: 'Certification',
+          items: [
+            parseLine('AWS Certified Developer (Amazon) https://www.credly.com/badges/aws-dev'),
+            parseLine('AWS Certified Developer (Amazon) https://www.credly.com/badges/aws-dev')
+          ]
+        }
+      ]
+    };
+    const ensured = ensureRequiredSections(data, {});
+    const certSection = ensured.sections.find((s) => s.heading === 'Certification');
+    expect(certSection.items).toHaveLength(1);
+  });
+
+  test('removes certification section if no certificates remain', () => {
+    const data = { sections: [{ heading: 'Certification', items: [] }] };
+    const ensured = ensureRequiredSections(data, {});
+    const certSection = ensured.sections.find((s) => s.heading === 'Certification');
+    expect(certSection).toBeUndefined();
+  });
 });

--- a/tests/extractCertifications.test.js
+++ b/tests/extractCertifications.test.js
@@ -13,6 +13,18 @@ describe('extractCertifications', () => {
     ]);
   });
 
+  test('detects credly link outside certification section', () => {
+    const text = `- AWS Certified Developer (Amazon) https://www.credly.com/badges/abc`;
+    const certs = extractCertifications(text);
+    expect(certs).toEqual([
+      {
+        name: 'AWS Certified Developer',
+        provider: 'Amazon',
+        url: 'https://www.credly.com/badges/abc'
+      }
+    ]);
+  });
+
   test('parses LinkedIn style objects', () => {
     const src = [
       {


### PR DESCRIPTION
## Summary
- detect Credly URLs in resume text and LinkedIn data when extracting certifications
- de-duplicate certifications and drop the section when none remain
- test certification extraction and empty-section removal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b50ea09634832ba67a01aaf222a759