### PR TITLE
Validate OpenAI instructions before request

### DIFF
--- a/openaiClient.js
+++ b/openaiClient.js
@@ -43,6 +43,9 @@ export async function requestEnhancedCV({
   credlyFileId,
   instructions,
 }) {
+  if (typeof instructions !== 'string' || !instructions.trim()) {
+    throw new Error('instructions must be a non-empty string');
+  }
   const client = await getClient();
   const content = [
     { type: 'input_text', text: instructions },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "moduleNameMapper": {
       "^@google/generative-ai$": "<rootDir>/tests/mocks/google-generative-ai.js",
       "^@aws-sdk/client-dynamodb$": "<rootDir>/tests/mocks/aws-sdk-client-dynamodb.js",
+      "^@aws-sdk/s3-request-presigner$": "<rootDir>/tests/mocks/aws-sdk-s3-request-presigner.js",
       "^openai$": "<rootDir>/tests/mocks/openai.js"
     }
   }

--- a/tests/mocks/aws-sdk-s3-request-presigner.js
+++ b/tests/mocks/aws-sdk-s3-request-presigner.js
@@ -1,0 +1,5 @@
+import { jest } from '@jest/globals';
+export const getSignedUrl = jest.fn(async (_client, command) => {
+  const key = command?.input?.Key || '';
+  return `https://example.com/${key}`;
+});

--- a/tests/openaiClientInstructions.test.js
+++ b/tests/openaiClientInstructions.test.js
@@ -1,0 +1,9 @@
+import { requestEnhancedCV } from '../openaiClient.js';
+import { createResponse } from './mocks/openai.js';
+
+test('throws when instructions missing', async () => {
+  await expect(
+    requestEnhancedCV({ cvFileId: 'cv', jobDescFileId: 'jd' })
+  ).rejects.toThrow('instructions must be a non-empty string');
+  expect(createResponse).not.toHaveBeenCalled();
+});

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -7,7 +7,7 @@ const mockS3Send = jest.fn().mockResolvedValue({});
 jest.unstable_mockModule('@aws-sdk/client-s3', () => ({
   S3Client: jest.fn(() => ({ send: mockS3Send })),
   PutObjectCommand: jest.fn((input) => ({ input })),
-  GetObjectCommand: jest.fn()
+  GetObjectCommand: jest.fn((input) => ({ input }))
 }));
 
 jest.unstable_mockModule('@aws-sdk/client-secrets-manager', () => ({


### PR DESCRIPTION
## Summary
- Ensure OpenAI requests include non-empty instructions input
- Mock AWS S3 presigner and add test for missing instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7f7ed91f0832b950095c67151c4df