### PR TITLE
feat: handle missing fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node server.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "dev": "node server.js",
-    "build": "echo 'No build step'"
+    "copy-fonts": "if [ -d fonts ]; then mkdir -p dist/fonts && cp -r fonts/* dist/fonts/; fi",
+    "build": "npm run copy-fonts && echo 'No build step'"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.432.0",

--- a/services/generatePdf.js
+++ b/services/generatePdf.js
@@ -186,8 +186,11 @@ export async function generatePdf(
       const doc = new PDFDocument({ margin: 50 });
       const buffers = [];
       const fontPaths = {};
+      const fontsDir = path.resolve('fonts');
+      const fontsDirExists = fsSync.existsSync(fontsDir);
 
       function registerFontSafe(name, p) {
+        if (!fontsDirExists) return false;
         if (!fsSync.existsSync(p)) {
           console.warn('Font file missing:', p);
           return false;
@@ -220,31 +223,32 @@ export async function generatePdf(
 
       // Optional font embedding for Roboto/Helvetica families if available
       try {
-        const fontsDir = path.resolve('fonts');
-        const rReg = path.join(fontsDir, 'Roboto-Regular.ttf');
-        const rBold = path.join(fontsDir, 'Roboto-Bold.ttf');
-        const rItalic = path.join(fontsDir, 'Roboto-Italic.ttf');
-        const haveRoboto = [
-          ['Roboto', rReg],
-          ['Roboto-Bold', rBold],
-          ['Roboto-Italic', rItalic]
-        ].map(([name, p]) => registerFontSafe(name, p)).every(Boolean);
-        if (haveRoboto) {
-          ['modern', 'vibrant'].forEach((tpl) => {
-            styleMap[tpl].font = 'Roboto';
-            styleMap[tpl].bold = 'Roboto-Bold';
-            styleMap[tpl].italic = 'Roboto-Italic';
-          });
-        }
+        if (fontsDirExists) {
+          const rReg = path.join(fontsDir, 'Roboto-Regular.ttf');
+          const rBold = path.join(fontsDir, 'Roboto-Bold.ttf');
+          const rItalic = path.join(fontsDir, 'Roboto-Italic.ttf');
+          const haveRoboto = [
+            ['Roboto', rReg],
+            ['Roboto-Bold', rBold],
+            ['Roboto-Italic', rItalic]
+          ].map(([name, p]) => registerFontSafe(name, p)).every(Boolean);
+          if (haveRoboto) {
+            ['modern', 'vibrant'].forEach((tpl) => {
+              styleMap[tpl].font = 'Roboto';
+              styleMap[tpl].bold = 'Roboto-Bold';
+              styleMap[tpl].italic = 'Roboto-Italic';
+            });
+          }
 
-        const hReg = path.join(fontsDir, 'Helvetica.ttf');
-        const hBold = path.join(fontsDir, 'Helvetica-Bold.ttf');
-        const hItalic = path.join(fontsDir, 'Helvetica-Oblique.ttf');
-        [
-          ['Helvetica', hReg],
-          ['Helvetica-Bold', hBold],
-          ['Helvetica-Oblique', hItalic]
-        ].forEach(([name, p]) => registerFontSafe(name, p));
+          const hReg = path.join(fontsDir, 'Helvetica.ttf');
+          const hBold = path.join(fontsDir, 'Helvetica-Bold.ttf');
+          const hItalic = path.join(fontsDir, 'Helvetica-Oblique.ttf');
+          [
+            ['Helvetica', hReg],
+            ['Helvetica-Bold', hBold],
+            ['Helvetica-Oblique', hItalic]
+          ].forEach(([name, p]) => registerFontSafe(name, p));
+        }
       } catch (err) {
         console.warn('Font registration error', err);
       }


### PR DESCRIPTION
## Summary
- skip PDF font registration when `fonts/` directory is absent
- add `copy-fonts` script to copy fonts into build output

## Testing
- `node - <<'NODE'
import puppeteer from 'puppeteer';
puppeteer.launch = () => { throw new Error('fail'); };
const { generatePdf } = await import('./services/generatePdf.js');
const buffer = await generatePdf('John Doe\nExperience at Company');
console.log('PDF bytes', buffer.length);
NODE`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba5b71433c832b8b5d726717ac180c