### PR TITLE
feat: add sleek CV template

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -88,8 +88,10 @@ export default function registerProcessCv(app) {
       console.error('User agent parsing failed', err);
       return next(createError(500, 'Failed to parse user agent'));
     }
-    const defaultCvTemplate =
+    let defaultCvTemplate =
       req.body.template || req.query.template || CV_TEMPLATES[0];
+    if (!CV_TEMPLATES.includes(defaultCvTemplate))
+      defaultCvTemplate = CV_TEMPLATES[0];
     const defaultClTemplate =
       req.body.coverTemplate || req.query.coverTemplate || CL_TEMPLATES[0];
     const selection = selectTemplates({

--- a/server.js
+++ b/server.js
@@ -110,7 +110,7 @@ const upload = multer({
 
 const uploadResume = upload.single('resume');
 
-const CV_TEMPLATES = ['modern', 'ucmo', 'professional', 'vibrant', '2025'];
+const CV_TEMPLATES = ['modern', 'ucmo', 'professional', 'vibrant', '2025', 'sleek'];
 const CL_TEMPLATES = ['cover_modern', 'cover_classic'];
 const TEMPLATE_IDS = CV_TEMPLATES; // Backwards compatibility
 const ALL_TEMPLATES = [...CV_TEMPLATES, ...CL_TEMPLATES];
@@ -121,14 +121,16 @@ const CV_TEMPLATE_GROUPS = {
   ucmo: 'classic',
   professional: 'professional',
   vibrant: 'creative',
-  2025: 'futuristic'
+  2025: 'futuristic',
+  sleek: 'modern'
 };
 
 // Predefined contrasting template pairs used when no explicit templates are provided
 const CONTRASTING_PAIRS = [
   ['modern', 'vibrant'],
   ['ucmo', '2025'],
-  ['professional', 'vibrant']
+  ['professional', 'vibrant'],
+  ['sleek', 'professional']
 ];
 
 const TECHNICAL_TERMS = [

--- a/services/generatePdf.js
+++ b/services/generatePdf.js
@@ -16,6 +16,7 @@ const ALL_TEMPLATES = [
   'professional',
   'vibrant',
   '2025',
+  'sleek',
   'cover_modern',
   'cover_classic'
 ];
@@ -200,6 +201,18 @@ export async function generatePdf(
         textColor: '#333',
         lineGap: 6,
         paragraphGap: 8
+      },
+      sleek: {
+        font: 'Helvetica',
+        bold: 'Helvetica-Bold',
+        italic: 'Helvetica-Oblique',
+        headingColor: '#4a90e2',
+        bullet: '•',
+        eduBullet: '•',
+        bulletColor: '#4a90e2',
+        textColor: '#333',
+        lineGap: 8,
+        paragraphGap: 12
       }
     };
     return new Promise((resolve, reject) => {

--- a/templates/sleek.css
+++ b/templates/sleek.css
@@ -1,0 +1,66 @@
+body {
+  font-family: 'Inter', Arial, sans-serif;
+  margin: 40px;
+  line-height: 1.6;
+  color: #1a1a1a;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+h1 {
+  font-size: 36px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.section {
+  margin-bottom: 24px;
+}
+
+h2 {
+  font-size: 20px;
+  color: #4a90e2;
+  border-bottom: 2px solid #4a90e2;
+  padding-bottom: 4px;
+  margin: 24px 0 12px;
+  font-weight: 700;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+li {
+  margin-bottom: 8px;
+  margin-left: 1.2em;
+  position: relative;
+  white-space: pre-wrap;
+}
+
+.bullet {
+  position: absolute;
+  left: -1.2em;
+  color: #4a90e2;
+  font-weight: 700;
+}
+
+.edu-bullet {
+  position: absolute;
+  left: -1.2em;
+  color: #4a90e2;
+  font-weight: 700;
+}
+
+.tab {
+  display: inline-block;
+  width: 1.5em;
+}
+
+strong {
+  font-weight: 700;
+}

--- a/templates/sleek.html
+++ b/templates/sleek.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Resume</title>
+</head>
+<body>
+  <header class="header">
+    <h1>{{name}}</h1>
+  </header>
+  {{#each sections}}
+  <section class="section">
+    {{#if heading}}<h2>{{heading}}</h2>{{/if}}
+    {{#if items}}
+      <ul>
+        {{#each items}}
+          {{#if this.bullets}}
+            <li>
+              <strong>{{{this.title}}}</strong>
+              <ul>
+                {{#each this.bullets}}
+                  <li>{{{this}}}</li>
+                {{/each}}
+              </ul>
+            </li>
+          {{else}}
+            <li>{{{this}}}</li>
+          {{/if}}
+        {{/each}}
+      </ul>
+    {{/if}}
+  </section>
+  {{/each}}
+</body>
+</html>

--- a/tests/__snapshots__/selectTemplatesGroup.test.js.snap
+++ b/tests/__snapshots__/selectTemplatesGroup.test.js.snap
@@ -6,6 +6,7 @@ exports[`selectTemplates defaults and overrides heading styles are bold across t
   "modern": "h2 { font-size: 20px; margin: 24px 0 12px; border-bottom: 1px solid #2a9d8f; padding-bottom: 4px; font-weight: 700; }",
   "professional": "h2 { font-size: 20px; color: #1d3557; margin: 30px 0 16px; border-bottom: 1px solid #1d3557; padding-bottom: 4px; font-weight: 700; }",
   "ucmo": "h2 { font-size: 18px; margin: 30px 0 12px; background: #f2f2f2; padding: 6px 10px; color: #990000; font-weight: 700; text-transform: uppercase; }",
-  "vibrant": "h2 { font-size: 20px; color: #ff6b6b; margin: 24px 0 12px; border-bottom: 2px solid #ff6b6b; padding-bottom: 4px; font-weight: 700; }",
-}
+   "vibrant": "h2 { font-size: 20px; color: #ff6b6b; margin: 24px 0 12px; border-bottom: 2px solid #ff6b6b; padding-bottom: 4px; font-weight: 700; }",
+   "sleek": "h2 {\n  font-size: 20px;\n  color: #4a90e2;\n  border-bottom: 2px solid #4a90e2;\n  padding-bottom: 4px;\n  margin: 24px 0 12px;\n  font-weight: 700;\n}",
+ }
 `;

--- a/tests/templates/compileTemplates.test.js
+++ b/tests/templates/compileTemplates.test.js
@@ -10,7 +10,8 @@ const templates = [
   'modern',
   'professional',
   'ucmo',
-  'vibrant'
+  'vibrant',
+  'sleek'
 ];
 
 describe('handlebars template compilation', () => {


### PR DESCRIPTION
## Summary
- add modern "sleek" resume template with Inter typography and blue accent
- wire template into selection logic and PDF generation
- update tests for new template

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env' imported from babel-virtual-resolve-base.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bba77c4ff8832ba5d208b6394a6eed