### PR TITLE
Default CV templates to 2025 and update tests

### DIFF
--- a/server.js
+++ b/server.js
@@ -147,34 +147,9 @@ function selectTemplates({
     if (!coverTemplate1 && clTemplates[0]) coverTemplate1 = clTemplates[0];
     if (!coverTemplate2 && clTemplates[1]) coverTemplate2 = clTemplates[1];
   }
-  // Always include 'ucmo' and ensure the other template is from a different group
-  const UCMO_GROUP = CV_TEMPLATE_GROUPS['ucmo'];
-  const pickOther = (exclude = []) => {
-    const candidates = CV_TEMPLATES.filter(
-      (t) =>
-        t !== 'ucmo' &&
-        !exclude.includes(t) &&
-        CV_TEMPLATE_GROUPS[t] !== UCMO_GROUP
-    );
-    return candidates[Math.floor(Math.random() * candidates.length)] || 'modern';
-  };
-
-  const userOther = [template1, template2].find(
-    (t) => t && t !== 'ucmo' && CV_TEMPLATE_GROUPS[t] !== UCMO_GROUP
-  );
-
-  if (template1 === 'ucmo') {
-    template2 = userOther || pickOther([template1]);
-  } else if (template2 === 'ucmo') {
-    template1 = userOther || pickOther([template2]);
-  } else {
-    template1 = 'ucmo';
-    template2 = userOther || pickOther([template1]);
-  }
-
-  if (template1 === template2) {
-    template2 = pickOther([template1]);
-  }
+  // Default CV templates to '2025' unless explicitly provided
+  if (!template1) template1 = '2025';
+  if (!template2) template2 = '2025';
 
   if (!coverTemplate1 && !coverTemplate2) {
     coverTemplate1 = CL_TEMPLATES[0];

--- a/tests/__snapshots__/selectTemplatesGroup.test.js.snap
+++ b/tests/__snapshots__/selectTemplatesGroup.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`selectTemplates enforces ucmo and distinct groups heading styles are bold across templates 1`] = `
+exports[`selectTemplates defaults and overrides heading styles are bold across templates 1`] = `
 {
   "2025": "h2 {\n    font-size: 1.5rem;\n    font-weight: 700;\n    margin-top: 2.5rem;\n    margin-bottom: 0.75rem;\n    color: var(--accent);\n    border-bottom: 2px solid var(--accent);\n    padding-bottom: 0.25rem;\n  }",
   "modern": "h2 { font-size: 20px; margin: 24px 0 12px; border-bottom: 1px solid #2a9d8f; padding-bottom: 4px; font-weight: 700; }",

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -4,9 +4,7 @@ import {
   parseContent,
   CV_TEMPLATES,
   CL_TEMPLATES,
-  selectTemplates,
-  CONTRASTING_PAIRS,
-  CV_TEMPLATE_GROUPS
+  selectTemplates
 } from '../server.js';
 import puppeteer from 'puppeteer';
 import pdfParse from 'pdf-parse/lib/pdf-parse.js';
@@ -102,29 +100,26 @@ describe('generatePdf and parsing', () => {
     }
   );
 
-  test('selectTemplates defaults to ucmo and contrasting style', () => {
+  test('selectTemplates defaults to 2025 templates', () => {
     const { template1, template2, coverTemplate1, coverTemplate2 } = selectTemplates();
-    expect(template1).toBe('ucmo');
-    expect(template2).not.toBe('ucmo');
-    expect(CV_TEMPLATE_GROUPS[template2]).not.toBe(CV_TEMPLATE_GROUPS['ucmo']);
+    expect(template1).toBe('2025');
+    expect(template2).toBe('2025');
+    expect(CV_TEMPLATES).toContain(template1);
     expect(CV_TEMPLATES).toContain(template2);
     expect(coverTemplate1).not.toBe(coverTemplate2);
     expect(CL_TEMPLATES).toContain(coverTemplate1);
     expect(CL_TEMPLATES).toContain(coverTemplate2);
   });
 
-  test('providing one template still includes ucmo', () => {
+  test('providing one template defaults the other to 2025', () => {
     const { template1, template2, coverTemplate1, coverTemplate2 } = selectTemplates({
       template1: CV_TEMPLATES[0],
       coverTemplate1: CL_TEMPLATES[0]
     });
-    expect([template1, template2]).toContain('ucmo');
-    const other = template1 === 'ucmo' ? template2 : template1;
-    expect(other).toBe(CV_TEMPLATES[0]);
-    expect(CV_TEMPLATE_GROUPS[other]).not.toBe(CV_TEMPLATE_GROUPS['ucmo']);
+    expect(template1).toBe(CV_TEMPLATES[0]);
+    expect(template2).toBe('2025');
     expect(coverTemplate1).toBe(CL_TEMPLATES[0]);
     expect(coverTemplate2).not.toBe(coverTemplate1);
-    expect(CV_TEMPLATES).toContain(template1);
     expect(CV_TEMPLATES).toContain(template2);
     expect(CL_TEMPLATES).toContain(coverTemplate2);
   });

--- a/tests/selectTemplatesGroup.test.js
+++ b/tests/selectTemplatesGroup.test.js
@@ -1,38 +1,27 @@
-import { selectTemplates, CV_TEMPLATES, CV_TEMPLATE_GROUPS } from '../server.js';
+import { selectTemplates, CV_TEMPLATES } from '../server.js';
 import fs from 'fs/promises';
 import path from 'path';
 
-describe('selectTemplates enforces ucmo and distinct groups', () => {
-  test.each(CV_TEMPLATES)('includes ucmo when both templates are %s', (tpl) => {
-    const { template1, template2 } = selectTemplates({ template1: tpl, template2: tpl });
-    expect([template1, template2]).toContain('ucmo');
-    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
-      CV_TEMPLATE_GROUPS[template2]
-    );
-    expect(template1).not.toBe(template2);
+describe('selectTemplates defaults and overrides', () => {
+  test('defaults to 2025 when no templates provided', () => {
+    const { template1, template2 } = selectTemplates();
+    expect(template1).toBe('2025');
+    expect(template2).toBe('2025');
   });
 
-  test('overrides when neither input is ucmo', () => {
+  test('overrides when templates are provided', () => {
     const { template1, template2 } = selectTemplates({
       template1: 'modern',
       template2: 'professional'
     });
-    expect([template1, template2]).toContain('ucmo');
-    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
-      CV_TEMPLATE_GROUPS[template2]
-    );
-    expect(template1).not.toBe(template2);
+    expect(template1).toBe('modern');
+    expect(template2).toBe('professional');
   });
 
-  test('random selection yields ucmo and distinct groups', () => {
-    for (let i = 0; i < 20; i++) {
-      const { template1, template2 } = selectTemplates();
-      expect([template1, template2]).toContain('ucmo');
-      expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
-        CV_TEMPLATE_GROUPS[template2]
-      );
-      expect(template1).not.toBe(template2);
-    }
+  test('single template defaults the other to 2025', () => {
+    const { template1, template2 } = selectTemplates({ template1: 'modern' });
+    expect(template1).toBe('modern');
+    expect(template2).toBe('2025');
   });
 
   test('heading styles are bold across templates', async () => {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -342,7 +342,7 @@ describe('/api/process-cv', () => {
     ]);
   });
 
-  test('uses provided template and ucmo', async () => {
+  test('uses provided templates', async () => {
     generateContentMock.mockReset();
     generateContentMock
       .mockResolvedValueOnce({
@@ -367,8 +367,8 @@ describe('/api/process-cv', () => {
 
     const calls = serverModule.generatePdf.mock.calls;
     const resumeCalls = calls.filter(([, , opts]) => opts && opts.resumeExperience);
-    expect(resumeCalls[0][1]).toBe('ucmo');
-    expect(resumeCalls[1][1]).toBe('modern');
+    expect(resumeCalls[0][1]).toBe('modern');
+    expect(resumeCalls[1][1]).toBe('professional');
   });
 
   test('uses templates array', async () => {
@@ -390,12 +390,12 @@ describe('/api/process-cv', () => {
       .post('/api/process-cv')
       .field('jobDescriptionUrl', 'http://example.com')
       .field('linkedinProfileUrl', 'http://linkedin.com/in/example')
-      .field('templates', JSON.stringify(['ucmo', 'vibrant']))
+      .field('templates', JSON.stringify(['modern', 'vibrant']))
       .attach('resume', Buffer.from('dummy'), 'resume.pdf');
 
     const calls = serverModule.generatePdf.mock.calls;
     const resumeCalls = calls.filter(([, , opts]) => opts && opts.resumeExperience);
-    expect(resumeCalls[0][1]).toBe('ucmo');
+    expect(resumeCalls[0][1]).toBe('modern');
     expect(resumeCalls[1][1]).toBe('vibrant');
   });
 


### PR DESCRIPTION
## Summary
- default `selectTemplates` to use '2025' for both templates unless overridden
- drop hard-coded ucmo selection and simplify template logic
- refresh tests for new defaults and template override behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7ce1b9d3c832b973e7457e56e69fc