### PR TITLE
fix: update OpenAI model preferences to supported versions

### DIFF
--- a/openaiClient.js
+++ b/openaiClient.js
@@ -2,7 +2,10 @@ import OpenAI from 'openai';
 import { File } from 'node:buffer';
 import { getSecrets } from './server.js';
 
-const preferredModels = ['gpt-5', 'gpt-4.1', 'gpt-4o-mini'];
+// Ordered list of supported models. Unavailable or experimental models should
+// be placed at the end or removed to avoid unnecessary `model_not_found`
+// warnings during résumé generation.
+const preferredModels = ['gpt-4.1', 'gpt-4o-mini'];
 
 let clientPromise;
 async function getClient() {

--- a/tests/mocks/openai.js
+++ b/tests/mocks/openai.js
@@ -15,12 +15,15 @@ export const requestEnhancedCV = jest.fn(async () =>
   })
 );
 
+// Track calls to responses.create so tests can inspect model selection.
+export const createResponse = jest.fn(async (options) => ({
+  output_text: await requestEnhancedCV(options),
+}));
+
 export default class OpenAI {
   constructor() {
     this.files = { create: uploadFile };
-    this.responses = {
-      create: async () => ({ output_text: await requestEnhancedCV() }),
-    };
+    this.responses = { create: createResponse };
   }
 }
 

--- a/tests/openaiClientModels.test.js
+++ b/tests/openaiClientModels.test.js
@@ -1,0 +1,24 @@
+import { jest } from '@jest/globals';
+
+// Mock getSecrets to avoid loading full server and external services
+jest.unstable_mockModule('../server.js', () => ({
+  getSecrets: jest.fn().mockResolvedValue({ OPENAI_API_KEY: 'test-key' }),
+}));
+
+// Import the module under test after mocks are in place
+const { requestEnhancedCV } = await import('../openaiClient.js');
+import { createResponse } from './mocks/openai.js';
+
+test('uses supported model without model_not_found warnings', async () => {
+  const warnSpy = jest.spyOn(console, 'warn');
+
+  await requestEnhancedCV({
+    cvFileId: 'cv',
+    jobDescFileId: 'jd',
+    instructions: 'Test instructions',
+  });
+
+  expect(createResponse).toHaveBeenCalledTimes(1);
+  expect(createResponse.mock.calls[0][0].model).toBe('gpt-4.1');
+  expect(warnSpy).not.toHaveBeenCalledWith(expect.stringMatching(/Model not found/));
+});


### PR DESCRIPTION
## Summary
- remove unsupported `gpt-5` entry and keep valid models in `preferredModels`
- enhance OpenAI test mock to record requested model
- add unit test ensuring résumé generation uses supported model without warnings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b72a0f57dc832bbb672ac70627e1b9