### PR TITLE
Handle skills in more headings

### DIFF
--- a/server.js
+++ b/server.js
@@ -781,7 +781,7 @@ function isJobEntry(tokens = []) {
 
 function splitSkills(sections = []) {
   sections.forEach((sec) => {
-    if (normalizeHeading(sec.heading || '').toLowerCase() !== 'skills') return;
+    if (!((sec.heading || '').toLowerCase().includes('skill'))) return;
     const expanded = [];
     sec.items.forEach((tokens) => {
       const text = tokens

--- a/tests/splitSkills.test.js
+++ b/tests/splitSkills.test.js
@@ -1,23 +1,31 @@
 import { splitSkills, parseLine } from '../server.js';
 
 describe('splitSkills bullet handling', () => {
-  test('adds bullet to comma-separated skills', () => {
-    const sections = [{ heading: 'Skills', items: [parseLine('Python, Java')] }];
-    splitSkills(sections);
-    expect(sections[0].items).toHaveLength(2);
-    sections[0].items.forEach((tokens) => {
-      expect(tokens[0].type).toBe('bullet');
-    });
-  });
+  const headings = ['Skills', 'Technical Skills', 'Skills & Tools'];
 
-  test('adds bullet to newline-separated skills', () => {
-    const sections = [
-      { heading: 'Skills', items: [parseLine('Python'), parseLine('Java')] }
-    ];
-    splitSkills(sections);
-    expect(sections[0].items).toHaveLength(2);
-    sections[0].items.forEach((tokens) => {
-      expect(tokens[0].type).toBe('bullet');
-    });
-  });
+  test.each(headings)(
+    'adds bullet to comma-separated skills for heading %s',
+    (heading) => {
+      const sections = [{ heading, items: [parseLine('Python, Java')] }];
+      splitSkills(sections);
+      expect(sections[0].items).toHaveLength(2);
+      sections[0].items.forEach((tokens) => {
+        expect(tokens[0].type).toBe('bullet');
+      });
+    }
+  );
+
+  test.each(headings)(
+    'adds bullet to newline-separated skills for heading %s',
+    (heading) => {
+      const sections = [
+        { heading, items: [parseLine('Python'), parseLine('Java')] }
+      ];
+      splitSkills(sections);
+      expect(sections[0].items).toHaveLength(2);
+      sections[0].items.forEach((tokens) => {
+        expect(tokens[0].type).toBe('bullet');
+      });
+    }
+  );
 });


### PR DESCRIPTION
## Summary
- Expand splitSkills to process any section whose heading includes "skill" (e.g., Technical Skills, Skills & Tools)
- Test splitSkills across multiple headings to ensure bullets added for comma- and newline-separated skills

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b51fc2ddd4832ba579b179a57ad8ee