### PR TITLE
Log AI generation failures with job metadata

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -320,6 +320,22 @@ export default function registerProcessCv(app) {
           improvementSummary = parsed.improvement_summary;
         }
       } catch (e) {
+        const responseMeta = e.response
+          ? `; status=${e.response.status}; data=${JSON.stringify(e.response.data)}`
+          : '';
+        try {
+          await logEvent({
+            s3,
+            bucket,
+            key: logKey,
+            jobId,
+            event: 'ai_generation_failed',
+            level: 'error',
+            message: `Failed to generate enhanced CV: ${e.message}${responseMeta}`,
+          });
+        } catch (logErr) {
+          console.error('failed to log ai generation error', logErr);
+        }
         console.error('Failed to generate enhanced CV:', e);
       }
 


### PR DESCRIPTION
## Summary
- log AI generation errors to S3 with `ai_generation_failed` event
- include response status/data in failure message for easier debugging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9c14ab944832babe903c7a2f6f58a