### PR TITLE
Ensure latest experience title matches job description

### DIFF
--- a/server.js
+++ b/server.js
@@ -951,9 +951,6 @@ function ensureRequiredSections(
         const bDate = Date.parse(b.endDate || b.startDate || '');
         return (isNaN(bDate) ? 0 : bDate) - (isNaN(aDate) ? 0 : aDate);
       });
-      if (jobTitle && additions.length && existing.length === 0) {
-        additions[0].title = jobTitle;
-      }
 
       const format = (exp) => {
         const datePart =
@@ -983,6 +980,19 @@ function ensureRequiredSections(
         const bDate = Date.parse(b.exp.endDate || b.exp.startDate || '');
         return (isNaN(bDate) ? 0 : bDate) - (isNaN(aDate) ? 0 : aDate);
       });
+
+      if (jobTitle && all.length) {
+        all[0].exp.title = jobTitle;
+        const key = [
+          all[0].exp.company || '',
+          all[0].exp.title || '',
+          all[0].exp.startDate || '',
+          all[0].exp.endDate || ''
+        ]
+          .map((s) => s.toLowerCase())
+          .join('|');
+        all[0] = toTokens(all[0].exp, key);
+      }
 
       if (all.length || unparsedItems.length) {
         section.items = [

--- a/tests/ensureRequiredSections.test.js
+++ b/tests/ensureRequiredSections.test.js
@@ -88,6 +88,37 @@ describe('ensureRequiredSections work experience merging', () => {
       );
     expect(placeholders).not.toContain('Information not provided');
   });
+
+  test('overwrites latest existing role title with jobTitle', () => {
+    const latest = parseLine('- Dev at Beta (2022 – 2023)');
+    const older = parseLine('- Engineer at Acme (2020 – 2022)');
+    const data = {
+      sections: [{ heading: 'Work Experience', items: [latest, older] }]
+    };
+    const ensured = ensureRequiredSections(data, { jobTitle: 'Senior Dev' });
+    const lines = ensured.sections[0].items.map((tokens) =>
+      tokens.map((t) => t.text || '').join('').trim()
+    );
+    expect(lines[0]).toBe('Senior Dev at Beta (2022 – 2023)');
+    expect(lines[1]).toBe('Engineer at Acme (2020 – 2022)');
+  });
+
+  test('overwrites latest merged role title with jobTitle', () => {
+    const existingToken = parseLine('- Engineer at Acme (2020 – 2021)');
+    const data = { sections: [{ heading: 'Work Experience', items: [existingToken] }] };
+    const resumeExperience = [
+      { company: 'Beta', title: 'Developer', startDate: '2022', endDate: '2023' }
+    ];
+    const ensured = ensureRequiredSections(data, {
+      resumeExperience,
+      jobTitle: 'Lead Developer'
+    });
+    const lines = ensured.sections[0].items.map((tokens) =>
+      tokens.map((t) => t.text || '').join('').trim()
+    );
+    expect(lines[0]).toBe('Lead Developer at Beta (2022 – 2023)');
+    expect(lines[1]).toBe('Engineer at Acme (2020 – 2021)');
+  });
 });
 
 describe('ensureRequiredSections certifications merging', () => {


### PR DESCRIPTION
## Summary
- Always replace the most recent experience title with the provided job description title.
- Add tests covering job title replacement for existing and newly merged experiences.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8ec741d7c832bb433f079c14b8f14