### PR TITLE
Handle responsibility bullets in experience parsing

### DIFF
--- a/server.js
+++ b/server.js
@@ -1505,7 +1505,14 @@ function extractExperience(source) {
     }
     const jobMatch = line.match(/^[-*]\s+(.*)/) || (!line.match(/^\s/) ? [null, trimmed] : null);
     if (jobMatch) {
-      entries.push(parseEntry(jobMatch[1].trim()));
+      const text = jobMatch[1].trim();
+      const entry = parseEntry(text);
+      const hasCompanyTitleOrDate =
+        /\bat\b/i.test(text) ||
+        /\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\b\s+\d{4}\s*[\u2013-]\s*/i.test(text);
+      if (hasCompanyTitleOrDate && !(entry.company === '' && entry.startDate === '')) {
+        entries.push(entry);
+      }
     }
   }
   return entries;

--- a/tests/extractExperience.test.js
+++ b/tests/extractExperience.test.js
@@ -115,6 +115,21 @@ describe('extractExperience', () => {
       }
     ]);
   });
+
+  test('ignores technology bullet lines following a role', () => {
+    const text =
+      'Experience\n' +
+      '- Developer at Beta Corp (Mar 2018 - Apr 2019)\n' +
+      '- React, Node, AWS\n';
+    expect(extractExperience(text)).toEqual([
+      {
+        company: 'Beta Corp',
+        title: 'Developer',
+        startDate: 'Mar 2018',
+        endDate: 'Apr 2019'
+      }
+    ]);
+  });
 });
 
 describe('fetchLinkedInProfile', () => {


### PR DESCRIPTION
## Summary
- refine `extractExperience` to skip lines lacking company/title or date range and ignore empty company/startDate pairs
- add test to verify technology bullet lists after a role are not treated as new jobs

## Testing
- `npm test tests/extractExperience.test.js`
- ⚠️ `npm test` *(fails: libatk-1.0.so.0 missing; 1 snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b56635d910832b9438cfb626c7c7ad