### PR TITLE
Handle multi-role experience sections

### DIFF
--- a/server.js
+++ b/server.js
@@ -1331,12 +1331,15 @@ function extractExperience(source) {
       inSection = true;
       continue;
     }
-    if (inSection && /^\s*$/.test(trimmed)) {
-      inSection = false;
-      current = null;
-      continue;
-    }
     if (inSection) {
+      if (/^(education|skills|projects|certifications|summary|objective|awards|interests|languages)/i.test(trimmed)) {
+        inSection = false;
+        current = null;
+        continue;
+      }
+      if (/^\s*$/.test(trimmed)) {
+        continue;
+      }
       const jobMatch = line.match(/^[-*]\s+(.*)/);
       if (jobMatch) {
         current = parseEntry(jobMatch[1].trim());

--- a/tests/extractExperience.test.js
+++ b/tests/extractExperience.test.js
@@ -58,6 +58,35 @@ describe('extractExperience', () => {
       }
     ]);
   });
+
+  test('retains multiple roles and responsibilities within the section', () => {
+    const text =
+      'Experience\n' +
+      '- Developer at Beta Corp (Mar 2018 - Apr 2019)\n' +
+      '  - Built API\n\n' +
+      '  - Improved UX\n\n' +
+      '- Manager at Gamma LLC (May 2019 - Jun 2020)\n' +
+      '  - Led team\n' +
+      '  - Managed budget\n' +
+      'Education\n' +
+      '- BSc Computer Science\n';
+    expect(extractExperience(text)).toEqual([
+      {
+        company: 'Beta Corp',
+        title: 'Developer',
+        startDate: 'Mar 2018',
+        endDate: 'Apr 2019',
+        responsibilities: ['Built API', 'Improved UX']
+      },
+      {
+        company: 'Gamma LLC',
+        title: 'Manager',
+        startDate: 'May 2019',
+        endDate: 'Jun 2020',
+        responsibilities: ['Led team', 'Managed budget']
+      }
+    ]);
+  });
 });
 
 describe('fetchLinkedInProfile', () => {


### PR DESCRIPTION
## Summary
- Update `extractExperience` to continue through blank lines and stop only at new section headings
- Keep responsibilities attached to their corresponding roles
- Add test to verify multiple experience entries are retained

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b529a553a0832ba5922a904c7b7b39