### PR TITLE
Limit AI response logging on parse errors

### DIFF
--- a/server.js
+++ b/server.js
@@ -1924,16 +1924,22 @@ function extractJsonBlock(text) {
   return null;
 }
 
+function snippet(text, maxLength = 200) {
+  if (!text) return '';
+  const clean = String(text).replace(/\s+/g, ' ').trim();
+  return clean.length > maxLength ? clean.slice(0, maxLength) + '...' : clean;
+}
+
 function parseAiJson(text) {
   const block = extractJsonBlock(text);
   if (!block) {
-    console.error('No JSON object found in AI response:', text);
+    console.error('No JSON object found in AI response:', snippet(text));
     return null;
   }
   try {
     return JSON5.parse(block);
   } catch (e) {
-    console.error('Failed to parse AI JSON:', text);
+    console.error('Failed to parse AI JSON:', snippet(text));
     return null;
   }
 }
@@ -2546,6 +2552,7 @@ export {
   setGeneratePdf,
   parseContent,
   parseLine,
+  parseAiJson,
   ensureRequiredSections,
   extractExperience,
   extractEducation,

--- a/tests/parseAiJson.test.js
+++ b/tests/parseAiJson.test.js
@@ -1,0 +1,34 @@
+import { jest } from '@jest/globals';
+import { parseAiJson } from '../server.js';
+
+describe('parseAiJson logging', () => {
+  let errorSpy;
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  test('logs truncated snippet when JSON block is missing', () => {
+    const longText = 'A'.repeat(1000);
+    parseAiJson(longText);
+    expect(errorSpy).toHaveBeenCalled();
+    const logged = errorSpy.mock.calls[0].join(' ');
+    expect(logged).toContain('A'.repeat(200));
+    expect(logged).not.toContain('A'.repeat(300));
+    expect(logged).not.toContain(longText);
+  });
+
+  test('logs truncated snippet when JSON parsing fails', () => {
+    const prefix = 'B'.repeat(1000);
+    const invalidJson = `${prefix}{"foo": [}`;
+    parseAiJson(invalidJson);
+    expect(errorSpy).toHaveBeenCalled();
+    const logged = errorSpy.mock.calls[0].join(' ');
+    expect(logged).toContain('B'.repeat(200));
+    expect(logged).not.toContain('B'.repeat(300));
+    expect(logged).not.toContain(prefix);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Truncate AI response logging to 200 characters when JSON extraction or parsing fails, preventing full user content from being logged.
- Export `parseAiJson` and add unit tests verifying logs do not include the entire response text.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b78d64df50832bbbd158c226e7318f