### PR TITLE
Skip OpenAI call for empty resume sections

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -50,6 +50,23 @@ async function withRetry(fn, retries = 3, delay = 500) {
   throw lastErr;
 }
 
+export async function improveSections(sections, jobDescription) {
+  const improvedSections = {};
+  for (const key of ['summary', 'experience', 'education', 'certifications']) {
+    const text = sections[key]?.trim();
+    if (!text) {
+      improvedSections[key] = '';
+      continue;
+    }
+    improvedSections[key] = await requestSectionImprovement({
+      sectionName: key,
+      sectionText: text,
+      jobDescription,
+    });
+  }
+  return improvedSections;
+}
+
 export default function registerProcessCv(app) {
   app.post(
     '/api/process-cv',
@@ -330,14 +347,7 @@ export default function registerProcessCv(app) {
         resumeExperience[0]?.title || linkedinExperience[0]?.title || '';
 
       const sections = collectSectionText(text, linkedinData, credlyCertifications);
-      const improvedSections = {};
-      for (const key of ['summary', 'experience', 'education', 'certifications']) {
-        improvedSections[key] = await requestSectionImprovement({
-          sectionName: key,
-          sectionText: sections[key] || '',
-          jobDescription,
-        });
-      }
+      const improvedSections = await improveSections(sections, jobDescription);
       const improvedCv = [
         sanitizedName,
         '# Summary',

--- a/tests/__snapshots__/selectTemplatesGroup.test.js.snap
+++ b/tests/__snapshots__/selectTemplatesGroup.test.js.snap
@@ -2,11 +2,26 @@
 
 exports[`selectTemplates defaults and overrides heading styles are bold across templates 1`] = `
 {
-  "2025": "h2 {\n    font-size: 1.5rem;\n    font-weight: 700;\n    margin-top: 2.5rem;\n    margin-bottom: 0.75rem;\n    color: var(--accent);\n    border-bottom: 2px solid var(--accent);\n    padding-bottom: 0.25rem;\n  }",
+  "2025": "h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+    color: var(--accent);
+    border-bottom: 2px solid var(--accent);
+    padding-bottom: 0.25rem;
+  }",
   "modern": "h2 { font-size: 20px; margin: 24px 0 12px; border-bottom: 1px solid #2a9d8f; padding-bottom: 4px; font-weight: 700; }",
   "professional": "h2 { font-size: 20px; color: #1d3557; margin: 30px 0 16px; border-bottom: 1px solid #1d3557; padding-bottom: 4px; font-weight: 700; }",
+  "sleek": "h2 {
+  font-size: 20px;
+  color: #4a90e2;
+  border-bottom: 2px solid #4a90e2;
+  padding-bottom: 4px;
+  margin: 24px 0 12px;
+  font-weight: 700;
+}",
   "ucmo": "h2 { font-size: 18px; margin: 30px 0 12px; background: #f2f2f2; padding: 6px 10px; color: #990000; font-weight: 700; text-transform: uppercase; }",
-   "vibrant": "h2 { font-size: 20px; color: #ff6b6b; margin: 24px 0 12px; border-bottom: 2px solid #ff6b6b; padding-bottom: 4px; font-weight: 700; }",
-   "sleek": "h2 {\n  font-size: 20px;\n  color: #4a90e2;\n  border-bottom: 2px solid #4a90e2;\n  padding-bottom: 4px;\n  margin: 24px 0 12px;\n  font-weight: 700;\n}",
- }
+  "vibrant": "h2 { font-size: 20px; color: #ff6b6b; margin: 24px 0 12px; border-bottom: 2px solid #ff6b6b; padding-bottom: 4px; font-weight: 700; }",
+}
 `;

--- a/tests/improveSections.test.js
+++ b/tests/improveSections.test.js
@@ -1,0 +1,32 @@
+import { jest } from '@jest/globals';
+
+const requestSectionImprovement = jest.fn(async ({ sectionName }) => `${sectionName}-improved`);
+const uploadFile = jest.fn();
+const requestEnhancedCV = jest.fn();
+jest.unstable_mockModule('../openaiClient.js', () => ({
+  requestSectionImprovement,
+  uploadFile,
+  requestEnhancedCV,
+}));
+
+const { improveSections } = await import('../routes/processCv.js');
+
+test('missing sections return empty strings and skip OpenAI call', async () => {
+  const sections = {
+    summary: '   ',
+    experience: 'Worked hard',
+    education: undefined,
+    certifications: '',
+  };
+  const result = await improveSections(sections, 'JD');
+  expect(result.summary).toBe('');
+  expect(result.education).toBe('');
+  expect(result.certifications).toBe('');
+  expect(result.experience).toBe('experience-improved');
+  expect(requestSectionImprovement).toHaveBeenCalledTimes(1);
+  expect(requestSectionImprovement).toHaveBeenCalledWith({
+    sectionName: 'experience',
+    sectionText: 'Worked hard',
+    jobDescription: 'JD',
+  });
+});

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -36,6 +36,7 @@ import { parseContent } from '../services/parseContent.js';
 jest.unstable_mockModule('../openaiClient.js', () => ({
   uploadFile,
   requestEnhancedCV,
+  requestSectionImprovement: jest.fn(async ({ sectionText }) => sectionText),
 }));
 
 generateContentMock


### PR DESCRIPTION
## Summary
- Add `improveSections` helper to trim section text and skip OpenAI requests for empty sections
- Use `improveSections` in `/api/process-cv` route
- Test that missing sections produce empty strings and no OpenAI calls

## Testing
- `npm test` *(fails: client/src/App.test.jsx, tests/server.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb198a418832bb81c72f61421be73