### PR TITLE
Ensure ucmo template paired with contrasting style group

### DIFF
--- a/server.js
+++ b/server.js
@@ -149,57 +149,29 @@ function selectTemplates({
     if (!coverTemplate1 && clTemplates[0]) coverTemplate1 = clTemplates[0];
     if (!coverTemplate2 && clTemplates[1]) coverTemplate2 = clTemplates[1];
   }
-  // Ensure one template is 'ucmo' and the other is from a different group
-  const pickNonUcmo = (tpl) => {
-    if (tpl && tpl !== 'ucmo' && CV_TEMPLATE_GROUPS[tpl] !== CV_TEMPLATE_GROUPS['ucmo']) {
-      return tpl;
+  // Ensure one template is always 'ucmo'
+  if (template1 !== 'ucmo' && template2 !== 'ucmo') {
+    if (template1) {
+      template2 = 'ucmo';
+    } else if (template2) {
+      template1 = 'ucmo';
+    } else {
+      template1 = 'ucmo';
     }
-    const candidates = CV_TEMPLATES.filter(
-      (t) => t !== 'ucmo' && CV_TEMPLATE_GROUPS[t] !== CV_TEMPLATE_GROUPS['ucmo']
-    );
-    return candidates[Math.floor(Math.random() * candidates.length)] || CV_TEMPLATES.find((t) => t !== 'ucmo');
-  };
-
-  if (template1 === 'ucmo') {
-    template2 = pickNonUcmo(template2);
-  } else if (template2 === 'ucmo') {
-    template1 = pickNonUcmo(template1);
-  } else if (template1 && !template2) {
-    template1 = pickNonUcmo(template1);
-    template2 = 'ucmo';
-  } else if (!template1 && template2) {
-    template2 = pickNonUcmo(template2);
-    template1 = 'ucmo';
-  } else if (template1 && template2) {
-    template1 = pickNonUcmo(template1);
-    template2 = 'ucmo';
-  } else {
-    template1 = 'ucmo';
-    template2 = pickNonUcmo();
+  }
+  if (!template1) template1 = 'ucmo';
+  if (!template2) {
+    // pick a random template other than template1
+    const candidates = CV_TEMPLATES.filter((t) => t !== template1);
+    template2 = candidates[Math.floor(Math.random() * candidates.length)];
   }
 
-  if (
-    !template2 ||
-    template1 === template2 ||
-    CV_TEMPLATE_GROUPS[template1] === CV_TEMPLATE_GROUPS[template2]
-  ) {
+  // Ensure templates come from different style groups; re-draw template2 if needed
+  if (CV_TEMPLATE_GROUPS[template1] === CV_TEMPLATE_GROUPS[template2]) {
     const candidates = CV_TEMPLATES.filter(
       (t) => t !== template1 && CV_TEMPLATE_GROUPS[t] !== CV_TEMPLATE_GROUPS[template1]
     );
-    template2 =
-      candidates[Math.floor(Math.random() * candidates.length)] ||
-      CV_TEMPLATES[0];
-  }
-
-  // Final sanity check: ensure one template is 'ucmo' and the other is from a different group
-  const isValidPair = () =>
-    template1 &&
-    template2 &&
-    (template1 === 'ucmo' || template2 === 'ucmo') &&
-    CV_TEMPLATE_GROUPS[template1] !== CV_TEMPLATE_GROUPS[template2];
-  while (!isValidPair()) {
-    template1 = 'ucmo';
-    template2 = pickNonUcmo();
+    template2 = candidates[Math.floor(Math.random() * candidates.length)] || template2;
   }
 
   if (!coverTemplate1 && !coverTemplate2) {

--- a/tests/__snapshots__/selectTemplatesGroup.test.js.snap
+++ b/tests/__snapshots__/selectTemplatesGroup.test.js.snap
@@ -1,16 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`selectTemplates enforces ucmo presence heading styles are bold across templates 1`] = `
+exports[`selectTemplates enforces ucmo and distinct groups heading styles are bold across templates 1`] = `
 {
-  "2025": "h2 {
-    font-size: 1.5rem;
-    font-weight: 700;
-    margin-top: 2.5rem;
-    margin-bottom: 0.75rem;
-    color: var(--accent);
-    border-bottom: 2px solid var(--accent);
-    padding-bottom: 0.25rem;
-  }",
+  "2025": "h2 {\n    font-size: 1.5rem;\n    font-weight: 700;\n    margin-top: 2.5rem;\n    margin-bottom: 0.75rem;\n    color: var(--accent);\n    border-bottom: 2px solid var(--accent);\n    padding-bottom: 0.25rem;\n  }",
   "modern": "h2 { font-size: 20px; margin: 24px 0 12px; border-bottom: 1px solid #2a9d8f; padding-bottom: 4px; font-weight: 700; }",
   "professional": "h2 { font-size: 20px; color: #1d3557; margin: 30px 0 16px; border-bottom: 1px solid #1d3557; padding-bottom: 4px; font-weight: 700; }",
   "ucmo": "h2 { font-size: 18px; margin: 30px 0 12px; background: #f2f2f2; padding: 6px 10px; color: #990000; font-weight: 700; text-transform: uppercase; }",

--- a/tests/selectTemplatesGroup.test.js
+++ b/tests/selectTemplatesGroup.test.js
@@ -2,14 +2,13 @@ import { selectTemplates, CV_TEMPLATES, CV_TEMPLATE_GROUPS } from '../server.js'
 import fs from 'fs/promises';
 import path from 'path';
 
-describe('selectTemplates enforces ucmo presence', () => {
+describe('selectTemplates enforces ucmo and distinct groups', () => {
   test.each(CV_TEMPLATES)('includes ucmo when both templates are %s', (tpl) => {
     const { template1, template2 } = selectTemplates({ template1: tpl, template2: tpl });
     expect([template1, template2]).toContain('ucmo');
-    const other = template1 === 'ucmo' ? template2 : template1;
-    expect(other).not.toBe('ucmo');
-    expect(CV_TEMPLATE_GROUPS[other]).not.toBe(CV_TEMPLATE_GROUPS['ucmo']);
-    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(CV_TEMPLATE_GROUPS[template2]);
+    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
+      CV_TEMPLATE_GROUPS[template2]
+    );
   });
 
   test('overrides when neither input is ucmo', () => {
@@ -18,17 +17,18 @@ describe('selectTemplates enforces ucmo presence', () => {
       template2: 'professional'
     });
     expect([template1, template2]).toContain('ucmo');
-    const other = template1 === 'ucmo' ? template2 : template1;
-    expect(other).not.toBe('ucmo');
-    expect(CV_TEMPLATE_GROUPS[other]).not.toBe(CV_TEMPLATE_GROUPS['ucmo']);
-    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(CV_TEMPLATE_GROUPS[template2]);
+    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
+      CV_TEMPLATE_GROUPS[template2]
+    );
   });
 
   test('random selection yields ucmo and distinct groups', () => {
     for (let i = 0; i < 20; i++) {
       const { template1, template2 } = selectTemplates();
       expect([template1, template2]).toContain('ucmo');
-      expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(CV_TEMPLATE_GROUPS[template2]);
+      expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
+        CV_TEMPLATE_GROUPS[template2]
+      );
     }
   });
 


### PR DESCRIPTION
## Summary
- enforce selectTemplates to always include 'ucmo' and redraw second template if from same group
- update selectTemplatesGroup tests and snapshots for ucmo presence and distinct groups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a34100f0832bb20222f5ca285265