### PR TITLE
Enforce UCMO template and dedupe normalized headings

### DIFF
--- a/tests/noDuplicateHeaders.test.js
+++ b/tests/noDuplicateHeaders.test.js
@@ -1,0 +1,24 @@
+import { parseContent } from '../server.js';
+
+describe('heading normalization removes duplicates', () => {
+  test('normalizes to title case and merges sections', () => {
+    const input = [
+      'Jane Doe',
+      '# experience',
+      '- Job A',
+      '# EXPERIENCE!',
+      '- Job B',
+      '# education',
+      '- School A',
+      '# EDUCATION ',
+      '- School B'
+    ].join('\n');
+    const data = parseContent(input);
+    const counts = data.sections.reduce((acc, s) => {
+      acc[s.heading] = (acc[s.heading] || 0) + 1;
+      return acc;
+    }, {});
+    expect(counts['Work Experience']).toBe(1);
+    expect(counts['Education']).toBe(1);
+  });
+});

--- a/tests/selectTemplatesGroup.test.js
+++ b/tests/selectTemplatesGroup.test.js
@@ -9,6 +9,7 @@ describe('selectTemplates enforces ucmo and distinct groups', () => {
     expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
       CV_TEMPLATE_GROUPS[template2]
     );
+    expect(template1).not.toBe(template2);
   });
 
   test('overrides when neither input is ucmo', () => {
@@ -20,6 +21,7 @@ describe('selectTemplates enforces ucmo and distinct groups', () => {
     expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
       CV_TEMPLATE_GROUPS[template2]
     );
+    expect(template1).not.toBe(template2);
   });
 
   test('random selection yields ucmo and distinct groups', () => {
@@ -29,6 +31,7 @@ describe('selectTemplates enforces ucmo and distinct groups', () => {
       expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
         CV_TEMPLATE_GROUPS[template2]
       );
+      expect(template1).not.toBe(template2);
     }
   });
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -318,8 +318,8 @@ describe('/api/process-cv', () => {
 
     const calls = serverModule.generatePdf.mock.calls;
     const resumeCalls = calls.filter(([, , opts]) => opts && opts.resumeExperience);
-    expect(resumeCalls[0][1]).toBe('modern');
-    expect(resumeCalls[1][1]).toBe('ucmo');
+    expect(resumeCalls[0][1]).toBe('ucmo');
+    expect(resumeCalls[1][1]).toBe('modern');
   });
 
   test('uses templates array', async () => {


### PR DESCRIPTION
## Summary
- Ensure `selectTemplates` always includes the `ucmo` template and selects a contrasting second template from a different style group
- Merge duplicate sections after headings are normalized to title case before PDF rendering
- Add tests asserting template uniqueness and heading deduplication

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5b96c3a60832b9ecec112307a84aa