### PR TITLE
Ensure ucmo template is always included

### DIFF
--- a/server.js
+++ b/server.js
@@ -113,13 +113,34 @@ function selectTemplates({
     if (!coverTemplate1 && clTemplates[0]) coverTemplate1 = clTemplates[0];
     if (!coverTemplate2 && clTemplates[1]) coverTemplate2 = clTemplates[1];
   }
-  // Always start with the classic "ucmo" template when none is specified
-  template1 = template1 || 'ucmo';
-  if (!template2 || CV_TEMPLATE_GROUPS[template1] === CV_TEMPLATE_GROUPS[template2]) {
-    const pair = CONTRASTING_PAIRS.find((p) => p.includes(template1));
-    if (pair) {
-      template2 = pair.find((t) => t !== template1);
+  // Ensure one of the templates is always "ucmo"
+  if (!template1 && !template2) {
+    template1 = 'ucmo';
+  } else if (template1 !== 'ucmo' && template2 !== 'ucmo') {
+    if (template1) {
+      template2 = 'ucmo';
+    } else {
+      template1 = 'ucmo';
     }
+  }
+  // Ensure the non-ucmo template contrasts with "ucmo"
+  if (template1 === 'ucmo') {
+    if (!template2 || template2 === 'ucmo') {
+      const pair = CONTRASTING_PAIRS.find((p) => p.includes('ucmo'));
+      template2 = pair ? pair.find((t) => t !== 'ucmo') : CV_TEMPLATES.find((t) => t !== 'ucmo');
+    }
+  } else if (template2 === 'ucmo') {
+    if (!template1 || template1 === 'ucmo') {
+      const pair = CONTRASTING_PAIRS.find((p) => p.includes('ucmo'));
+      template1 = pair ? pair.find((t) => t !== 'ucmo') : CV_TEMPLATES.find((t) => t !== 'ucmo');
+    }
+  } else if (
+    !template2 ||
+    template1 === template2 ||
+    CV_TEMPLATE_GROUPS[template1] === CV_TEMPLATE_GROUPS[template2]
+  ) {
+    const pair = CONTRASTING_PAIRS.find((p) => p.includes(template1));
+    if (pair) template2 = pair.find((t) => t !== template1);
   }
   if (
     !template2 ||

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -114,16 +114,18 @@ describe('generatePdf and parsing', () => {
     expect(CL_TEMPLATES).toContain(coverTemplate2);
   });
 
-  test('mismatched defaults yield contrasting templates', () => {
+  test('providing one template still includes ucmo', () => {
     const { template1, template2, coverTemplate1, coverTemplate2 } = selectTemplates({
       template1: CV_TEMPLATES[0],
       coverTemplate1: CL_TEMPLATES[0]
     });
-    expect(template1).toBe(CV_TEMPLATES[0]);
-    const pair = CONTRASTING_PAIRS.find((p) => p.includes(template1));
-    expect(template2).toBe(pair.find((t) => t !== template1));
+    expect([template1, template2]).toContain('ucmo');
+    const other = template1 === 'ucmo' ? template2 : template1;
+    expect(other).toBe(CV_TEMPLATES[0]);
+    expect(CV_TEMPLATE_GROUPS[other]).not.toBe(CV_TEMPLATE_GROUPS['ucmo']);
     expect(coverTemplate1).toBe(CL_TEMPLATES[0]);
     expect(coverTemplate2).not.toBe(coverTemplate1);
+    expect(CV_TEMPLATES).toContain(template1);
     expect(CV_TEMPLATES).toContain(template2);
     expect(CL_TEMPLATES).toContain(coverTemplate2);
   });

--- a/tests/selectTemplatesGroup.test.js
+++ b/tests/selectTemplatesGroup.test.js
@@ -1,17 +1,22 @@
 import { selectTemplates, CV_TEMPLATES, CV_TEMPLATE_GROUPS } from '../server.js';
 
-describe('selectTemplates group enforcement', () => {
-  test.each(CV_TEMPLATES)('replaces second template when both are %s', (tpl) => {
+describe('selectTemplates enforces ucmo presence', () => {
+  test.each(CV_TEMPLATES)('includes ucmo when both templates are %s', (tpl) => {
     const { template1, template2 } = selectTemplates({ template1: tpl, template2: tpl });
-    expect(template1).toBe(tpl);
-    expect(template2).not.toBe(tpl);
-    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(CV_TEMPLATE_GROUPS[template2]);
+    expect([template1, template2]).toContain('ucmo');
+    const other = template1 === 'ucmo' ? template2 : template1;
+    expect(other).not.toBe('ucmo');
+    expect(CV_TEMPLATE_GROUPS[other]).not.toBe(CV_TEMPLATE_GROUPS['ucmo']);
   });
 
-  test('defaults template1 to ucmo and contrasts with provided template2', () => {
-    const { template1, template2 } = selectTemplates({ template2: 'ucmo' });
-    expect(template1).toBe('ucmo');
-    expect(template2).not.toBe('ucmo');
-    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(CV_TEMPLATE_GROUPS[template2]);
+  test('overrides when neither input is ucmo', () => {
+    const { template1, template2 } = selectTemplates({
+      template1: 'modern',
+      template2: 'professional'
+    });
+    expect([template1, template2]).toContain('ucmo');
+    const other = template1 === 'ucmo' ? template2 : template1;
+    expect(other).not.toBe('ucmo');
+    expect(CV_TEMPLATE_GROUPS[other]).not.toBe(CV_TEMPLATE_GROUPS['ucmo']);
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -281,7 +281,7 @@ describe('/api/process-cv', () => {
     ]);
   });
 
-  test('uses template1 and template2', async () => {
+  test('uses provided template and ucmo', async () => {
     generateContentMock.mockReset();
     generateContentMock
       .mockResolvedValueOnce({
@@ -303,7 +303,7 @@ describe('/api/process-cv', () => {
     const calls = serverModule.generatePdf.mock.calls;
     const resumeCalls = calls.filter(([, , opts]) => opts && opts.resumeExperience);
     expect(resumeCalls[0][1]).toBe('modern');
-    expect(resumeCalls[1][1]).toBe('professional');
+    expect(resumeCalls[1][1]).toBe('ucmo');
   });
 
   test('uses templates array', async () => {


### PR DESCRIPTION
## Summary
- Force `selectTemplates` to always include `ucmo`, replacing user selections when necessary and choosing a contrasting template for the other slot
- Update unit tests to verify `ucmo` is always present with a template from a different group

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52da8f7d4832b83530ab4f9a205fb