### PR TITLE
Handle LinkedIn 999 response

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -274,6 +274,10 @@ export default function registerProcessCv(app) {
           () => fetchLinkedInProfile(linkedinProfileUrl),
           2
         );
+        const hasContent = Object.values(linkedinData).some((v) =>
+          Array.isArray(v) ? v.length > 0 : v
+        );
+        if (!hasContent) linkedinData = {};
         await logEvent({
           s3,
           bucket,

--- a/server.js
+++ b/server.js
@@ -315,6 +315,15 @@ async function fetchLinkedInProfile(url) {
     };
   } catch (err) {
     const status = err?.response?.status;
+    if (status === 999) {
+      return {
+        headline: '',
+        experience: [],
+        education: [],
+        skills: [],
+        certifications: []
+      };
+    }
     const msg = `LinkedIn profile fetch failed: ${err.message}` +
       (status ? ` (status ${status})` : '');
     const error = new Error(msg);

--- a/tests/fetchLinkedInProfileError.test.js
+++ b/tests/fetchLinkedInProfileError.test.js
@@ -22,4 +22,19 @@ describe('fetchLinkedInProfile error handling', () => {
       status: 404
     });
   });
+
+  test('returns empty profile on LinkedIn status 999', async () => {
+    const error = new Error('Blocked');
+    error.response = { status: 999 };
+    mockGet.mockRejectedValueOnce(error);
+    await expect(
+      fetchLinkedInProfile('https://linkedin.com/in/example')
+    ).resolves.toEqual({
+      headline: '',
+      experience: [],
+      education: [],
+      skills: [],
+      certifications: []
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Treat LinkedIn HTTP 999 responses as empty profiles instead of errors
- Skip LinkedIn processing when the fetched profile contains no data
- Add regression test covering 999 LinkedIn response

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68bb99544ef0832b85d1aeed308699a3