### PR TITLE
test: mock OpenAI client for CV processing

### DIFF
--- a/tests/mocks/openai.js
+++ b/tests/mocks/openai.js
@@ -1,8 +1,9 @@
 import { jest } from '@jest/globals';
 
-export const filesCreate = jest.fn(async () => ({ id: 'file-id' }));
-export const responsesCreate = jest.fn(async () => ({
-  output_text: JSON.stringify({
+export const uploadFile = jest.fn(async () => ({ id: 'file-id' }));
+
+export const requestEnhancedCV = jest.fn(async () =>
+  JSON.stringify({
     cv_version1: 'v1',
     cv_version2: 'v2',
     cover_letter1: 'cl1',
@@ -10,13 +11,16 @@ export const responsesCreate = jest.fn(async () => ({
     original_score: 40,
     enhanced_score: 80,
     skills_added: ['skill1'],
-    improvement_summary: 'summary'
+    improvement_summary: 'summary',
   })
-}));
+);
 
 export default class OpenAI {
   constructor() {
-    this.files = { create: filesCreate };
-    this.responses = { create: responsesCreate };
+    this.files = { create: uploadFile };
+    this.responses = {
+      create: async () => ({ output_text: await requestEnhancedCV() }),
+    };
   }
 }
+


### PR DESCRIPTION
## Summary
- add OpenAI test mock with `uploadFile` and `requestEnhancedCV`
- refactor server tests to use OpenAI mock and expect new score fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7131327b8832ba803dbcdc33014c3