### PR TITLE
feat: insert project summary into resumes

### DIFF
--- a/tests/sanitizeGeneratedText.test.js
+++ b/tests/sanitizeGeneratedText.test.js
@@ -14,7 +14,7 @@ describe('sanitizeGeneratedText', () => {
     ].join('\n');
 
     const output = sanitizeGeneratedText(input, { skipRequiredSections: true });
-    expect(output).toBe(['John Doe', '# Experience', 'Did things'].join('\n'));
+    expect(output).toBe(['John Doe', '# Experience', '- Did things'].join('\n'));
   });
 
   test('removes bracketed placeholders within cover letters', () => {
@@ -46,7 +46,7 @@ describe('sanitizeGeneratedText', () => {
 
     const output = sanitizeGeneratedText(input, { skipRequiredSections: true });
     expect(output).toBe(
-      ['John Doe', '# Education', 'High School', 'College'].join('\n')
+      ['John Doe', '# Education', '- High School', '- College'].join('\n')
     );
   });
 


### PR DESCRIPTION
## Summary
- derive a project summary from job description and skills
- ensure a Projects section with bullet is added to generated resumes
- test for project section creation and update sanitize tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b554387a38832bb0aa0cd7d7db47ee