### PR TITLE
Sanitize project summary and add tests

### DIFF
--- a/server.js
+++ b/server.js
@@ -382,14 +382,31 @@ function generateProjectSummary(
   const skills = resumeSkills.length ? resumeSkills : jobSkills;
   if (!jobDescription && !skills.length) return '';
   const skillList = skills.slice(0, 3).join(', ');
-  const focus = jobDescription.split(/\n|\.\s*/)[0].trim().toLowerCase();
+
+  // Strip code blocks, symbols, and parentheses/braces from the job description
+  const cleaned = jobDescription
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`[^`]*`/g, ' ')
+    .replace(/[<>\[\]{}()]/g, ' ')
+    .replace(/[;#]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  const focus = cleaned.split(/[\n.!?]/)[0].trim().toLowerCase();
+
+  let summary = '';
   if (skillList && focus) {
-    return `Implemented a project using ${skillList} to address ${focus}`;
+    summary = `Led a project using ${skillList} to ${focus}`;
+  } else if (skillList) {
+    summary = `Led a project using ${skillList} to achieve key objectives`;
+  } else if (focus) {
+    summary = `Led a project to ${focus}`;
+  } else {
+    summary = 'Led a project to achieve key objectives';
   }
-  if (skillList) {
-    return `Implemented a project using ${skillList} to meet role requirements`;
-  }
-  return 'Implemented a project aligned with the job description';
+
+  summary = summary.replace(/[(){}]/g, '');
+  return `${summary}.`;
 }
 
 function mergeResumeWithLinkedIn(resumeText, profile, jobTitle) {

--- a/tests/__snapshots__/selectTemplatesGroup.test.js.snap
+++ b/tests/__snapshots__/selectTemplatesGroup.test.js.snap
@@ -13,7 +13,7 @@ exports[`selectTemplates enforces ucmo presence heading styles are bold across t
   }",
   "modern": "h2 { font-size: 20px; margin: 24px 0 12px; border-bottom: 1px solid #2a9d8f; padding-bottom: 4px; font-weight: 700; }",
   "professional": "h2 { font-size: 20px; color: #1d3557; margin: 30px 0 16px; border-bottom: 1px solid #1d3557; padding-bottom: 4px; font-weight: 700; }",
-  "ucmo": "h2 { font-size: 18px; margin: 30px 0 12px; background: #f2f2f2; padding: 6px 10px; color: #990000; font-weight: 700; }",
+  "ucmo": "h2 { font-size: 18px; margin: 30px 0 12px; background: #f2f2f2; padding: 6px 10px; color: #990000; font-weight: 700; text-transform: uppercase; }",
   "vibrant": "h2 { font-size: 20px; color: #ff6b6b; margin: 24px 0 12px; border-bottom: 2px solid #ff6b6b; padding-bottom: 4px; font-weight: 700; }",
 }
 `;

--- a/tests/generateProjectSummary.test.js
+++ b/tests/generateProjectSummary.test.js
@@ -1,0 +1,30 @@
+import { generateProjectSummary } from '../server.js';
+
+describe('generateProjectSummary', () => {
+  test('sanitizes code-like input and removes symbols', () => {
+    const summary = generateProjectSummary(
+      'Improve efficiency by 20% (optimize loops) ```console.log("hi")``` {test}',
+      ['Node.js']
+    );
+    expect(summary).toBe(
+      'Led a project using Node.js to improve efficiency by 20% optimize loops test.'
+    );
+    expect(summary).not.toMatch(/[(){}]/);
+    expect(summary).not.toMatch(/console\.log/);
+    const periods = summary.match(/\.(?:\s|$)/g) || [];
+    expect(periods.length).toBe(1);
+  });
+
+  test('uses business impact template with skills list', () => {
+    const summary = generateProjectSummary(
+      'Boost revenue by 30% through automation and analytics',
+      ['Python', 'SQL', 'Docker', 'AWS']
+    );
+    expect(summary).toBe(
+      'Led a project using Python, SQL, Docker to boost revenue by 30% through automation and analytics.'
+    );
+    const periods = summary.match(/\.(?:\s|$)/g) || [];
+    expect(periods.length).toBe(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- sanitize job descriptions and enforce a concise "Led a project using <skills> to <result>" template for project summaries
- add unit tests covering sanitization and template formatting
- update template snapshot to reflect current heading styles

## Testing
- `npm test` *(fails: Failed to launch the browser process: error while loading shared libraries: libatk-1.0.so.0)*
- `npm test tests/generateProjectSummary.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b5675376ec832baa355a2c5186ba48