### PR TITLE
Handle multi-role experience sections

### DIFF
--- a/server.js
+++ b/server.js
@@ -1409,7 +1409,7 @@ function extractExperience(source) {
     let endDate = '';
     const dateMatch = text.match(/\(([^)]+)\)/);
     if (dateMatch) {
-      const parts = dateMatch[1].split(/[-–to]+/);
+      const parts = dateMatch[1].split(/\s*[-–]\s*/);
       startDate = parts[0]?.trim() || '';
       endDate = parts[1]?.trim() || '';
       text = text.replace(dateMatch[0], '').trim();
@@ -1436,25 +1436,23 @@ function extractExperience(source) {
       inSection = true;
       continue;
     }
-    if (inSection) {
-      if (/^(education|skills|projects|certifications|summary|objective|awards|interests|languages)/i.test(trimmed)) {
-        inSection = false;
-        current = null;
-        continue;
-      }
-      if (/^\s*$/.test(trimmed)) {
-        continue;
-      }
-      const jobMatch = line.match(/^[-*]\s+(.*)/);
-      if (jobMatch) {
-        current = parseEntry(jobMatch[1].trim());
-        entries.push(current);
-        continue;
-      }
-      const respMatch = line.match(/^\s+[-*]\s+(.*)/);
-      if (current && respMatch) {
-        current.responsibilities.push(respMatch[1].trim());
-      }
+    if (!inSection) continue;
+    if (/^(education|skills|projects|certifications|summary|objective|awards|interests|languages)/i.test(trimmed)) {
+      break;
+    }
+    if (trimmed === '') {
+      continue;
+    }
+    const jobMatch = line.match(/^[-*]\s+(.*)/) || (!line.match(/^\s/) ? [null, trimmed] : null);
+    if (jobMatch) {
+      current = parseEntry(jobMatch[1].trim());
+      entries.push(current);
+      continue;
+    }
+    const respMatch = line.match(/^\s+[-*]\s+(.*)/) || line.match(/^\s+(.*)/);
+    if (current && respMatch) {
+      const resp = respMatch[1].trim();
+      if (resp) current.responsibilities.push(resp);
     }
   }
   return entries;

--- a/tests/extractExperience.test.js
+++ b/tests/extractExperience.test.js
@@ -87,6 +87,42 @@ describe('extractExperience', () => {
       }
     ]);
   });
+
+  test('captures roles separated by blank lines until next heading', () => {
+    const text =
+      'Experience\n' +
+      'Developer at Beta Corp (Mar 2018 - Apr 2019)\n' +
+      '  - Built API\n\n' +
+      'Manager at Gamma LLC (May 2019 - Jun 2020)\n' +
+      '  - Led team\n\n' +
+      'Analyst at Delta Inc (Jul 2020 - Present)\n' +
+      '  - Analyzed data\n' +
+      'Skills\n' +
+      '- JavaScript\n';
+    expect(extractExperience(text)).toEqual([
+      {
+        company: 'Beta Corp',
+        title: 'Developer',
+        startDate: 'Mar 2018',
+        endDate: 'Apr 2019',
+        responsibilities: ['Built API']
+      },
+      {
+        company: 'Gamma LLC',
+        title: 'Manager',
+        startDate: 'May 2019',
+        endDate: 'Jun 2020',
+        responsibilities: ['Led team']
+      },
+      {
+        company: 'Delta Inc',
+        title: 'Analyst',
+        startDate: 'Jul 2020',
+        endDate: 'Present',
+        responsibilities: ['Analyzed data']
+      }
+    ]);
+  });
 });
 
 describe('fetchLinkedInProfile', () => {


### PR DESCRIPTION
## Summary
- Allow experience parsing to span blank lines and stop only at new section headings
- Recognize non-bulleted role entries and keep indented bullet responsibilities with their role
- Extend experience extraction tests for multiple roles separated by blank lines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b54d462f18832b9343c73f6c60fa1c