### PR TITLE
Add messaging for decreased match scores

### DIFF
--- a/client/src/formatMatchMessage.js
+++ b/client/src/formatMatchMessage.js
@@ -4,5 +4,8 @@ export function formatMatchMessage(originalScore = 0, enhancedScore = 0) {
   if (enhancedScore > originalScore) {
     return `Your score improved from ${originalScore}% to ${enhancedScore}%, indicating a ${likelihood} selection likelihood.`;
   }
+  if (enhancedScore < originalScore) {
+    return `Your score decreased from ${originalScore}% to ${enhancedScore}%, indicating a ${likelihood} selection likelihood.`;
+  }
   return `Your score remains at ${enhancedScore}%, indicating a ${likelihood} selection likelihood.`;
 }


### PR DESCRIPTION
## Summary
- handle decreased match score when enhancedScore drops below originalScore

## Testing
- `npm test`
- `npm --prefix client test`

------
https://chatgpt.com/codex/tasks/task_e_68b7c5009d68832badd1902ab1be8c55