### PR TITLE
Log LinkedIn fetch errors

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -268,7 +268,11 @@ export default function registerProcessCv(app) {
           event: 'fetched_linkedin_profile'
         });
       } catch (err) {
-        console.error('LinkedIn profile fetch failed', err);
+        console.error(
+          'LinkedIn profile fetch failed',
+          err.message,
+          err.status
+        );
         await logEvent({
           s3,
           bucket,
@@ -276,7 +280,7 @@ export default function registerProcessCv(app) {
           jobId,
           event: 'linkedin_profile_fetch_failed',
           level: 'error',
-          message: err.message
+          message: err.message + (err.status ? ` (status ${err.status})` : '')
         });
       }
 

--- a/server.js
+++ b/server.js
@@ -314,7 +314,13 @@ async function fetchLinkedInProfile(url) {
       certifications: extractList('licenses_and_certifications'),
     };
   } catch (err) {
-    throw new Error('LinkedIn profile fetch failed');
+    const status = err?.response?.status;
+    const msg = `LinkedIn profile fetch failed: ${err.message}` +
+      (status ? ` (status ${status})` : '');
+    const error = new Error(msg);
+    if (status) error.status = status;
+    console.error(msg);
+    throw error;
   }
 }
 

--- a/tests/fetchLinkedInProfileError.test.js
+++ b/tests/fetchLinkedInProfileError.test.js
@@ -1,0 +1,25 @@
+import { jest } from '@jest/globals';
+
+const mockGet = jest.fn();
+
+jest.unstable_mockModule('axios', () => ({ default: { get: mockGet } }));
+
+const { fetchLinkedInProfile } = await import('../server.js');
+
+describe('fetchLinkedInProfile error handling', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  test('includes status and message in thrown error', async () => {
+    const error = new Error('Request failed');
+    error.response = { status: 404 };
+    mockGet.mockRejectedValueOnce(error);
+    await expect(
+      fetchLinkedInProfile('https://linkedin.com/in/example')
+    ).rejects.toMatchObject({
+      message: 'LinkedIn profile fetch failed: Request failed (status 404)',
+      status: 404
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- include original message and status when LinkedIn profile fetch fails
- surface LinkedIn fetch errors in CV processing route
- add test for fetchLinkedInProfile error propagation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba86125c30832baca2d6f17d3c1a81