### PR TITLE
Include candidate name in S3 prefix

### DIFF
--- a/server.js
+++ b/server.js
@@ -2128,7 +2128,6 @@ app.post('/api/process-cv', (req, res, next) => {
   });
 }, async (req, res) => {
   const jobId = Date.now().toString();
-  const date = new Date().toISOString().slice(0, 10);
   const s3 = new S3Client({ region });
   let bucket;
   let secrets;
@@ -2184,9 +2183,10 @@ app.post('/api/process-cv', (req, res, next) => {
       .json({ error: `Uploaded document classified as ${docType}; please upload a resume` });
   }
   const applicantName = extractName(text);
-  const sanitizedName = sanitizeName(applicantName);
+  let sanitizedName = sanitizeName(applicantName);
+  if (!sanitizedName) sanitizedName = 'candidate';
   const ext = path.extname(req.file.originalname).toLowerCase();
-  const prefix = `first/${date}/${sanitizedName}/`;
+  const prefix = `sessions/${sanitizedName}/${jobId}/`;
   const logKey = `${prefix}logs/processing.jsonl`;
 
   // Store raw file to configured bucket

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -207,7 +207,7 @@ describe('/api/process-cv', () => {
       .toLowerCase();
 
     res2.body.urls.forEach(({ type, url }) => {
-      expect(url).toContain('/first/');
+      expect(url).toContain('/sessions/');
       expect(url).toContain(`/${sanitized}/`);
       if (type.startsWith('cover_letter')) {
         expect(url).toContain('/generated/cover_letter/');
@@ -221,7 +221,7 @@ describe('/api/process-cv', () => {
       .filter((k) => k && k.endsWith('.pdf'));
     expect(pdfKeys).toHaveLength(5);
     pdfKeys.forEach((k) => {
-      expect(k).toContain('first/');
+      expect(k).toContain('sessions/');
       expect(k).toContain(`/${sanitized}/`);
     });
 


### PR DESCRIPTION
## Summary
- Build S3 session prefix with candidate's sanitized name and job ID
- Default missing candidate name to `candidate`
- Update tests to match new session key format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b88a921d80832b89efad27c7960d26