### PR TITLE
Normalize training headings and link certificates to URLs

### DIFF
--- a/tests/ensureRequiredSections.test.js
+++ b/tests/ensureRequiredSections.test.js
@@ -80,8 +80,7 @@ describe('ensureRequiredSections work experience merging', () => {
     };
     const ensured = ensureRequiredSections(data, {});
     const work = ensured.sections.find((s) => s.heading === 'Work Experience');
-    expect(work).toBeTruthy();
-    expect(work.items).toHaveLength(0);
+    expect(work).toBeUndefined();
     const placeholders = ensured.sections
       .filter((s) => s.heading.toLowerCase().includes('experience'))
       .flatMap((s) =>

--- a/tests/extractCertifications.test.js
+++ b/tests/extractCertifications.test.js
@@ -91,33 +91,43 @@ describe('extractCertifications', () => {
     expect(certSection.items).toHaveLength(1);
     const link = certSection.items[0].find((t) => t.type === 'link');
     expect(link).toMatchObject({
-      text: 'Credly',
+      text: 'AWS Certified Developer',
       href: 'https://www.credly.com/badges/abc'
     });
   });
 
-  test('renders credential URLs in (Credly) format', () => {
+  test('consolidates training headings and links certificate names to their URLs', () => {
     const resumeCertifications = [
       {
         name: 'PMP',
         provider: 'PMI',
         url: 'https://www.credly.com/pmp'
+      },
+      {
+        name: 'CKA',
+        provider: 'CNCF',
+        url: 'https://www.credly.com/cka'
       }
     ];
-    const ensured = ensureRequiredSections(
-      { sections: [] },
-      { resumeCertifications }
-    );
-    const certSection = ensured.sections.find(
+    const data = {
+      sections: [
+        { heading: 'Trainings', items: [] },
+        { heading: 'Certifications', items: [] }
+      ]
+    };
+    const ensured = ensureRequiredSections(data, { resumeCertifications });
+    const certSections = ensured.sections.filter(
       (s) => s.heading === 'Certification'
     );
-    const tokens = certSection.items[0];
-    const link = tokens.find((t) => t.type === 'link');
-    expect(link).toMatchObject({
-      text: 'Credly',
-      href: 'https://www.credly.com/pmp'
+    expect(certSections).toHaveLength(1);
+    const items = certSections[0].items;
+    expect(items).toHaveLength(2);
+    items.forEach((tokens, idx) => {
+      const link = tokens.find((t) => t.type === 'link');
+      expect(link).toMatchObject({
+        text: resumeCertifications[idx].name,
+        href: resumeCertifications[idx].url
+      });
     });
-    const text = tokens.filter((t) => t.text).map((t) => t.text).join('');
-    expect(text).toContain('(Credly)');
   });
 });


### PR DESCRIPTION
## Summary
- Normalize headings containing training or certification to unified "Certification" and prune empty sections before merging duplicates
- Link certificate names directly to credential URLs instead of adding separate Credly links
- Test certification extraction to ensure consolidated section and correct hyperlinking

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b595335740832bbd40444b1dc0a9e1