### PR TITLE
Use hyphen for education bullets

### DIFF
--- a/server.js
+++ b/server.js
@@ -1070,7 +1070,7 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
             if (t.type === 'tab') return '<span class="tab"></span>';
             if (t.type === 'bullet') {
               if (sec.heading.toLowerCase() === 'education') {
-                return '<span class="edu-bullet">–</span> ';
+                return '<span class="edu-bullet">-</span> ';
               }
               return '<span class="bullet">•</span> ';
             }
@@ -1102,7 +1102,7 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
         italic: 'Helvetica-Oblique',
         headingColor: '#1f3c5d',
         bullet: '•',
-        eduBullet: '–',
+        eduBullet: '-',
         bulletColor: '#4a5568',
         textColor: '#333',
         lineGap: 6,
@@ -1114,7 +1114,7 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
         italic: 'Helvetica-Oblique',
         headingColor: '#1f3c5d',
         bullet: '•',
-        eduBullet: '–',
+        eduBullet: '-',
         bulletColor: '#4a5568',
         textColor: '#333',
         lineGap: 6,
@@ -1126,7 +1126,7 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
         italic: 'Times-Italic',
         headingColor: '#1f3c5d',
         bullet: '•',
-        eduBullet: '–',
+        eduBullet: '-',
         bulletColor: '#4a5568',
         textColor: '#333',
         lineGap: 6,
@@ -1138,7 +1138,7 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
         italic: 'Helvetica-Oblique',
         headingColor: '#1f3c5d',
         bullet: '•',
-        eduBullet: '–',
+        eduBullet: '-',
         bulletColor: '#4a5568',
         textColor: '#333',
         lineGap: 6,
@@ -1150,7 +1150,7 @@ let generatePdf = async function (text, templateId = 'modern', options = {}) {
         italic: 'Helvetica-Oblique',
         headingColor: '#1f3c5d',
         bullet: '•',
-        eduBullet: '–',
+        eduBullet: '-',
         bulletColor: '#4a5568',
         textColor: '#333',
         lineGap: 6,

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -263,25 +263,25 @@ describe('generatePdf and parsing', () => {
       .map((t) => {
         if (t.type === 'bullet') {
           if (edu.heading.toLowerCase() === 'education') {
-            return '<span class="edu-bullet">–</span> ';
+            return '<span class="edu-bullet">-</span> ';
           }
           return '<span class="bullet">•</span> ';
         }
         return t.text || '';
       })
       .join('');
-    expect(rendered).toBe('<span class="edu-bullet">–</span> Bachelor of Science');
+    expect(rendered).toBe('<span class="edu-bullet">-</span> Bachelor of Science');
   });
 
-  test('PDFKit fallback uses en dash for EDUCATION heading', () => {
+  test('PDFKit fallback uses hyphen for EDUCATION heading', () => {
     const sec = {
       heading: 'EDUCATION',
       items: [[{ type: 'bullet' }, { text: 'Bachelor of Science' }]]
     };
-    const style = { bullet: '•', eduBullet: '–' };
+    const style = { bullet: '•', eduBullet: '-' };
     const glyph =
       sec.heading.toLowerCase() === 'education' ? style.eduBullet : style.bullet;
-    expect(glyph).toBe('–');
+    expect(glyph).toBe('-');
   });
 
   test('single asterisk italic and bullet handling', () => {


### PR DESCRIPTION
## Summary
- show hyphen for education section bullets in HTML output
- update PDFKit style map to use hyphen for `eduBullet`
- adjust tests for updated glyph

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52bbf38ec832b97fb2842fa2be7d1