### PR TITLE
Disallow extra fields in OpenAI response schema

### DIFF
--- a/openaiClient.js
+++ b/openaiClient.js
@@ -69,6 +69,7 @@ export async function requestEnhancedCV({
       'skills_added',
       'improvement_summary',
     ],
+    additionalProperties: false,
   };
   let lastError;
   for (const model of preferredModels) {

--- a/tests/openaiClientModels.test.js
+++ b/tests/openaiClientModels.test.js
@@ -27,5 +27,6 @@ test('uses supported model without model_not_found warnings', async () => {
     schema: expect.any(Object),
     strict: true,
   });
+  expect(options.text.format.schema).toHaveProperty('additionalProperties', false);
   expect(warnSpy).not.toHaveBeenCalledWith(expect.stringMatching(/Model not found/));
 });


### PR DESCRIPTION
## Summary
- disallow unexpected keys from OpenAI response schema by setting `additionalProperties: false`
- assert that the JSON schema forbids extra fields in `openaiClientModels` test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b73684fb54832bb094c597b0fbe17b