### PR TITLE
Open PDF downloads in new tab

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -223,7 +223,14 @@ function App() {
           return (
             <div key={file.type} className="p-4 bg-gradient-to-r from-white to-purple-50 rounded shadow text-center">
               <p className="mb-2 font-semibold text-purple-800">{label}</p>
-              <a href={file.url} className="text-purple-700 hover:underline">Download PDF</a>
+              <a
+                href={file.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-purple-700 hover:underline"
+              >
+                Download PDF
+              </a>
               <p className="mt-1 text-xs text-purple-600">
                 Link expires in one hour
                 {file.expiresAt && (


### PR DESCRIPTION
## Summary
- Ensure PDF download links open in a new browser tab

## Testing
- `npm test`
- `npm --prefix client test`
- `node -e "const fs=require('fs'); const src=fs.readFileSync('client/src/App.jsx','utf8'); const m=/<a\n\s*href=\{file.url\}\n\s*target=\"_blank\"\n\s*rel=\"noopener noreferrer\"/.test(src); console.log('anchor_has_target_rel:',m);"`

------
https://chatgpt.com/codex/tasks/task_e_68ba5272fcdc832bb45c789cf699698d