### PR TITLE
Use crypto.randomUUID for job identifiers

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import axios from 'axios';
+import crypto from 'crypto';
 import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import {
@@ -48,7 +49,7 @@ export default function registerProcessCv(app) {
       next();
     });
   }, async (req, res) => {
-    const jobId = Date.now().toString();
+    const jobId = crypto.randomUUID();
     const s3 = new S3Client({ region });
     let bucket;
     let secrets;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -240,7 +240,9 @@ describe('/api/process-cv', () => {
     );
     expect(putCall).toBeTruthy();
     expect(putCall[0].input.TableName).toBe('ResumeForge');
-    expect(putCall[0].input.Item.jobId.S).toMatch(/\d+/);
+    expect(putCall[0].input.Item.jobId.S).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
     expect(putCall[0].input.Item.linkedinProfileUrl.S).toBe(
       'https://linkedin.com/in/example'
     );


### PR DESCRIPTION
## Summary
- generate job IDs with `crypto.randomUUID` instead of `Date.now`
- ensure S3 prefixes and log events propagate the UUID-based job ID
- update server test to expect UUID format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba4cee0938832bbc9d949ab65f96d5