### PR TITLE
Ensure headings render bold in HTML and PDF outputs

### DIFF
--- a/server.js
+++ b/server.js
@@ -1356,10 +1356,12 @@ let generatePdf = async function (
                   : '';
                 return `<a href="${t.href}">${text.trim()}</a>${space}`;
               }
+              if (t.type === 'heading') {
+                return `<strong>${text}</strong>`;
+              }
               if (t.style === 'bolditalic') return `<strong><em>${text}</em></strong>`;
               if (t.style === 'bold') return `<strong>${text}</strong>`;
               if (t.style === 'italic') return `<em>${text}</em>`;
-              if (t.type === 'heading') return `<strong>${text}</strong>`;
               if (t.type === 'newline') return '<br>';
               if (t.type === 'tab') return '<span class="tab"></span>';
               if (t.type === 'bullet') {
@@ -1544,6 +1546,7 @@ let generatePdf = async function (
               return;
             }
             if (t.type === 'heading') {
+              // Render heading tokens using the bold font
               doc.font(style.bold);
               doc.text(t.text, opts);
               doc.font(style.font);

--- a/tests/boldHeadings.test.js
+++ b/tests/boldHeadings.test.js
@@ -15,6 +15,7 @@ function tokensToHtml(tokens) {
       if (t.style === 'bolditalic') return `<strong><em>${text}</em></strong>`;
       if (t.style === 'bold') return `<strong>${text}</strong>`;
       if (t.style === 'italic') return `<em>${text}</em>`;
+      if (t.type === 'heading') return `<strong>${text}</strong>`;
       if (t.type === 'newline') return '<br>';
       if (t.type === 'tab') return '<span class="tab"></span>';
       if (t.type === 'bullet') return '<span class="bullet">•</span> ';


### PR DESCRIPTION
## Summary
- Ensure heading tokens render with `<strong>` in HTML and bold font in PDFKit fallback
- Mirror heading handling in unit tests for bold heading validation

## Testing
- `npm test tests/boldHeadings.test.js -- -u`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a8028bf0832ba69534b37ddb2b5a