### PR TITLE
Reparse sanitized text and guard against empty sections

### DIFF
--- a/server.js
+++ b/server.js
@@ -1620,7 +1620,18 @@ function sanitizeGeneratedText(text, options = {}) {
   if (!text) return text;
   const cleaned = removeGuidanceLines(text);
   if (options.defaultHeading === '') return cleaned;
-  return reparseAndStringify(cleaned, options);
+  const reparsed = reparseAndStringify(cleaned, options);
+  const data = parseContent(reparsed, { ...options, skipRequiredSections: true });
+  const merged = mergeDuplicateSections(data.sections);
+  const pruned = pruneEmptySections(merged);
+  const lines = [data.name];
+  pruned.forEach((sec) => {
+    lines.push(`# ${sec.heading}`);
+    sec.items.forEach((tokens) => {
+      lines.push(tokens.map((t) => t.text || '').join(''));
+    });
+  });
+  return lines.join('\n');
 }
 
 function relocateProfileLinks(text) {


### PR DESCRIPTION
## Summary
- Reparse generated text in `sanitizeGeneratedText` to merge duplicate sections and prune empties
- Test that empty certification headings are removed and duplicate education sections merge
- Ensure `ensureRequiredSections` does not reintroduce empty sections post-sanitization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b537342c78832ba2c1cbfdaaf96e38