### PR TITLE
Enhance resume generation with Gemini-driven role and skill updates

### DIFF
--- a/tests/geminiSections.test.js
+++ b/tests/geminiSections.test.js
@@ -27,11 +27,15 @@ describe('rewriteSectionsWithGemini', () => {
             skills: ['Skill B'],
             projects: ['Proj C'],
             projectSnippet: 'Led project.',
+            latestRoleTitle: 'Updated Title',
+            latestRoleDescription: 'Improved desc',
+            mandatorySkills: ['Skill B', 'Skill C'],
+            addedSkills: ['Skill C'],
           }),
       },
     });
     const generativeModel = { generateContent: generateContentMock };
-    const { text } = await rewriteSectionsWithGemini(
+    const { text, modifiedTitle, addedSkills } = await rewriteSectionsWithGemini(
       'John Doe',
       sections,
       'JD text',
@@ -44,6 +48,10 @@ describe('rewriteSectionsWithGemini', () => {
     expect(text).toContain('Studied Y');
     expect(text).toContain('Cert A');
     expect(text).toContain('Skill B');
+    expect(text).toContain('Skill C');
     expect(text).toContain('Proj C');
+    expect(text).toContain('Updated Title');
+    expect(modifiedTitle).toBe('Updated Title');
+    expect(addedSkills).toEqual(['Skill C']);
   });
 });


### PR DESCRIPTION
## Summary
- Prompt Gemini to return a revised latest-role title/description, a JD-aligned project bullet, and mandatory skills with additions
- Surface Gemini's added skills and revised title in the API response and client UI
- Test that final CV PDFs embed the updated title, project snippet, and added skills

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5bb431510832b8e7b96f69c6b6cdf