### PR TITLE
Handle LinkedIn certifications

### DIFF
--- a/tests/fetchLinkedInCertifications.test.js
+++ b/tests/fetchLinkedInCertifications.test.js
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+
+const mockGet = jest.fn();
+
+jest.unstable_mockModule('axios', () => ({ default: { get: mockGet } }));
+
+const { fetchLinkedInProfile, ensureRequiredSections } = await import('../server.js');
+
+describe('fetchLinkedInProfile certifications', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  test('includes certifications when present', async () => {
+    const html = `
+      <section id="licenses_and_certifications">
+        <li>
+          <h3>AWS Certified Developer</h3>
+          <h4>Amazon</h4>
+          <a href="https://credly.com/aws-dev">Link</a>
+        </li>
+      </section>
+    `;
+    mockGet.mockResolvedValueOnce({ data: html });
+    const profile = await fetchLinkedInProfile('http://example.com');
+    expect(profile.certifications).toEqual([
+      {
+        name: 'AWS Certified Developer',
+        provider: 'Amazon',
+        url: 'https://credly.com/aws-dev'
+      }
+    ]);
+    const ensured = ensureRequiredSections(
+      { sections: [] },
+      { linkedinCertifications: profile.certifications }
+    );
+    const certSection = ensured.sections.find(
+      (s) => s.heading === 'Certification'
+    );
+    expect(certSection).toBeTruthy();
+    expect(certSection.items).toHaveLength(1);
+  });
+
+  test('omits certification section when no valid data', async () => {
+    const html = `
+      <section id="licenses_and_certifications">
+        <li><a href="https://credly.com/aws-dev">https://credly.com/aws-dev</a></li>
+      </section>
+    `;
+    mockGet.mockResolvedValueOnce({ data: html });
+    const profile = await fetchLinkedInProfile('http://example.com');
+    expect(profile.certifications).toEqual([
+      { name: '', provider: '', url: 'https://credly.com/aws-dev' }
+    ]);
+    const ensured = ensureRequiredSections(
+      { sections: [] },
+      { linkedinCertifications: profile.certifications }
+    );
+    const certSection = ensured.sections.find(
+      (s) => s.heading === 'Certification'
+    );
+    expect(certSection).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- parse LinkedIn `licenses_and_certifications` section and expose `certifications`
- drop certification tokens without name or provider during section merge
- test LinkedIn profiles with and without certifications

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b52c86ac0c832b8a6cbab2beded8aa