### PR TITLE
feat: add configurable request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The server relies on the following environment variables:
   "SECRET_ID": "your-secret-id",
   "PORT": "3000",
   "GEMINI_API_KEY": "<api-key>",
-  "S3_BUCKET": "resume-forge-data"
+  "S3_BUCKET": "resume-forge-data",
+  "REQUEST_TIMEOUT_MS": "5000"
 }
 ```
 
@@ -22,6 +23,8 @@ JSON structure. If neither `SECRET_ID` nor `local-secrets.json` is present, the 
 
 `S3_BUCKET` defines where uploads and logs are stored. If it is not set in the environment or secret, the server falls back to
 `resume-forge-data`, which is suitable for local development.
+
+`REQUEST_TIMEOUT_MS` sets the timeout in milliseconds for outbound HTTP requests when fetching external profiles and job descriptions. It defaults to `5000`.
 
 `GEMINI_API_KEY` supplies the Google Gemini API key. Set it directly in your environment for development or include it in the
 secret.

--- a/server.js
+++ b/server.js
@@ -184,12 +184,13 @@ function selectTemplates({
 }
 
 const region = process.env.AWS_REGION || 'ap-south-1';
+const REQUEST_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS, 10) || 5000;
 
 async function fetchLinkedInProfile(url) {
   const valid = validateUrl(url, ['linkedin.com']);
   if (!valid) throw new Error('Invalid LinkedIn URL');
   try {
-    const { data: html } = await axios.get(valid);
+    const { data: html } = await axios.get(valid, { timeout: REQUEST_TIMEOUT_MS });
     const strip = (s) => s.replace(/<[^>]+>/g, '').trim();
     const headlineMatch =
       html.match(/<title>([^<]*)<\/title>/i) || html.match(/"headline":"(.*?)"/i);
@@ -270,7 +271,7 @@ async function fetchCredlyProfile(url) {
   const valid = validateUrl(url, ['credly.com']);
   if (!valid) throw new Error('Invalid Credly URL');
   try {
-    const { data: html } = await axios.get(valid);
+    const { data: html } = await axios.get(valid, { timeout: REQUEST_TIMEOUT_MS });
     const strip = (s) => s.replace(/<[^>]+>/g, '').trim();
     const badgeRegex = /<div[^>]*class=["'][^"']*badge[^"']*["'][^>]*>([\s\S]*?)<\/div>/gi;
     const badges = [];
@@ -2316,7 +2317,9 @@ app.post('/api/process-cv', (req, res, next) => {
       message: `template1=${template1}; template2=${template2}`
     });
 
-    const { data: jobDescriptionHtml } = await axios.get(jobDescriptionUrl);
+    const { data: jobDescriptionHtml } = await axios.get(jobDescriptionUrl, {
+      timeout: REQUEST_TIMEOUT_MS
+    });
     await logEvent({ s3, bucket, key: logKey, jobId, event: 'fetched_job_description' });
     const {
       title: jobTitle,


### PR DESCRIPTION
## Summary
- make HTTP request timeout configurable through REQUEST_TIMEOUT_MS env var
- apply timeout to LinkedIn, Credly, and job description fetches
- document REQUEST_TIMEOUT_MS in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b949538388832badd7b1046daf2010