### PR TITLE
feat: expand ATS metrics and schema

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -12,6 +12,16 @@ function App() {
   const [latestCvKey, setLatestCvKey] = useState('')
   const [error, setError] = useState('')
   const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
+  const metricLabels = {
+    layoutSearchability: 'Layout Searchability',
+    atsReadability: 'ATS Readability',
+    impact: 'Impact',
+    crispness: 'Crispness',
+    keywordDensity: 'Keyword Density',
+    sectionHeadingClarity: 'Section Heading Clarity',
+    contactInfoCompleteness: 'Contact Info Completeness'
+  }
+  const metricOrder = Object.keys(metricLabels)
 
   const handleDrop = useCallback((e) => {
     e.preventDefault()
@@ -291,22 +301,26 @@ function App() {
                 </tr>
               </thead>
               <tbody>
-                {metrics.map((m) => (
-                  <tr key={m.metric}>
-                    <td className="py-1 text-purple-800">{m.metric}</td>
-                    <td className="py-1 text-right">{m.original}</td>
-                    <td className="py-1 text-right">{m.improved}</td>
-                    <td className="py-1 text-right">{m.improvement}%</td>
-                    <td className="py-1 text-right">
-                      <button
-                        onClick={() => handleImproveMetric(m.metric)}
-                        className="text-blue-600 hover:underline"
-                      >
-                        Improve
-                      </button>
-                    </td>
-                  </tr>
-                ))}
+                {[...metrics]
+                  .sort((a, b) => metricOrder.indexOf(a.metric) - metricOrder.indexOf(b.metric))
+                  .map((m) => (
+                    <tr key={m.metric}>
+                      <td className="py-1 text-purple-800">
+                        {metricLabels[m.metric] || m.metric}
+                      </td>
+                      <td className="py-1 text-right">{m.original}</td>
+                      <td className="py-1 text-right">{m.improved}</td>
+                      <td className="py-1 text-right">{m.improvement}%</td>
+                      <td className="py-1 text-right">
+                        <button
+                          onClick={() => handleImproveMetric(m.metric)}
+                          className="text-blue-600 hover:underline"
+                        >
+                          Improve
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
               </tbody>
             </table>
           )}

--- a/openaiClient.js
+++ b/openaiClient.js
@@ -8,6 +8,16 @@ import { getSecrets } from './config/secrets.js';
 // warnings during résumé generation.
 const preferredModels = ['gpt-4.1', 'gpt-4o-mini'];
 
+const metricNames = [
+  'layoutSearchability',
+  'atsReadability',
+  'impact',
+  'crispness',
+  'keywordDensity',
+  'sectionHeadingClarity',
+  'contactInfoCompleteness',
+];
+
 let clientPromise;
 async function getClient() {
   if (!clientPromise) {
@@ -76,7 +86,7 @@ export async function requestEnhancedCV({
         items: {
           type: 'object',
           properties: {
-            metric: { type: 'string' },
+            metric: { type: 'string', enum: metricNames },
             original: { type: 'number' },
             improved: { type: 'number' },
             improvement: { type: 'number' }

--- a/services/atsMetrics.js
+++ b/services/atsMetrics.js
@@ -54,12 +54,52 @@ export function scoreCrispness(text) {
   return Math.max(0, Math.min(100, Math.round(score)));
 }
 
+export function scoreKeywordDensity(text) {
+  const words = text.toLowerCase().match(/\b[a-z]+\b/g) || [];
+  if (words.length === 0) return 0;
+  const freq = words.reduce((map, w) => {
+    map[w] = (map[w] || 0) + 1;
+    return map;
+  }, {});
+  const repeated = Object.values(freq).filter((c) => c > 1).length;
+  const density = repeated / words.length;
+  return Math.min(100, Math.round(density * 500));
+}
+
+export function scoreSectionHeadingClarity(text) {
+  const lines = text.split(/\n+/).map((l) => l.toLowerCase());
+  const headings = [
+    'experience',
+    'education',
+    'skills',
+    'projects',
+    'summary',
+    'contact'
+  ];
+  const found = headings.filter((h) => lines.some((l) => l.includes(h)));
+  return Math.round((found.length / headings.length) * 100);
+}
+
+export function scoreContactInfoCompleteness(text) {
+  const email = /[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}/.test(text);
+  const phone = /\b(?:\+?\d{1,2}[\s-]?)?(?:\(\d{3}\)|\d{3})[\s-]?\d{3}[\s-]?\d{4}\b/.test(
+    text
+  );
+  const linkedin = /linkedin\.com\/\S+/i.test(text);
+  const components = [email, phone, linkedin];
+  const score = components.filter(Boolean).length / components.length;
+  return Math.round(score * 100);
+}
+
 export function calculateMetrics(text) {
   return {
     layoutSearchability: scoreLayoutSearchability(text),
     atsReadability: scoreAtsReadability(text),
     impact: scoreImpact(text),
-    crispness: scoreCrispness(text)
+    crispness: scoreCrispness(text),
+    keywordDensity: scoreKeywordDensity(text),
+    sectionHeadingClarity: scoreSectionHeadingClarity(text),
+    contactInfoCompleteness: scoreContactInfoCompleteness(text)
   };
 }
 

--- a/tests/atsMetrics.test.js
+++ b/tests/atsMetrics.test.js
@@ -8,7 +8,10 @@ describe('ATS metric calculations', () => {
       'layoutSearchability',
       'atsReadability',
       'impact',
-      'crispness'
+      'crispness',
+      'keywordDensity',
+      'sectionHeadingClarity',
+      'contactInfoCompleteness',
     ]);
     for (const score of Object.values(metrics)) {
       expect(score).toBeGreaterThanOrEqual(0);

--- a/tests/openaiClientModels.test.js
+++ b/tests/openaiClientModels.test.js
@@ -32,6 +32,17 @@ test('uses supported model without model_not_found warnings', async () => {
   });
   expect(options.text.format.schema).toHaveProperty('additionalProperties', false);
   expect(options.text.format.schema.properties).toHaveProperty('metrics');
+  expect(
+    options.text.format.schema.properties.metrics.items.properties.metric.enum
+  ).toEqual([
+    'layoutSearchability',
+    'atsReadability',
+    'impact',
+    'crispness',
+    'keywordDensity',
+    'sectionHeadingClarity',
+    'contactInfoCompleteness',
+  ]);
   expect(options.text.format.schema.required).toEqual(
     expect.arrayContaining(['metrics'])
   );


### PR DESCRIPTION
## Summary
- add keyword density, section heading clarity, and contact info completeness metrics
- enumerate expanded metrics in OpenAI schema and client UI
- update tests for new metrics

## Testing
- `npm test tests/atsMetrics.test.js` *(fails: Cannot find package '@babel/preset-env')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aws-sdk%2fs3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bba4f1464c832b9a0442bab391487b