### PR TITLE
Use name field for OpenAI JSON schema format

### DIFF
--- a/openaiClient.js
+++ b/openaiClient.js
@@ -78,7 +78,7 @@ export async function requestEnhancedCV({
         input: [{ role: 'user', content }],
         text: {
           format: {
-            type: 'json_schema',
+            name: 'json_schema',
             json_schema: { name: 'cv_enhancement', schema, strict: true },
           },
         },

--- a/tests/openaiClientModels.test.js
+++ b/tests/openaiClientModels.test.js
@@ -20,5 +20,7 @@ test('uses supported model without model_not_found warnings', async () => {
 
   expect(createResponse).toHaveBeenCalledTimes(1);
   expect(createResponse.mock.calls[0][0].model).toBe('gpt-4.1');
+  expect(createResponse.mock.calls[0][0].text.format.name).toBe('json_schema');
+  expect(createResponse.mock.calls[0][0].text.format.type).toBeUndefined();
   expect(warnSpy).not.toHaveBeenCalledWith(expect.stringMatching(/Model not found/));
 });


### PR DESCRIPTION
## Summary
- fix OpenAI `requestEnhancedCV` to send `text.format.name` instead of deprecated `type`
- add tests ensuring the new `json_schema` format structure is used

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b72d9fe678832b92bbd4c52b2cda62