### PR TITLE
feat: enforce OpenAI API key

### DIFF
--- a/openaiClient.js
+++ b/openaiClient.js
@@ -12,10 +12,9 @@ async function getClient() {
   if (!clientPromise) {
     clientPromise = (async () => {
       const secrets = await getSecrets();
-      let apiKey = process.env.OPENAI_API_KEY || secrets.OPENAI_API_KEY;
+      const apiKey = process.env.OPENAI_API_KEY || secrets.OPENAI_API_KEY;
       if (!apiKey) {
-        console.warn('OPENAI_API_KEY missing, using dummy key');
-        apiKey = 'test';
+        throw new Error('OPENAI_API_KEY is required');
       }
       return new OpenAI({ apiKey });
     })();

--- a/tests/openaiClientModels.test.js
+++ b/tests/openaiClientModels.test.js
@@ -1,5 +1,8 @@
 import { jest } from '@jest/globals';
 
+// Ensure tests don't depend on a real environment key
+delete process.env.OPENAI_API_KEY;
+
 // Mock getSecrets to avoid loading full server and external services
 jest.unstable_mockModule('../config/secrets.js', () => ({
   getSecrets: jest.fn().mockResolvedValue({ OPENAI_API_KEY: 'test-key' }),

--- a/tests/openaiClientNoKey.test.js
+++ b/tests/openaiClientNoKey.test.js
@@ -1,0 +1,23 @@
+import { jest } from '@jest/globals';
+
+// Ensure no API key from environment
+delete process.env.OPENAI_API_KEY;
+
+// Mock secrets module to provide no key
+jest.unstable_mockModule('../config/secrets.js', () => ({
+  getSecrets: jest.fn().mockResolvedValue({})
+}));
+
+// Import after mocks are set up
+const { requestEnhancedCV } = await import('../openaiClient.js');
+
+import { createResponse } from './mocks/openai.js';
+
+// Basic parameters for call
+const params = { cvFileId: 'cv', jobDescFileId: 'jd', instructions: 'Test' };
+
+test('throws when OPENAI_API_KEY is missing', async () => {
+  await expect(requestEnhancedCV(params)).rejects.toThrow('OPENAI_API_KEY is required');
+  // Ensure mocked client was never used
+  expect(createResponse).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- throw an explicit error if `OPENAI_API_KEY` is missing
- adjust OpenAI client model tests to inject a key
- add a test confirming the client fails without an API key

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7382c665c832b8b9d985a7c8dc05a