### PR TITLE
Add optional Credly profile URL support

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,6 +3,7 @@ import { useState, useCallback } from 'react'
 function App() {
   const [profileUrl, setProfileUrl] = useState('')
   const [jobUrl, setJobUrl] = useState('')
+  const [credlyUrl, setCredlyUrl] = useState('')
   const [cvFile, setCvFile] = useState(null)
   const [isProcessing, setIsProcessing] = useState(false)
   const [outputFiles, setOutputFiles] = useState([])
@@ -39,6 +40,7 @@ function App() {
       formData.append('resume', cvFile)
       formData.append('linkedinProfileUrl', profileUrl)
       formData.append('jobDescriptionUrl', jobUrl)
+      if (credlyUrl) formData.append('credlyProfileUrl', credlyUrl)
 
       const response = await fetch(`${API_BASE_URL}/api/process-cv`, {
         method: 'POST',
@@ -125,6 +127,14 @@ function App() {
         placeholder="Job Description URL"
         value={jobUrl}
         onChange={(e) => setJobUrl(e.target.value)}
+        className="w-full max-w-md p-2 border border-purple-300 rounded mb-4"
+      />
+
+      <input
+        type="url"
+        placeholder="Credly Profile URL (optional)"
+        value={credlyUrl}
+        onChange={(e) => setCredlyUrl(e.target.value)}
         className="w-full max-w-md p-2 border border-purple-300 rounded mb-4"
       />
 

--- a/tests/ensureRequiredSections.test.js
+++ b/tests/ensureRequiredSections.test.js
@@ -92,9 +92,17 @@ describe('ensureRequiredSections certifications merging', () => {
         url: 'https://example.com/pmp'
       }
     ];
+    const credlyCertifications = [
+      {
+        name: 'AWS Certified Developer',
+        provider: 'Amazon',
+        url: 'https://www.credly.com/badges/aws-dev'
+      }
+    ];
     const ensured = ensureRequiredSections(data, {
       resumeCertifications,
-      linkedinCertifications
+      linkedinCertifications,
+      credlyCertifications
     });
     const certSection = ensured.sections.find(
       (s) => s.heading === 'Certification'
@@ -106,10 +114,16 @@ describe('ensureRequiredSections certifications merging', () => {
       expect(tokens[0].type).toBe('bullet');
     });
     const first = certSection.items[0];
-    const hasLink = first.some(
+    const firstText = first
+      .filter((t) => t.text)
+      .map((t) => t.text)
+      .join(' ');
+    expect(firstText).toContain('AWS Certified Developer');
+    expect(firstText).toContain('Amazon');
+    const firstLink = first.find(
       (t) => t.type === 'link' && t.href === 'https://www.credly.com/badges/aws-dev'
     );
-    expect(hasLink).toBe(true);
+    expect(firstLink).toBeTruthy();
   });
 
   test('prepends bullet to existing certification entries missing one', () => {
@@ -158,6 +172,9 @@ describe('ensureRequiredSections certifications merging', () => {
     expect(certSection).toBeTruthy();
     expect(certSection.items).toHaveLength(2);
     const first = certSection.items[0];
+    const text = first.filter((t) => t.text).map((t) => t.text).join(' ');
+    expect(text).toContain('AWS Certified Developer');
+    expect(text).toContain('Amazon');
     const hasLink = first.some(
       (t) => t.type === 'link' && t.href === 'https://credly.com/aws-dev'
     );


### PR DESCRIPTION
## Summary
- allow users to include an optional Credly profile URL when enhancing their CV
- fetch and render Credly certifications alongside other sources without duplicates
- expand Credly tests for integration and rendering

## Testing
- `npm test tests/fetchCredlyProfile.test.js tests/ensureRequiredSections.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5710ba108832ba1f4c8d9bc360078