### PR TITLE
feat: generate project section

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -472,7 +472,7 @@ describe('/api/process-cv', () => {
     generateContentMock
       .mockResolvedValueOnce({
         response: {
-          text: () => JSON.stringify({ version1: 'Name', version2: 'Name', project: 'Example project' })
+          text: () => JSON.stringify({ version1: 'Name', version2: 'Name' })
         }
       })
       .mockResolvedValueOnce({ response: { text: () => '' } })
@@ -505,11 +505,8 @@ describe('/api/process-cv', () => {
       (s) => s.heading === 'Projects'
     );
     expect(projectSection).toBeTruthy();
-    expect(
-      projectSection.items.some((tokens) =>
-        tokens.some((t) => t.type === 'bullet')
-      )
-    ).toBe(true);
+    expect(projectSection.items.length).toBeGreaterThan(0);
+    expect(projectSection.items.length).toBeLessThanOrEqual(2);
 
     setGeneratePdf(jest.fn().mockResolvedValue(Buffer.from('pdf')));
   });


### PR DESCRIPTION
## Summary
- add project placeholder handling in ensureRequiredSections
- generate project summary from job description when missing
- test that project section is added from job description

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5aa363910832bb43ed3d1aaea84ac