### PR TITLE
refine match message for non-improvements

### DIFF
--- a/client/src/formatMatchMessage.js
+++ b/client/src/formatMatchMessage.js
@@ -4,8 +4,5 @@ export function formatMatchMessage(originalScore = 0, enhancedScore = 0) {
   if (enhancedScore > originalScore) {
     return `Your score improved from ${originalScore}% to ${enhancedScore}%, indicating a ${likelihood} selection likelihood.`;
   }
-  if (enhancedScore < originalScore) {
-    return `Your score decreased from ${originalScore}% to ${enhancedScore}%, indicating a ${likelihood} selection likelihood.`;
-  }
-  return `Your score remains at ${enhancedScore}%, indicating a ${likelihood} selection likelihood.`;
+  return 'Unable to improve score';
 }

--- a/tests/matchMessaging.test.js
+++ b/tests/matchMessaging.test.js
@@ -30,7 +30,7 @@ describe('match messaging and skills', () => {
     expect(addedSkills).toEqual([]);
     expect(best.newSkills).toEqual(['a']);
     expect(formatMatchMessage(original.score, best.score)).toBe(
-      'Your score remains at 50%, indicating a Medium selection likelihood.'
+      'Unable to improve score'
     );
   });
 });


### PR DESCRIPTION
## Summary
- return success message only when enhanced score exceeds original
- emit brief failure notice when score can't be improved
- adjust tests for new messaging

## Testing
- `npm test tests/matchMessaging.test.js` *(fails: Cannot find module '@aws-sdk/s3-request-presigner')*


------
https://chatgpt.com/codex/tasks/task_e_68b7d06f6fb0832babde3393ecd35956