### PR TITLE
Normalize certification URLs before comparison

### DIFF
--- a/server.js
+++ b/server.js
@@ -757,6 +757,12 @@ function normalizeHeading(heading = '') {
   return normalized;
 }
 
+function normalizeUrl(url = '') {
+  let result = String(url).trim();
+  while (result.endsWith('/')) result = result.slice(0, -1);
+  return result;
+}
+
 
 function ensureRequiredSections(
   data,
@@ -1013,8 +1019,11 @@ function ensureRequiredSections(
   });
 
   if (credlyProfileUrl) {
+    const normalizedProfile = normalizeUrl(credlyProfileUrl);
     const alreadyHasProfile = certItems.some((item) =>
-      item.some((t) => t.type === 'link' && t.href === credlyProfileUrl)
+      item.some(
+        (t) => t.type === 'link' && normalizeUrl(t.href) === normalizedProfile
+      )
     );
     if (!alreadyHasProfile) {
       certItems.push([

--- a/tests/ensureRequiredSections.test.js
+++ b/tests/ensureRequiredSections.test.js
@@ -251,6 +251,26 @@ describe('ensureRequiredSections certifications merging', () => {
     });
   });
 
+  test('deduplicates credly profile link when URLs differ only by trailing slash', () => {
+    const resumeCertifications = [
+      { name: 'Credly Profile', url: 'https://credly.com/user/' }
+    ];
+    const ensured = ensureRequiredSections(
+      { sections: [] },
+      { resumeCertifications, credlyProfileUrl: 'https://credly.com/user' }
+    );
+    const certSection = ensured.sections.find(
+      (s) => s.heading === 'Certification'
+    );
+    expect(certSection.items).toHaveLength(1);
+    const link = certSection.items[0][1];
+    expect(link).toMatchObject({
+      type: 'link',
+      text: 'Credly Profile',
+      href: 'https://credly.com/user/'
+    });
+  });
+
     test('removes certification section if no certificates remain', () => {
       const data = { sections: [{ heading: 'Certification', items: [] }] };
       const ensured = ensureRequiredSections(data, {});


### PR DESCRIPTION
## Summary
- Add URL normalization helper to trim trailing slashes from credential links
- Compare normalized URLs to avoid duplicate Credly profile entries
- Test certification deduplication when profile URL includes trailing slash

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7c58f9f98832ba6c6e11fe13b7161