### PR TITLE
Remove empty certification section

### DIFF
--- a/server.js
+++ b/server.js
@@ -744,7 +744,8 @@ function ensureRequiredSections(
       ...existing.map((e) => e.tokens),
       ...certAdditions.map((c) => c.tokens),
     ];
-    if (!certSection.items.length) {
+
+    if (certSection.items.length === 0) {
       data.sections = data.sections.filter((s) => s !== certSection);
     }
   }

--- a/tests/extractCertifications.test.js
+++ b/tests/extractCertifications.test.js
@@ -1,4 +1,4 @@
-import { extractCertifications } from '../server.js';
+import { extractCertifications, ensureRequiredSections } from '../server.js';
 
 describe('extractCertifications', () => {
   test('parses certification line with provider and credly link', () => {
@@ -51,5 +51,19 @@ describe('extractCertifications', () => {
         url: 'https://www.credly.com/cka'
       }
     ]);
+  });
+
+  test('omits certification heading when no certifications are present', () => {
+    const text = `No credentials listed here.`;
+    const certs = extractCertifications(text);
+    expect(certs).toEqual([]);
+    const ensured = ensureRequiredSections(
+      { sections: [{ heading: 'Certification', items: [] }] },
+      { resumeCertifications: certs }
+    );
+    const certSection = ensured.sections.find(
+      (s) => s.heading === 'Certification'
+    );
+    expect(certSection).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Skip Certification section in output when no certification entries remain
- Add regression test covering absence of Certification heading when no certs found

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52062c0c0832b8d4b98f578052380