### PR TITLE
Expand experience section header recognition

### DIFF
--- a/server.js
+++ b/server.js
@@ -1334,7 +1334,7 @@ function extractExperience(source) {
   let current = null;
   for (const line of lines) {
     const trimmed = line.trim();
-    if (/^experience/i.test(trimmed)) {
+    if (/^(work|professional)?\s*experience/i.test(trimmed)) {
       inSection = true;
       continue;
     }

--- a/tests/extractExperience.test.js
+++ b/tests/extractExperience.test.js
@@ -30,6 +30,34 @@ describe('extractExperience', () => {
       }
     ]);
   });
+
+  test('handles "Work Experience" section header', () => {
+    const text =
+      'Work Experience\n- Developer at Beta Corp (Mar 2018 - Apr 2019)\n';
+    expect(extractExperience(text)).toEqual([
+      {
+        company: 'Beta Corp',
+        title: 'Developer',
+        startDate: 'Mar 2018',
+        endDate: 'Apr 2019',
+        responsibilities: []
+      }
+    ]);
+  });
+
+  test('handles "Professional Experience" section header', () => {
+    const text =
+      'Professional Experience\n- Developer at Beta Corp (Mar 2018 - Apr 2019)\n';
+    expect(extractExperience(text)).toEqual([
+      {
+        company: 'Beta Corp',
+        title: 'Developer',
+        startDate: 'Mar 2018',
+        endDate: 'Apr 2019',
+        responsibilities: []
+      }
+    ]);
+  });
 });
 
 describe('fetchLinkedInProfile', () => {


### PR DESCRIPTION
## Summary
- Broaden `extractExperience` to accept "Work" or "Professional" prefixes in experience section headers
- Add tests verifying extraction from "Work Experience" and "Professional Experience" sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b51cb739cc832b9070739392138837