### PR TITLE
Remove responsibilities from experience entries

### DIFF
--- a/tests/extractExperience.test.js
+++ b/tests/extractExperience.test.js
@@ -17,7 +17,7 @@ jest.unstable_mockModule('axios', () => ({
 const { extractExperience, fetchLinkedInProfile } = await import('../server.js');
 
 describe('extractExperience', () => {
-  test('parses company, dates, and responsibilities from resume text', () => {
+  test('parses company and dates from resume text, ignoring responsibilities', () => {
     const text =
       'Experience\n- Developer at Beta Corp (Mar 2018 - Apr 2019)\n  - Built API\n';
     expect(extractExperience(text)).toEqual([
@@ -25,8 +25,7 @@ describe('extractExperience', () => {
         company: 'Beta Corp',
         title: 'Developer',
         startDate: 'Mar 2018',
-        endDate: 'Apr 2019',
-        responsibilities: ['Built API']
+        endDate: 'Apr 2019'
       }
     ]);
   });
@@ -39,8 +38,7 @@ describe('extractExperience', () => {
         company: 'Beta Corp',
         title: 'Developer',
         startDate: 'Mar 2018',
-        endDate: 'Apr 2019',
-        responsibilities: []
+        endDate: 'Apr 2019'
       }
     ]);
   });
@@ -53,13 +51,12 @@ describe('extractExperience', () => {
         company: 'Beta Corp',
         title: 'Developer',
         startDate: 'Mar 2018',
-        endDate: 'Apr 2019',
-        responsibilities: []
+        endDate: 'Apr 2019'
       }
     ]);
   });
 
-  test('retains multiple roles and responsibilities within the section', () => {
+  test('retains multiple roles within the section', () => {
     const text =
       'Experience\n' +
       '- Developer at Beta Corp (Mar 2018 - Apr 2019)\n' +
@@ -75,15 +72,13 @@ describe('extractExperience', () => {
         company: 'Beta Corp',
         title: 'Developer',
         startDate: 'Mar 2018',
-        endDate: 'Apr 2019',
-        responsibilities: ['Built API', 'Improved UX']
+        endDate: 'Apr 2019'
       },
       {
         company: 'Gamma LLC',
         title: 'Manager',
         startDate: 'May 2019',
-        endDate: 'Jun 2020',
-        responsibilities: ['Led team', 'Managed budget']
+        endDate: 'Jun 2020'
       }
     ]);
   });
@@ -104,22 +99,19 @@ describe('extractExperience', () => {
         company: 'Beta Corp',
         title: 'Developer',
         startDate: 'Mar 2018',
-        endDate: 'Apr 2019',
-        responsibilities: ['Built API']
+        endDate: 'Apr 2019'
       },
       {
         company: 'Gamma LLC',
         title: 'Manager',
         startDate: 'May 2019',
-        endDate: 'Jun 2020',
-        responsibilities: ['Led team']
+        endDate: 'Jun 2020'
       },
       {
         company: 'Delta Inc',
         title: 'Analyst',
         startDate: 'Jul 2020',
-        endDate: 'Present',
-        responsibilities: ['Analyzed data']
+        endDate: 'Present'
       }
     ]);
   });

--- a/tests/parseContent.test.js
+++ b/tests/parseContent.test.js
@@ -188,8 +188,12 @@ describe('parseContent experience fallbacks', () => {
     });
     const work = data.sections.find((s) => s.heading === 'Work Experience');
     expect(work.items).toHaveLength(2);
-    expect(work.items[0].map((t) => t.text).join('')).toBe('Senior Engineer at Acme (Jan 2020 – Feb 2021)');
-    expect(work.items[1].map((t) => t.text).join('')).toBe('Developer at Beta Corp (Mar 2018 – Apr 2019)Built things');
+    expect(work.items[0].map((t) => t.text).join('')).toBe(
+      'Senior Engineer at Acme (Jan 2020 – Feb 2021)'
+    );
+    expect(work.items[1].map((t) => t.text).join('')).toBe(
+      'Developer at Beta Corp (Mar 2018 – Apr 2019)'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Ensure work experience items only contain a bullet and job summary line
- Simplify experience extraction to omit responsibilities
- Adjust tests to reflect condensed experience format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b552fb332c832b9db13f956a2c4df7