### PR TITLE
Improve job description skill extraction

### DIFF
--- a/server.js
+++ b/server.js
@@ -323,12 +323,25 @@ function analyzeJobDescription(html) {
 
   const lower = text.toLowerCase();
   const skills = [];
+  const termCounts = [];
   for (const term of TECHNICAL_TERMS) {
     const regex = new RegExp(`\\b${term}\\b`, 'g');
     const matches = lower.match(regex);
-    if (matches && matches.length > 1) {
-      skills.push(term.replace(/\\+\\+/g, '++'));
+    const count = matches ? matches.length : 0;
+    const normalized = term.replace(/\\+\\+/g, '++');
+    if (count > 0) {
+      skills.push(normalized);
     }
+    termCounts.push({ term: normalized, count });
+  }
+
+  if (skills.length < 5) {
+    const remaining = termCounts
+      .filter(({ term }) => !skills.includes(term))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5 - skills.length)
+      .map(({ term }) => term);
+    skills.push(...remaining);
   }
 
   return { title, skills, text };
@@ -2068,6 +2081,7 @@ export {
   splitSkills,
   fetchLinkedInProfile,
   mergeResumeWithLinkedIn,
+  analyzeJobDescription,
   extractResumeSkills,
   calculateMatchScore,
   TEMPLATE_IDS,

--- a/tests/analyzeJobDescription.test.js
+++ b/tests/analyzeJobDescription.test.js
@@ -1,0 +1,16 @@
+import { analyzeJobDescription } from '../server.js';
+
+describe('analyzeJobDescription', () => {
+  test('includes skills that appear once', () => {
+    const html = '<p>Proficiency in JavaScript is required.</p>';
+    const { skills } = analyzeJobDescription(html);
+    expect(skills).toContain('javascript');
+  });
+
+  test('pads skills list to five items', () => {
+    const html = '<p>JavaScript and Python are needed.</p>';
+    const { skills } = analyzeJobDescription(html);
+    expect(skills.slice(0, 2)).toEqual(['javascript', 'python']);
+    expect(skills).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## Summary
- capture single-occurrence technical terms when analyzing job descriptions
- pad extracted skills to at least five items based on term frequency
- add unit tests for single-match extraction and padding behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b533439960832bb2169b8b0f216c71