### PR TITLE
Group and filter skills from job description

### DIFF
--- a/tests/splitSkills.test.js
+++ b/tests/splitSkills.test.js
@@ -29,3 +29,42 @@ describe('splitSkills bullet handling', () => {
     }
   );
 });
+
+describe('splitSkills filtering and grouping', () => {
+  test('only job relevant skills are kept', () => {
+    const sections = [
+      { heading: 'Skills', items: [parseLine('Python, Java, AWS, Oracle')] }
+    ];
+    splitSkills(sections, ['python', 'aws', 'oracle']);
+    const texts = sections[0].items.map((tokens) =>
+      tokens.filter((t) => t.text).map((t) => t.text).join('')
+    );
+    expect(texts.join(' ')).toMatch(/Python/);
+    expect(texts.join(' ')).toMatch(/AWS/);
+    expect(texts.join(' ')).toMatch(/Oracle/);
+    expect(texts.join(' ')).not.toMatch(/Java/);
+  });
+
+  test('limits to at most five bullets', () => {
+    const skills =
+      'Python, Java, AWS, Docker, Kubernetes, Terraform, React, Node, HTML, CSS';
+    const sections = [{ heading: 'Skills', items: [parseLine(skills)] }];
+    splitSkills(
+      sections,
+      skills.split(',').map((s) => s.trim().toLowerCase())
+    );
+    expect(sections[0].items.length).toBeLessThanOrEqual(5);
+  });
+
+  test('groups database related skills', () => {
+    const sections = [{ heading: 'Skills', items: [parseLine('MySQL, Oracle')] }];
+    splitSkills(sections, ['mysql', 'oracle']);
+    expect(sections[0].items).toHaveLength(1);
+    const text = sections[0].items[0]
+      .filter((t) => t.text)
+      .map((t) => t.text)
+      .join('')
+      .toLowerCase();
+    expect(text).toBe('database, mysql, oracle');
+  });
+});


### PR DESCRIPTION
## Summary
- Deduplicate and group resume skills, filtering against job description skills and limiting output to five bullet lines
- Pass jobSkills through parsing pipeline to preserve only relevant skills in generated PDFs
- Add tests validating filtering, grouping, and bullet limits for splitSkills

## Testing
- `npm test tests/splitSkills.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b551931e54832bb923115641555aa4