### PR TITLE
Ensure default CV templates are contrasting

### DIFF
--- a/server.js
+++ b/server.js
@@ -175,9 +175,28 @@ function selectTemplates({
     if (!coverTemplate1 && clTemplates[0]) coverTemplate1 = clTemplates[0];
     if (!coverTemplate2 && clTemplates[1]) coverTemplate2 = clTemplates[1];
   }
-  // Default CV templates to '2025' unless explicitly provided
-  if (!template1) template1 = '2025';
-  if (!template2) template2 = '2025';
+  // Helper to pick a contrasting template based on group
+  const pickContrasting = (tpl) => {
+    const group = CV_TEMPLATE_GROUPS[tpl];
+    const options = CV_TEMPLATES.filter(
+      (t) => t !== tpl && CV_TEMPLATE_GROUPS[t] !== group
+    );
+    return options[Math.floor(Math.random() * options.length)] || tpl;
+  };
+
+  if (!template1 && !template2) {
+    [template1, template2] =
+      CONTRASTING_PAIRS[Math.floor(Math.random() * CONTRASTING_PAIRS.length)];
+  } else {
+    if (!template1) template1 = '2025';
+    if (!template2) template2 = pickContrasting(template1);
+    if (
+      template1 === template2 ||
+      CV_TEMPLATE_GROUPS[template1] === CV_TEMPLATE_GROUPS[template2]
+    ) {
+      template2 = pickContrasting(template1);
+    }
+  }
 
   if (!coverTemplate1 && !coverTemplate2) {
     coverTemplate1 = CL_TEMPLATES[0];

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -1,5 +1,10 @@
 import { jest } from '@jest/globals';
-import { CV_TEMPLATES, CL_TEMPLATES, selectTemplates } from '../server.js';
+import {
+  CV_TEMPLATES,
+  CL_TEMPLATES,
+  selectTemplates,
+  CV_TEMPLATE_GROUPS
+} from '../server.js';
 import { generatePdf } from '../services/generatePdf.js';
 import { parseContent } from '../services/parseContent.js';
 import puppeteer from 'puppeteer';
@@ -96,24 +101,29 @@ describe('generatePdf and parsing', () => {
     }
   );
 
-  test('selectTemplates defaults to 2025 templates', () => {
+  test('selectTemplates returns contrasting templates by default', () => {
     const { template1, template2, coverTemplate1, coverTemplate2 } = selectTemplates();
-    expect(template1).toBe('2025');
-    expect(template2).toBe('2025');
     expect(CV_TEMPLATES).toContain(template1);
     expect(CV_TEMPLATES).toContain(template2);
+    expect(template1).not.toBe(template2);
+    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
+      CV_TEMPLATE_GROUPS[template2]
+    );
     expect(coverTemplate1).not.toBe(coverTemplate2);
     expect(CL_TEMPLATES).toContain(coverTemplate1);
     expect(CL_TEMPLATES).toContain(coverTemplate2);
   });
 
-  test('providing one template defaults the other to 2025', () => {
+  test('providing one template yields a contrasting default', () => {
     const { template1, template2, coverTemplate1, coverTemplate2 } = selectTemplates({
       template1: CV_TEMPLATES[0],
       coverTemplate1: CL_TEMPLATES[0]
     });
     expect(template1).toBe(CV_TEMPLATES[0]);
-    expect(template2).toBe('2025');
+    expect(template2).not.toBe(template1);
+    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
+      CV_TEMPLATE_GROUPS[template2]
+    );
     expect(coverTemplate1).toBe(CL_TEMPLATES[0]);
     expect(coverTemplate2).not.toBe(coverTemplate1);
     expect(CV_TEMPLATES).toContain(template2);

--- a/tests/selectTemplatesGroup.test.js
+++ b/tests/selectTemplatesGroup.test.js
@@ -1,12 +1,16 @@
-import { selectTemplates, CV_TEMPLATES } from '../server.js';
+import { selectTemplates, CV_TEMPLATES, CV_TEMPLATE_GROUPS } from '../server.js';
 import fs from 'fs/promises';
 import path from 'path';
 
 describe('selectTemplates defaults and overrides', () => {
-  test('defaults to 2025 when no templates provided', () => {
+  test('defaults to contrasting templates when none provided', () => {
     const { template1, template2 } = selectTemplates();
-    expect(template1).toBe('2025');
-    expect(template2).toBe('2025');
+    expect(CV_TEMPLATES).toContain(template1);
+    expect(CV_TEMPLATES).toContain(template2);
+    expect(template1).not.toBe(template2);
+    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
+      CV_TEMPLATE_GROUPS[template2]
+    );
   });
 
   test('overrides when templates are provided', () => {
@@ -18,10 +22,13 @@ describe('selectTemplates defaults and overrides', () => {
     expect(template2).toBe('professional');
   });
 
-  test('single template defaults the other to 2025', () => {
+  test('single template defaults the other to a contrasting template', () => {
     const { template1, template2 } = selectTemplates({ template1: 'modern' });
     expect(template1).toBe('modern');
-    expect(template2).toBe('2025');
+    expect(template2).not.toBe('modern');
+    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
+      CV_TEMPLATE_GROUPS[template2]
+    );
   });
 
   test('heading styles are bold across templates', async () => {


### PR DESCRIPTION
## Summary
- Pick a random contrasting CV template pair when none are provided
- Guarantee the second CV template contrasts with the first
- Update tests for new template selection behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9cb449320832b95babef96c7ab199