### PR TITLE
Deduplicate Credly profile bullet

### DIFF
--- a/server.js
+++ b/server.js
@@ -906,10 +906,15 @@ function ensureRequiredSections(
   });
 
   if (credlyProfileUrl) {
-    certItems.push([
-      { type: 'bullet' },
-      { type: 'link', text: 'Credly Profile', href: credlyProfileUrl },
-    ]);
+    const alreadyHasProfile = certItems.some((item) =>
+      item.some((t) => t.type === 'link' && t.href === credlyProfileUrl)
+    );
+    if (!alreadyHasProfile) {
+      certItems.push([
+        { type: 'bullet' },
+        { type: 'link', text: 'Credly Profile', href: credlyProfileUrl },
+      ]);
+    }
   }
 
   if (certItems.length) {

--- a/tests/ensureRequiredSections.test.js
+++ b/tests/ensureRequiredSections.test.js
@@ -228,6 +228,29 @@ describe('ensureRequiredSections certifications merging', () => {
     });
   });
 
+  test('deduplicates credly profile link from multiple sources', () => {
+    const resumeCertifications = [
+      { name: 'Credly Profile', url: 'https://credly.com/user' }
+    ];
+    const ensured = ensureRequiredSections(
+      { sections: [] },
+      {
+        resumeCertifications,
+        credlyProfileUrl: 'https://credly.com/user'
+      }
+    );
+    const certSection = ensured.sections.find(
+      (s) => s.heading === 'Certification'
+    );
+    expect(certSection.items).toHaveLength(1);
+    const link = certSection.items[0][1];
+    expect(link).toMatchObject({
+      type: 'link',
+      text: 'Credly Profile',
+      href: 'https://credly.com/user'
+    });
+  });
+
     test('removes certification section if no certificates remain', () => {
       const data = { sections: [{ heading: 'Certification', items: [] }] };
       const ensured = ensureRequiredSections(data, {});


### PR DESCRIPTION
## Summary
- Prevent duplicate Credly profile bullets when merging certification sources
- Test deduplication logic for Credly profile link across inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b5513b44832b94295d3794b92e28