### PR TITLE
Prune bullet-only items and skip empty duplicate sections

### DIFF
--- a/server.js
+++ b/server.js
@@ -874,13 +874,15 @@ function mergeDuplicateSections(sections = []) {
       result.push(copy);
     }
   });
-  return result;
+  return result.filter((sec) => (sec.items || []).length > 0);
 }
 
 function pruneEmptySections(sections = []) {
+  const hasVisibleText = (t) =>
+    typeof t.text === 'string' && /[^\s\u2022·\-–—]/.test(t.text);
   return sections.filter((sec) => {
     sec.items = (sec.items || []).filter((tokens) =>
-      tokens.some((t) => t.text && t.text.trim())
+      tokens.some(hasVisibleText)
     );
     return sec.items.length > 0;
   });

--- a/tests/parseContent.test.js
+++ b/tests/parseContent.test.js
@@ -333,6 +333,25 @@ describe('parseContent duplicate section merging', () => {
     );
     expect(items).toEqual(['B.S. in CS']);
   });
+
+  test('merges education sections when the first has only a bullet', () => {
+    const input = [
+      'Jane Doe',
+      '# Education',
+      '- ',
+      '# Education',
+      '- B.S. in CS'
+    ].join('\n');
+    const data = parseContent(input, { skipRequiredSections: true });
+    const educationSections = data.sections.filter(
+      (s) => s.heading.toLowerCase() === 'education'
+    );
+    expect(educationSections).toHaveLength(1);
+    const items = educationSections[0].items.map((tokens) =>
+      tokens.filter((t) => t.text).map((t) => t.text).join('')
+    );
+    expect(items).toEqual(['B.S. in CS']);
+  });
 });
 
 describe('parseContent certification normalization and pruning', () => {


### PR DESCRIPTION
## Summary
- Avoid retaining duplicate sections whose items become empty after merging
- Prune list entries that lack any visible text, such as bullet-only lines
- Add regression test ensuring duplicate Education sections collapse into one

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52a7edf28832b89babb74214ca3e8