### PR TITLE
Handle invalid fonts in PDF generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Available template values:
 Any missing or invalid ID falls back to `modern`.
 
 
+## Fonts
+Custom TrueType fonts can be embedded by placing valid `.ttf` files in a `fonts/` directory at the project root. If the directory or required font files are missing or invalid, the PDF generator automatically falls back to PDFKit's built-in fonts.
+
+
 ## Edge Cases
 - **Name extraction fallback:** If the résumé text lacks a detectable name, the generated content defaults to a generic placeholder such as "Candidate".
 - **Job description scraping limitations:** The job description is retrieved with a simple HTTP GET request; dynamic or access-restricted pages may return empty or blocked content.


### PR DESCRIPTION
## Summary
- skip non-TTF fonts during registration
- switch to built-in fonts when PDFKit emits warnings
- document optional fonts directory and add tests for invalid fonts

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom not found and missing @babel/preset-env)*
- `npm install --no-save @babel/preset-env` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9a00dc60832bb7f1d4c19cb025d8