### PR TITLE
Integrate Gemini-generated UCMO HTML and snapshot test

### DIFF
--- a/tests/__snapshots__/ucmoGeminiLayout.test.js.snap
+++ b/tests/__snapshots__/ucmoGeminiLayout.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ucmo template uses Gemini layout markup 1`] = `"<html><body><table id="top"><tr><td>contact</td><td><img src="logo.png"/></td></tr></table></body></html>"`;

--- a/tests/ucmoGeminiLayout.test.js
+++ b/tests/ucmoGeminiLayout.test.js
@@ -1,0 +1,26 @@
+import { jest } from '@jest/globals';
+
+const setContent = jest.fn();
+const pdf = jest.fn().mockResolvedValue(Buffer.from('PDF'));
+const close = jest.fn();
+const newPage = jest.fn().mockResolvedValue({ setContent, pdf });
+const launch = jest.fn().mockResolvedValue({ newPage, close });
+
+jest.unstable_mockModule('puppeteer', () => ({ default: { launch } }));
+
+const { generatePdf } = await import('../server.js');
+
+test('ucmo template uses Gemini layout markup', async () => {
+  const markup = '<html><body><table id="top"><tr><td>contact</td><td><img src="logo.png"/></td></tr></table></body></html>';
+  const generativeModel = {
+    generateContent: jest
+      .fn()
+      .mockResolvedValue({ response: { text: () => markup } })
+  };
+  await generatePdf('Jane Doe\nExperience', 'ucmo', {}, generativeModel);
+  expect(generativeModel.generateContent).toHaveBeenCalled();
+  const prompt = generativeModel.generateContent.mock.calls[0][0];
+  expect(prompt).toMatch(/University of Central Missouri/);
+  expect(setContent).toHaveBeenCalledWith(markup, { waitUntil: 'networkidle0' });
+  expect(setContent.mock.calls[0][0]).toMatchSnapshot();
+});


### PR DESCRIPTION
## Summary
- Use Gemini to produce UCMO resume HTML, replacing template markup before PDF generation
- Pass Gemini model through PDF generation workflow
- Add snapshot test verifying Gemini-provided UCMO HTML is used

## Testing
- `npm test` *(fails: Failed to launch the browser process: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5858e2d88832b8cba857f9d225aef