### PR TITLE
Use try/finally for Puppeteer browser cleanup

### DIFF
--- a/server.js
+++ b/server.js
@@ -1615,12 +1615,12 @@ let generatePdf = async function (
       html = html.replace('</head>', `<style>${css}</style></head>`);
     }
   }
+  let browser;
   try {
-    const browser = await puppeteer.launch({ args: ['--no-sandbox'] });
+    browser = await puppeteer.launch({ args: ['--no-sandbox'] });
     const page = await browser.newPage();
     await page.setContent(html, { waitUntil: 'networkidle0' });
     const pdfBuffer = await page.pdf({ format: 'A4', printBackground: true });
-    await browser.close();
     return pdfBuffer;
   } catch (err) {
     // Fallback for environments without Chromium dependencies
@@ -1806,6 +1806,8 @@ let generatePdf = async function (
       });
       doc.end();
     });
+  } finally {
+    if (browser) await browser.close();
   }
 };
 


### PR DESCRIPTION
## Summary
- ensure generatePdf always closes the Puppeteer browser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b94c4b2174832b92ba2edcbf7ba33a