### PR TITLE
Validate fonts before PDF generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "puppeteer": "^22.9.0",
     "json5": "^2.2.3",
     "openai": "^4.0.0",
-    "ua-parser-js": "^1.0.35"
+    "ua-parser-js": "^1.0.35",
+    "fontkit": "^1.9.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/services/generatePdf.js
+++ b/services/generatePdf.js
@@ -195,10 +195,15 @@ export async function generatePdf(
           console.warn('Font file missing:', p);
           return false;
         }
+        let font;
         try {
-          fontkit.openSync(p); // Validate font file
+          font = fontkit.openSync(p); // Validate font file
         } catch (err) {
           console.warn(`Invalid font file ${p}:`, err.message);
+          return false;
+        }
+        if (font.type !== 'TTF') {
+          console.warn(`Invalid font format ${p}: expected TrueType, got ${font.type}`);
           return false;
         }
         try {

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -677,4 +677,16 @@ describe('generatePdf and parsing', () => {
     expect(css).toMatch(/li\s*{[^}]*line-height:\s*[0-9.]+/);
   });
 
+  test('PDFKit fallback emits no warnings for valid fonts', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const launchSpy = jest
+      .spyOn(puppeteer, 'launch')
+      .mockRejectedValue(new Error('no chromium'));
+    const buffer = await generatePdf('Jane Doe\n- test', 'modern');
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+    launchSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
 });


### PR DESCRIPTION
## Summary
- validate custom fonts with fontkit and only register TrueType fonts
- include fontkit as a direct dependency
- add regression test ensuring PDFKit emits no warnings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba5ee1ea84832bb785977dd0dd8479