### PR TITLE
Handle bare resume headings and add tests

### DIFF
--- a/server.js
+++ b/server.js
@@ -1034,11 +1034,12 @@ function parseContent(text, options = {}) {
     let current = [];
     for (const raw of lines) {
       const line = raw.replace(/\t/g, '\u0009');
-      if (!line.trim()) {
+      const trimmed = line.trim();
+      if (!trimmed) {
         if (current.length) current.push({ type: 'newline' });
         continue;
       }
-      const headingMatch = line.trim().match(/^#{1,6}\s+(.*)/);
+      const headingMatch = trimmed.match(/^#{1,6}\s+(.*)/);
       if (headingMatch) {
         if (current.length) {
           currentSection.items.push(current);
@@ -1052,6 +1053,25 @@ function parseContent(text, options = {}) {
         }
         currentSection = { heading: headingMatch[1].trim(), items: [] };
         sections.push(currentSection);
+        continue;
+      }
+      const plainHeadingMatch = trimmed.match(
+        /^((?:work|professional)\s*experience|education|skills|projects|certification|summary)$/i
+      );
+      if (plainHeadingMatch) {
+        if (current.length) currentSection.items.push(current);
+        if (
+          currentSection.items.length === 0 &&
+          currentSection.heading === defaultHeading
+        ) {
+          sections.pop();
+        }
+        currentSection = {
+          heading: normalizeHeading(plainHeadingMatch[0]),
+          items: []
+        };
+        sections.push(currentSection);
+        current = [];
         continue;
       }
       const bulletMatch = line.match(/^[\-*–]\s+/);

--- a/tests/parseContent.test.js
+++ b/tests/parseContent.test.js
@@ -125,6 +125,24 @@ describe('parseContent skills list handling', () => {
   });
 });
 
+describe('parseContent bare heading detection', () => {
+  test('creates sections for common headings without hashes and avoids summary', () => {
+    const input = [
+      'John Doe',
+      'Work Experience',
+      'Acme Corp | Developer | Jan 2020 - Present',
+      'Education',
+      'MIT',
+      'Skills',
+      'JavaScript, Python'
+    ].join('\n');
+    const data = parseContent(input);
+    const headings = data.sections.map((s) => s.heading);
+    expect(headings).toEqual(['Work Experience', 'Education', 'Skills']);
+    expect(data.sections.find((s) => s.heading === 'Summary')).toBeUndefined();
+  });
+});
+
 describe('parseContent experience fallbacks', () => {
   test('uses resume experience when AI output lacks it', () => {
     const data = parseContent('Jane Doe\n# Skills\n- JS', {


### PR DESCRIPTION
## Summary
- detect common headings like Work Experience and Skills even without markdown hashes
- start new sections for these bare headings and reset the running buffer
- add unit test ensuring unprefixed headings create sections and avoid populating Summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b54a744be8832b87eb306cd61fdd1c