### PR TITLE
Add template helper coverage and compilation tests

### DIFF
--- a/lib/handlebars.js
+++ b/lib/handlebars.js
@@ -2,30 +2,49 @@ export default {
   compile(template) {
     return (data) => {
       let result = template;
-      // Replace simple variables like {{name}}
-      result = result.replace(/{{\s*name\s*}}/g, data.name || '');
+
       // Handle sections loop
-      result = result.replace(/{{#each\s+sections}}([\s\S]*?){{\/each}}/, (_, sectionBlock) => {
-        return (data.sections || []).map((sec) => {
-          let block = sectionBlock;
-          // Conditional heading
-          block = block.replace(/{{#if\s+heading}}([\s\S]*?){{\/if}}/, (__, headingBlock) =>
-            sec.heading ? headingBlock.replace(/{{\s*heading\s*}}/g, sec.heading) : ''
-          );
-          // Conditional items with nested each
-          block = block.replace(/{{#if\s+items}}([\s\S]*?){{\/if}}/, (__, itemsBlock) => {
-            if (sec.items && sec.items.length) {
-              return itemsBlock.replace(/{{#each\s+items}}([\s\S]*?){{\/each}}/, (___, itemBlock) =>
-                sec.items
+      result = result.replace(
+        /{{#each\s+sections}}([\s\S]*){{\/each}}/g,
+        (_, sectionBlock) => {
+          return (data.sections || []).map((sec) => {
+            let block = sectionBlock;
+
+            // Conditional heading
+            block = block.replace(
+              /{{#if\s+heading}}([\s\S]*?){{\/if}}/g,
+              (__, headingBlock) =>
+                sec.heading
+                  ? headingBlock.replace(/{{\s*heading\s*}}/g, sec.heading)
+                  : ''
+            );
+
+            // Conditionally keep items block
+            block = block.replace(
+              /{{#if\s+items}}([\s\S]*?){{\/if}}/g,
+              (__, itemsBlock) => (sec.items && sec.items.length ? itemsBlock : '')
+            );
+
+            // Iterate over items
+            block = block.replace(
+              /{{#each\s+items}}([\s\S]*?){{\/each}}/g,
+              (__, itemBlock) =>
+                (sec.items || [])
                   .map((it) => itemBlock.replace(/{{{?\s*this\s*}?}}/g, it))
                   .join('')
-              );
-            }
-            return '';
-          });
-          return block;
-        }).join('');
-      });
+            );
+
+            return block;
+          }).join('');
+        }
+      );
+
+      // Replace remaining simple variables like {{name}} or {{email}}
+      result = result.replace(
+        /{{\s*([a-zA-Z0-9_]+)\s*}}/g,
+        (_, key) => (data[key] != null ? data[key] : '')
+      );
+
       return result;
     };
   }

--- a/tests/__snapshots__/boldHeadings.test.js.snap
+++ b/tests/__snapshots__/boldHeadings.test.js.snap
@@ -48,29 +48,37 @@ exports[`all headings including Skills are bold in HTML and PDF outputs: html 1`
   
   <section>
     <h2>Skills</h2>
-    {{#if items}}
+    
       <ul>
-        {{#each items}}
-          <li>{{{this}}}</li>
         
-  <section>
-    <h2>Work Experience</h2>
-    {{#if items}}
-      <ul>
-        {{#each items}}
-          <li>{{{this}}}</li>
-        
-  <section>
-    <h2>Education</h2>
-    {{#if items}}
-      <ul>
-        {{#each items}}
-          <li>{{{this}}}</li>
+          <li><span class="bullet">•</span> Testing</li>
         
       </ul>
-    {{/if}}
+    
   </section>
-  {{/each}}
+  
+  <section>
+    <h2>Work Experience</h2>
+    
+      <ul>
+        
+          <li>Information not provided</li>
+        
+      </ul>
+    
+  </section>
+  
+  <section>
+    <h2>Education</h2>
+    
+      <ul>
+        
+          <li>Information not provided</li>
+        
+      </ul>
+    
+  </section>
+  
 </body>
 </html>
 "

--- a/tests/__snapshots__/generatePdf.test.js.snap
+++ b/tests/__snapshots__/generatePdf.test.js.snap
@@ -122,29 +122,37 @@ strong {
     
     <section class="section">
       <h2>Skills</h2>
-      {{#if items}}
+      
         <ul>
-          {{#each items}}
-            <li>{{{this}}}</li>
           
-    <section class="section">
-      <h2>Work Experience</h2>
-      {{#if items}}
-        <ul>
-          {{#each items}}
-            <li>{{{this}}}</li>
-          
-    <section class="section">
-      <h2>Education</h2>
-      {{#if items}}
-        <ul>
-          {{#each items}}
-            <li>{{{this}}}</li>
+            <li><span class="bullet">•</span>Testing</li>
           
         </ul>
-      {{/if}}
+      
     </section>
-    {{/each}}
+    
+    <section class="section">
+      <h2>Work Experience</h2>
+      
+        <ul>
+          
+            <li>Information not provided</li>
+          
+        </ul>
+      
+    </section>
+    
+    <section class="section">
+      <h2>Education</h2>
+      
+        <ul>
+          
+            <li>Information not provided</li>
+          
+        </ul>
+      
+    </section>
+    
   </main>
 </body>
 </html>

--- a/tests/templates/__snapshots__/ucmo.test.js.snap
+++ b/tests/templates/__snapshots__/ucmo.test.js.snap
@@ -47,10 +47,10 @@ exports[`ucmo template renders with contact bar and logo: html 1`] = `
 <body>
   <div class="top-bar">
     <div class="contact">
-      <span>{{phone}}</span>
-      <span>{{email}}</span>
-      <span>{{cityState}}</span>
-      <span>{{linkedin}}</span>
+      <span>555-555-5555</span>
+      <span>jane@example.com</span>
+      <span>Warrensburg, MO</span>
+      <span>linkedin.com/in/jane</span>
     </div>
     <img src="https://resumeforge.s3.amazonaws.com/ucmo-logo.png" alt="UCMO logo" class="logo" />
   </div>
@@ -60,22 +60,26 @@ exports[`ucmo template renders with contact bar and logo: html 1`] = `
   
   <section>
     <h2>Work Experience</h2>
-    {{#if items}}
+    
       <ul>
-        {{#each items}}
-          <li>{{{this}}}</li>
         
-  <section>
-    <h2>Education</h2>
-    {{#if items}}
-      <ul>
-        {{#each items}}
-          <li>{{{this}}}</li>
+          <li><span class="bullet">•</span> Built things</li>
         
       </ul>
-    {{/if}}
+    
   </section>
-  {{/each}}
+  
+  <section>
+    <h2>Education</h2>
+    
+      <ul>
+        
+          <li><span class="bullet">•</span> BSc Stuff</li>
+        
+      </ul>
+    
+  </section>
+  
 </body>
 </html>
 "

--- a/tests/templates/compileTemplates.test.js
+++ b/tests/templates/compileTemplates.test.js
@@ -1,0 +1,35 @@
+import { jest } from '@jest/globals';
+import fs from 'fs/promises';
+import path from 'path';
+import Handlebars from '../../lib/handlebars.js';
+
+const templates = [
+  '2025',
+  'cover_classic',
+  'cover_modern',
+  'modern',
+  'professional',
+  'ucmo',
+  'vibrant'
+];
+
+describe('handlebars template compilation', () => {
+  test.each(templates)('%s template compiles without leftover helpers', async (tpl) => {
+    const src = await fs.readFile(path.resolve('templates', `${tpl}.html`), 'utf8');
+    const data = {
+      name: 'Jane Doe',
+      phone: '555-555-5555',
+      email: 'jane@example.com',
+      cityState: 'Nowhere, XX',
+      linkedin: 'linkedin.com/in/jane',
+      sections: [
+        { heading: 'Heading', items: ['First item', 'Second item'] }
+      ]
+    };
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const html = Handlebars.compile(src)(data);
+    warnSpy.mockRestore();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(html).not.toMatch(/{{[^}]+}}/);
+  });
+});


### PR DESCRIPTION
## Summary
- expand custom Handlebars compiler with generic variable replacement and direct item loops
- add tests ensuring every HTML template renders without leftover placeholders
- update snapshots for templates affected by new helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba8c229f20832b98ab323d444c6cc1