### PR TITLE
feat: integrate Credly certifications

### DIFF
--- a/tests/ensureRequiredSections.test.js
+++ b/tests/ensureRequiredSections.test.js
@@ -139,6 +139,47 @@ describe('ensureRequiredSections certifications merging', () => {
     expect(certSection.items).toHaveLength(1);
   });
 
+  test('includes credly certifications and profile link', () => {
+    const data = { sections: [] };
+    const credlyCertifications = [
+      {
+        name: 'AWS Certified Developer',
+        provider: 'Amazon',
+        url: 'https://credly.com/aws-dev'
+      }
+    ];
+    const ensured = ensureRequiredSections(data, {
+      credlyCertifications,
+      credlyProfileUrl: 'https://credly.com/user'
+    });
+    const certSection = ensured.sections.find(
+      (s) => s.heading === 'Certification'
+    );
+    expect(certSection).toBeTruthy();
+    expect(certSection.items).toHaveLength(2);
+    const first = certSection.items[0];
+    const hasLink = first.some(
+      (t) => t.type === 'link' && t.href === 'https://credly.com/aws-dev'
+    );
+    expect(hasLink).toBe(true);
+    const profile = certSection.items[1];
+    const profileLink = profile.find(
+      (t) => t.type === 'link' && t.href === 'https://credly.com/user'
+    );
+    expect(profileLink).toBeTruthy();
+  });
+
+  test('omits certification section when only credly profile link provided', () => {
+    const ensured = ensureRequiredSections(
+      { sections: [] },
+      { credlyCertifications: [], credlyProfileUrl: 'https://credly.com/user' }
+    );
+    const certSection = ensured.sections.find(
+      (s) => s.heading === 'Certification'
+    );
+    expect(certSection).toBeUndefined();
+  });
+
   test('removes certification section if no certificates remain', () => {
     const data = { sections: [{ heading: 'Certification', items: [] }] };
     const ensured = ensureRequiredSections(data, {});

--- a/tests/fetchCredlyProfile.test.js
+++ b/tests/fetchCredlyProfile.test.js
@@ -1,0 +1,38 @@
+import { jest } from '@jest/globals';
+
+const mockGet = jest.fn();
+
+jest.unstable_mockModule('axios', () => ({ default: { get: mockGet } }));
+
+const { fetchCredlyProfile } = await import('../server.js');
+
+describe('fetchCredlyProfile', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  test('parses active badges only', async () => {
+    const html = `
+      <div class="badge">
+        <a href="https://credly.com/aws-dev"><span class="badge-name">AWS Certified Developer</span></a>
+        <span class="issuer-name">Amazon</span>
+        <span class="badge-status">Active</span>
+      </div>
+      <div class="badge">
+        <a href="https://credly.com/expired"><span class="badge-name">Old Cert</span></a>
+        <span class="issuer-name">Old Org</span>
+        <span class="badge-status">Expired</span>
+      </div>
+    `;
+    mockGet.mockResolvedValueOnce({ data: html });
+    const certs = await fetchCredlyProfile('http://example.com');
+    expect(certs).toEqual([
+      {
+        name: 'AWS Certified Developer',
+        provider: 'Amazon',
+        url: 'https://credly.com/aws-dev',
+        source: 'credly'
+      }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `credlyProfileUrl` support in `/api/process-cv`
- parse Credly profiles and merge badges into certification section
- include Credly profile link and tests

## Testing
- `npm test` *(fails: tests/templates/ucmo.test.js – missing libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b568faab70832baeef7686c4f89a96