### PR TITLE
Avoid duplicate Credly profile certifications

### DIFF
--- a/services/parseContent.js
+++ b/services/parseContent.js
@@ -520,17 +520,37 @@ function ensureRequiredSections(
     const text = cert.provider
       ? `${cert.name} - ${cert.provider}`
       : cert.name;
-    tokens.push({ type: 'link', text, href: cert.url });
+    if (cert.url) {
+      tokens.push({ type: 'link', text, href: cert.url });
+    } else {
+      tokens.push({ type: 'paragraph', text });
+    }
     return tokens;
   });
 
   if (credlyProfileUrl) {
     const normalizedProfile = normalizeUrl(credlyProfileUrl);
-    const alreadyHasProfile = certItems.some((item) =>
-      item.some(
-        (t) => t.type === 'link' && normalizeUrl(t.href) === normalizedProfile
-      )
-    );
+    let alreadyHasProfile = false;
+    certItems.forEach((item) => {
+      item.forEach((t, idx) => {
+        const textMatch = (t.text || '').trim().toLowerCase() === 'credly profile';
+        const hrefMatch =
+          t.type === 'link' && normalizeUrl(t.href || '') === normalizedProfile;
+        if (hrefMatch || textMatch) {
+          alreadyHasProfile = true;
+          if (t.type === 'link') {
+            t.href = credlyProfileUrl;
+            t.text = 'Credly Profile';
+          } else {
+            item[idx] = {
+              type: 'link',
+              text: 'Credly Profile',
+              href: credlyProfileUrl,
+            };
+          }
+        }
+      });
+    });
     if (!alreadyHasProfile) {
       certItems.push([
         { type: 'bullet' },

--- a/tests/ensureRequiredSections.test.js
+++ b/tests/ensureRequiredSections.test.js
@@ -185,7 +185,7 @@ describe('ensureRequiredSections certifications merging', () => {
     const certSection = ensured.sections.find((s) => s.heading === 'Certification');
     expect(certSection.items).toHaveLength(1);
     expect(certSection.items[0][0].type).toBe('bullet');
-    expect(certSection.items[0][1].type).toBe('link');
+    expect(certSection.items[0][1].type).toBe('paragraph');
   });
 
   test('deduplicates existing certification entries', () => {
@@ -298,7 +298,7 @@ describe('ensureRequiredSections certifications merging', () => {
     expect(link).toMatchObject({
       type: 'link',
       text: 'Credly Profile',
-      href: 'https://credly.com/user/'
+      href: 'https://credly.com/user'
     });
   });
 

--- a/tests/parseContent.test.js
+++ b/tests/parseContent.test.js
@@ -458,6 +458,20 @@ describe('parseContent certification normalization and pruning', () => {
     const cert = data.sections.find((s) => s.heading === 'Certification');
     expect(cert).toBeUndefined();
   });
+
+  test('adds a single Credly Profile link when URL provided', () => {
+    const data = parseContent('Jane Doe', {
+      resumeCertifications: [{ name: 'Credly Profile' }],
+      credlyProfileUrl: 'https://credly.com/user'
+    });
+    const cert = data.sections.find((s) => s.heading === 'Certification');
+    expect(cert).toBeTruthy();
+    const links = cert.items
+      .flat()
+      .filter((t) => t.type === 'link' && t.text === 'Credly Profile');
+    expect(links).toHaveLength(1);
+    expect(links[0].href).toBe('https://credly.com/user');
+  });
 });
 
 describe('parseContent defaultHeading option', () => {


### PR DESCRIPTION
## Summary
- Skip link tokens for certifications missing URLs and treat them as plain text
- Deduplicate Credly profile entries by URL or name, upgrading plain text to a single linked profile
- Test Credly profile handling and adjust existing certification tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba510d666c832b8bc11610a672388d