### PR TITLE
Ensure ucmo template pairing and add group test

### DIFF
--- a/server.js
+++ b/server.js
@@ -191,6 +191,17 @@ function selectTemplates({
       CV_TEMPLATES[0];
   }
 
+  // Final sanity check: ensure one template is 'ucmo' and the other is from a different group
+  const isValidPair = () =>
+    template1 &&
+    template2 &&
+    (template1 === 'ucmo' || template2 === 'ucmo') &&
+    CV_TEMPLATE_GROUPS[template1] !== CV_TEMPLATE_GROUPS[template2];
+  while (!isValidPair()) {
+    template1 = 'ucmo';
+    template2 = pickNonUcmo();
+  }
+
   if (!coverTemplate1 && !coverTemplate2) {
     coverTemplate1 = CL_TEMPLATES[0];
     coverTemplate2 = CL_TEMPLATES.find((t) => t !== coverTemplate1) || CL_TEMPLATES[0];

--- a/tests/selectTemplatesGroup.test.js
+++ b/tests/selectTemplatesGroup.test.js
@@ -24,6 +24,14 @@ describe('selectTemplates enforces ucmo presence', () => {
     expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(CV_TEMPLATE_GROUPS[template2]);
   });
 
+  test('random selection yields ucmo and distinct groups', () => {
+    for (let i = 0; i < 20; i++) {
+      const { template1, template2 } = selectTemplates();
+      expect([template1, template2]).toContain('ucmo');
+      expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(CV_TEMPLATE_GROUPS[template2]);
+    }
+  });
+
   test('heading styles are bold across templates', async () => {
     const styles = {};
     for (const tpl of CV_TEMPLATES) {


### PR DESCRIPTION
## Summary
- enforce final template pair to include `ucmo` and a contrasting group
- add test verifying random selections return distinct groups and include `ucmo`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b599580628832b84761bba183695e7