### PR TITLE
Include sanitized applicant name in session paths

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -207,8 +207,7 @@ describe('/api/process-cv', () => {
       .toLowerCase();
 
     res2.body.urls.forEach(({ type, url }) => {
-      expect(url).toContain('/sessions/');
-      expect(url).toContain(`/${sanitized}/`);
+      expect(url).toContain(`/sessions/${sanitized}/`);
       if (type.startsWith('cover_letter')) {
         expect(url).toContain('/generated/cover_letter/');
       } else {
@@ -221,8 +220,7 @@ describe('/api/process-cv', () => {
       .filter((k) => k && k.endsWith('.pdf'));
     expect(pdfKeys).toHaveLength(5);
     pdfKeys.forEach((k) => {
-      expect(k).toContain('sessions/');
-      expect(k).toContain(`/${sanitized}/`);
+      expect(k).toContain(`sessions/${sanitized}/`);
     });
 
     const putCall = mockDynamoSend.mock.calls.find(


### PR DESCRIPTION
## Summary
- Verify output URLs include a full `/sessions/{name}/` segment
- Check that uploaded PDF keys embed `sessions/{name}/`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b88b727778832b9192f33ee9ba0729