### PR TITLE
Avoid placeholder when other experience roles exist

### DIFF
--- a/server.js
+++ b/server.js
@@ -804,9 +804,22 @@ function ensureRequiredSections(
         return (isNaN(bDate) ? 0 : bDate) - (isNaN(aDate) ? 0 : aDate);
       });
 
-      section.items = all.length
-        ? all.map((e) => e.tokens)
-        : [parseLine('Information not provided')];
+      if (all.length) {
+        section.items = all.map((e) => e.tokens);
+      } else {
+        const otherExperienceHasItems = data.sections.some((s) => {
+          if (s === section) return false;
+          const heading = normalizeHeading(s.heading).toLowerCase();
+          return (
+            heading.includes('experience') &&
+            Array.isArray(s.items) &&
+            s.items.length > 0
+          );
+        });
+        section.items = otherExperienceHasItems
+          ? []
+          : [parseLine('Information not provided')];
+      }
     } else if (!section.items || section.items.length === 0) {
       if (normalized.toLowerCase() === 'education') {
         const bullets = resumeEducation.length

--- a/tests/ensureRequiredSections.test.js
+++ b/tests/ensureRequiredSections.test.js
@@ -68,6 +68,27 @@ describe('ensureRequiredSections work experience merging', () => {
       'Engineer at Beta (2020 – 2022)'
     ]);
   });
+
+  test('skips placeholder when another experience section has items', () => {
+    const data = {
+      sections: [
+        {
+          heading: 'Professional Experience',
+          items: [parseLine('- Engineer at Acme (2020 – 2021)')]
+        }
+      ]
+    };
+    const ensured = ensureRequiredSections(data, {});
+    const work = ensured.sections.find((s) => s.heading === 'Work Experience');
+    expect(work).toBeTruthy();
+    expect(work.items).toHaveLength(0);
+    const placeholders = ensured.sections
+      .filter((s) => s.heading.toLowerCase().includes('experience'))
+      .flatMap((s) =>
+        (s.items || []).flatMap((tokens) => tokens.map((t) => t.text || ''))
+      );
+    expect(placeholders).not.toContain('Information not provided');
+  });
 });
 
 describe('ensureRequiredSections certifications merging', () => {


### PR DESCRIPTION
## Summary
- Prevent `ensureRequiredSections` from adding "Information not provided" to Work Experience if any other experience section has entries.
- Add regression test to ensure placeholder is skipped when at least one role is present.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b59398d4f8832b987a68987d327f74