### PR TITLE
Use jobId as DynamoDB partition key

### DIFF
--- a/server.js
+++ b/server.js
@@ -2522,10 +2522,10 @@ app.post('/api/process-cv', (req, res, next) => {
             new CreateTableCommand({
               TableName: tableName,
               AttributeDefinitions: [
-                { AttributeName: 'linkedinProfileUrl', AttributeType: 'S' }
+                { AttributeName: 'jobId', AttributeType: 'S' }
               ],
               KeySchema: [
-                { AttributeName: 'linkedinProfileUrl', KeyType: 'HASH' }
+                { AttributeName: 'jobId', KeyType: 'HASH' }
               ],
               BillingMode: 'PAY_PER_REQUEST'
             })
@@ -2548,6 +2548,7 @@ app.post('/api/process-cv', (req, res, next) => {
       new PutItemCommand({
         TableName: tableName,
         Item: {
+          jobId: { S: jobId },
           linkedinProfileUrl: { S: linkedinProfileUrl },
           candidateName: { S: applicantName },
           timestamp: { S: new Date().toISOString() },

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -146,6 +146,15 @@ describe('/api/process-cv', () => {
       'DescribeTableCommand',
       'PutItemCommand'
     ]);
+    const createCall = mockDynamoSend.mock.calls.find(
+      ([cmd]) => cmd.__type === 'CreateTableCommand'
+    );
+    expect(createCall[0].input.AttributeDefinitions).toEqual([
+      { AttributeName: 'jobId', AttributeType: 'S' }
+    ]);
+    expect(createCall[0].input.KeySchema).toEqual([
+      { AttributeName: 'jobId', KeyType: 'HASH' }
+    ]);
 
     setupDefaultDynamoMock();
     mockDynamoSend.mockClear();
@@ -228,6 +237,7 @@ describe('/api/process-cv', () => {
     );
     expect(putCall).toBeTruthy();
     expect(putCall[0].input.TableName).toBe('ResumeForge');
+    expect(putCall[0].input.Item.jobId.S).toMatch(/\d+/);
     expect(putCall[0].input.Item.linkedinProfileUrl.S).toBe(
       'http://linkedin.com/in/example'
     );


### PR DESCRIPTION
## Summary
- make DynamoDB table use `jobId` as partition key
- store `jobId` with each resume record and include in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b88cb380c0832bb96e8119a26904f2