### PR TITLE
Ensure ucmo template pairing and bold headings

### DIFF
--- a/server.js
+++ b/server.js
@@ -149,35 +149,35 @@ function selectTemplates({
     if (!coverTemplate1 && clTemplates[0]) coverTemplate1 = clTemplates[0];
     if (!coverTemplate2 && clTemplates[1]) coverTemplate2 = clTemplates[1];
   }
-  // Ensure one of the templates is always "ucmo"
-  if (!template1 && !template2) {
-    template1 = 'ucmo';
-  } else if (template1 !== 'ucmo' && template2 !== 'ucmo') {
-    if (template1) {
-      template2 = 'ucmo';
-    } else {
-      template1 = 'ucmo';
+  // Ensure one template is 'ucmo' and the other is from a different group
+  const pickNonUcmo = (tpl) => {
+    if (tpl && tpl !== 'ucmo' && CV_TEMPLATE_GROUPS[tpl] !== CV_TEMPLATE_GROUPS['ucmo']) {
+      return tpl;
     }
-  }
-  // Ensure the non-ucmo template contrasts with "ucmo"
+    const candidates = CV_TEMPLATES.filter(
+      (t) => t !== 'ucmo' && CV_TEMPLATE_GROUPS[t] !== CV_TEMPLATE_GROUPS['ucmo']
+    );
+    return candidates[Math.floor(Math.random() * candidates.length)] || CV_TEMPLATES.find((t) => t !== 'ucmo');
+  };
+
   if (template1 === 'ucmo') {
-    if (!template2 || template2 === 'ucmo') {
-      const pair = CONTRASTING_PAIRS.find((p) => p.includes('ucmo'));
-      template2 = pair ? pair.find((t) => t !== 'ucmo') : CV_TEMPLATES.find((t) => t !== 'ucmo');
-    }
+    template2 = pickNonUcmo(template2);
   } else if (template2 === 'ucmo') {
-    if (!template1 || template1 === 'ucmo') {
-      const pair = CONTRASTING_PAIRS.find((p) => p.includes('ucmo'));
-      template1 = pair ? pair.find((t) => t !== 'ucmo') : CV_TEMPLATES.find((t) => t !== 'ucmo');
-    }
-  } else if (
-    !template2 ||
-    template1 === template2 ||
-    CV_TEMPLATE_GROUPS[template1] === CV_TEMPLATE_GROUPS[template2]
-  ) {
-    const pair = CONTRASTING_PAIRS.find((p) => p.includes(template1));
-    if (pair) template2 = pair.find((t) => t !== template1);
+    template1 = pickNonUcmo(template1);
+  } else if (template1 && !template2) {
+    template1 = pickNonUcmo(template1);
+    template2 = 'ucmo';
+  } else if (!template1 && template2) {
+    template2 = pickNonUcmo(template2);
+    template1 = 'ucmo';
+  } else if (template1 && template2) {
+    template1 = pickNonUcmo(template1);
+    template2 = 'ucmo';
+  } else {
+    template1 = 'ucmo';
+    template2 = pickNonUcmo();
   }
+
   if (
     !template2 ||
     template1 === template2 ||

--- a/templates/2025.css
+++ b/templates/2025.css
@@ -22,22 +22,22 @@ header {
   justify-content: center;
 }
 
-h1 {
-  font-size: 2.8rem;
-  font-weight: bold;
-  margin: 0;
-  color: var(--accent);
-}
+  h1 {
+    font-size: 2.8rem;
+    font-weight: 700;
+    margin: 0;
+    color: var(--accent);
+  }
 
-h2 {
-  font-size: 1.5rem;
-  font-weight: bold;
-  margin-top: 2.5rem;
-  margin-bottom: 0.75rem;
-  color: var(--accent);
-  border-bottom: 2px solid var(--accent);
-  padding-bottom: 0.25rem;
-}
+  h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+    color: var(--accent);
+    border-bottom: 2px solid var(--accent);
+    padding-bottom: 0.25rem;
+  }
 
 main {
   display: grid;

--- a/templates/cover_classic.html
+++ b/templates/cover_classic.html
@@ -5,7 +5,7 @@
   <title>Cover Letter</title>
   <style>
     body { font-family: 'Times New Roman', serif; margin: 60px; color: #000; line-height: 1.4; }
-    h1 { text-align: center; font-size: 28px; margin-bottom: 24px; text-transform: uppercase; font-weight: bold; }
+      h1 { text-align: center; font-size: 28px; margin-bottom: 24px; text-transform: uppercase; font-weight: 700; }
     p { margin: 0 0 14px; }
   </style>
 </head>

--- a/templates/cover_modern.html
+++ b/templates/cover_modern.html
@@ -5,7 +5,7 @@
   <title>Cover Letter</title>
   <style>
     body { font-family: 'Segoe UI', Tahoma, sans-serif; margin: 40px; color: #333; line-height: 1.6; }
-    h1 { color: #2a9d8f; margin-bottom: 20px; font-size: 32px; font-weight: bold; }
+      h1 { color: #2a9d8f; margin-bottom: 20px; font-size: 32px; font-weight: 700; }
     p { margin: 0 0 12px; }
   </style>
 </head>

--- a/templates/modern.html
+++ b/templates/modern.html
@@ -6,8 +6,8 @@
   <style>
     body { font-family: 'Segoe UI', Tahoma, sans-serif; margin: 40px; color: #333; line-height: 1.5; }
     header { background: #2a9d8f; color: #fff; padding: 20px; margin-bottom: 20px; text-align: center; }
-    h1 { font-size: 32px; margin: 0 0 12px; }
-    h2 { font-size: 20px; margin: 24px 0 12px; border-bottom: 1px solid #2a9d8f; padding-bottom: 4px; font-weight: bold; }
+    h1 { font-size: 32px; margin: 0 0 12px; font-weight: 700; }
+    h2 { font-size: 20px; margin: 24px 0 12px; border-bottom: 1px solid #2a9d8f; padding-bottom: 4px; font-weight: 700; }
     section { margin-bottom: 16px; }
     ul { list-style: none; margin: 0; padding: 0; }
     li {
@@ -33,7 +33,7 @@
     }
     .tab { display:inline-block; width:1.5em; }
     .tab + p { margin-top: 0; }
-    strong { font-weight: bold; }
+    strong { font-weight: 700; }
   </style>
 </head>
 <body>

--- a/templates/professional.html
+++ b/templates/professional.html
@@ -6,8 +6,8 @@
   <style>
     body { font-family: 'Helvetica Neue', Arial, sans-serif; margin: 40px; color: #222; line-height: 1.5; }
     header { text-align: center; background: #1d3557; color: #fff; margin-bottom: 30px; padding: 20px 0; }
-    h1 { font-size: 36px; margin: 0 0 12px; }
-    h2 { font-size: 20px; color: #1d3557; margin: 30px 0 16px; border-bottom: 1px solid #1d3557; padding-bottom: 4px; font-weight: bold; }
+    h1 { font-size: 36px; margin: 0 0 12px; font-weight: 700; }
+    h2 { font-size: 20px; color: #1d3557; margin: 30px 0 16px; border-bottom: 1px solid #1d3557; padding-bottom: 4px; font-weight: 700; }
     section { margin-bottom: 16px; }
     ul { list-style: none; margin: 0; padding: 0; }
     li {
@@ -33,7 +33,7 @@
     }
     .tab { display:inline-block; width:1.5em; }
     .tab + p { margin-top: 0; }
-    strong { font-weight: bold; }
+    strong { font-weight: 700; }
   </style>
 </head>
 <body>

--- a/templates/ucmo.html
+++ b/templates/ucmo.html
@@ -6,8 +6,8 @@
   <style>
     body { font-family: 'Times New Roman', serif; margin: 50px; color: #222; line-height: 1.5; }
     header { text-align: center; background: #990000; color: #fff; padding: 20px 0; margin-bottom: 20px; }
-    h1 { font-size: 36px; margin: 0 0 12px; }
-    h2 { font-size: 18px; margin: 30px 0 12px; background: #f2f2f2; padding: 6px 10px; color: #990000; font-weight: bold; }
+    h1 { font-size: 36px; margin: 0 0 12px; font-weight: 700; }
+    h2 { font-size: 18px; margin: 30px 0 12px; background: #f2f2f2; padding: 6px 10px; color: #990000; font-weight: 700; }
     ul { list-style: none; padding-left: 0; margin: 0; }
     li {
       margin-bottom: 10px;
@@ -32,7 +32,7 @@
     }
     .tab { display:inline-block; width:1.5em; }
     .tab + p { margin-top: 0; }
-    strong { font-weight: bold; }
+    strong { font-weight: 700; }
   </style>
 </head>
 <body>

--- a/templates/vibrant.html
+++ b/templates/vibrant.html
@@ -6,8 +6,8 @@
   <style>
     body { font-family: 'Poppins', 'Segoe UI', sans-serif; margin: 40px; color: #333; line-height: 1.5; }
     header { background: #ff6b6b; color: #fff; padding: 20px; margin-bottom: 20px; text-align: center; }
-    h1 { font-size: 36px; margin: 0 0 12px; }
-    h2 { font-size: 20px; color: #ff6b6b; margin: 24px 0 12px; border-bottom: 2px solid #ff6b6b; padding-bottom: 4px; font-weight: bold; }
+    h1 { font-size: 36px; margin: 0 0 12px; font-weight: 700; }
+    h2 { font-size: 20px; color: #ff6b6b; margin: 24px 0 12px; border-bottom: 2px solid #ff6b6b; padding-bottom: 4px; font-weight: 700; }
     section { margin-bottom: 16px; }
     ul { list-style: none; margin: 0; padding: 0; }
     li {
@@ -33,7 +33,7 @@
     }
     .tab { display:inline-block; width:1.5em; }
     .tab + p { margin-top: 0; }
-    strong { font-weight: bold; }
+    strong { font-weight: 700; }
   </style>
 </head>
 <body>

--- a/tests/__snapshots__/boldHeadings.test.js.snap
+++ b/tests/__snapshots__/boldHeadings.test.js.snap
@@ -9,8 +9,8 @@ exports[`all headings including Skills are bold in HTML and PDF outputs: html 1`
   <style>
     body { font-family: 'Segoe UI', Tahoma, sans-serif; margin: 40px; color: #333; line-height: 1.5; }
     header { background: #2a9d8f; color: #fff; padding: 20px; margin-bottom: 20px; text-align: center; }
-    h1 { font-size: 32px; margin: 0 0 12px; }
-    h2 { font-size: 20px; margin: 24px 0 12px; border-bottom: 1px solid #2a9d8f; padding-bottom: 4px; font-weight: bold; }
+    h1 { font-size: 32px; margin: 0 0 12px; font-weight: 700; }
+    h2 { font-size: 20px; margin: 24px 0 12px; border-bottom: 1px solid #2a9d8f; padding-bottom: 4px; font-weight: 700; }
     section { margin-bottom: 16px; }
     ul { list-style: none; margin: 0; padding: 0; }
     li {
@@ -36,7 +36,7 @@ exports[`all headings including Skills are bold in HTML and PDF outputs: html 1`
     }
     .tab { display:inline-block; width:1.5em; }
     .tab + p { margin-top: 0; }
-    strong { font-weight: bold; }
+    strong { font-weight: 700; }
   </style>
 </head>
 <body>

--- a/tests/__snapshots__/generatePdf.test.js.snap
+++ b/tests/__snapshots__/generatePdf.test.js.snap
@@ -32,22 +32,22 @@ header {
   justify-content: center;
 }
 
-h1 {
-  font-size: 2.8rem;
-  font-weight: bold;
-  margin: 0;
-  color: var(--accent);
-}
+  h1 {
+    font-size: 2.8rem;
+    font-weight: 700;
+    margin: 0;
+    color: var(--accent);
+  }
 
-h2 {
-  font-size: 1.5rem;
-  font-weight: bold;
-  margin-top: 2.5rem;
-  margin-bottom: 0.75rem;
-  color: var(--accent);
-  border-bottom: 2px solid var(--accent);
-  padding-bottom: 0.25rem;
-}
+  h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+    color: var(--accent);
+    border-bottom: 2px solid var(--accent);
+    padding-bottom: 0.25rem;
+  }
 
 main {
   display: grid;
@@ -242,4 +242,3 @@ Information not provided
 Education
 Information not provided"
 `;
-

--- a/tests/__snapshots__/selectTemplatesGroup.test.js.snap
+++ b/tests/__snapshots__/selectTemplatesGroup.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`selectTemplates enforces ucmo presence heading styles are bold across templates 1`] = `
+{
+  "2025": "h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+    color: var(--accent);
+    border-bottom: 2px solid var(--accent);
+    padding-bottom: 0.25rem;
+  }",
+  "modern": "h2 { font-size: 20px; margin: 24px 0 12px; border-bottom: 1px solid #2a9d8f; padding-bottom: 4px; font-weight: 700; }",
+  "professional": "h2 { font-size: 20px; color: #1d3557; margin: 30px 0 16px; border-bottom: 1px solid #1d3557; padding-bottom: 4px; font-weight: 700; }",
+  "ucmo": "h2 { font-size: 18px; margin: 30px 0 12px; background: #f2f2f2; padding: 6px 10px; color: #990000; font-weight: 700; }",
+  "vibrant": "h2 { font-size: 20px; color: #ff6b6b; margin: 24px 0 12px; border-bottom: 2px solid #ff6b6b; padding-bottom: 4px; font-weight: 700; }",
+}
+`;

--- a/tests/selectTemplatesGroup.test.js
+++ b/tests/selectTemplatesGroup.test.js
@@ -1,4 +1,6 @@
 import { selectTemplates, CV_TEMPLATES, CV_TEMPLATE_GROUPS } from '../server.js';
+import fs from 'fs/promises';
+import path from 'path';
 
 describe('selectTemplates enforces ucmo presence', () => {
   test.each(CV_TEMPLATES)('includes ucmo when both templates are %s', (tpl) => {
@@ -7,6 +9,7 @@ describe('selectTemplates enforces ucmo presence', () => {
     const other = template1 === 'ucmo' ? template2 : template1;
     expect(other).not.toBe('ucmo');
     expect(CV_TEMPLATE_GROUPS[other]).not.toBe(CV_TEMPLATE_GROUPS['ucmo']);
+    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(CV_TEMPLATE_GROUPS[template2]);
   });
 
   test('overrides when neither input is ucmo', () => {
@@ -18,5 +21,24 @@ describe('selectTemplates enforces ucmo presence', () => {
     const other = template1 === 'ucmo' ? template2 : template1;
     expect(other).not.toBe('ucmo');
     expect(CV_TEMPLATE_GROUPS[other]).not.toBe(CV_TEMPLATE_GROUPS['ucmo']);
+    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(CV_TEMPLATE_GROUPS[template2]);
+  });
+
+  test('heading styles are bold across templates', async () => {
+    const styles = {};
+    for (const tpl of CV_TEMPLATES) {
+      const htmlPath = path.resolve('templates', `${tpl}.html`);
+      let src = await fs.readFile(htmlPath, 'utf8');
+      let match = src.match(/h2\s*{[^}]*}/i);
+      if (!match) {
+        try {
+          const css = await fs.readFile(path.resolve('templates', `${tpl}.css`), 'utf8');
+          match = css.match(/h2\s*{[^}]*}/i);
+        } catch {}
+      }
+      styles[tpl] = match ? match[0] : '';
+      expect(styles[tpl]).toMatch(/font-weight:\s*700/);
+    }
+    expect(styles).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary
- enforce that selectTemplates always pairs `ucmo` with a template from a different group
- use `font-weight:700` and strong tags across resume templates for consistent bold headings
- add tests confirming templates come from separate groups and snapshot heading styles

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_68b55700dbcc832b960f4cb95142662e