### PR TITLE
Validate requestEnhancedCV input IDs

### DIFF
--- a/openaiClient.js
+++ b/openaiClient.js
@@ -54,6 +54,8 @@ export async function requestEnhancedCV({
   instructions,
   priorCvFileId,
 }) {
+  if (!cvFileId) throw new Error('cvFileId is required');
+  if (!jobDescFileId) throw new Error('jobDescFileId is required');
   if (typeof instructions !== 'string' || !instructions.trim()) {
     throw new Error('instructions must be a non-empty string');
   }

--- a/tests/openaiClientInstructions.test.js
+++ b/tests/openaiClientInstructions.test.js
@@ -7,3 +7,17 @@ test('throws when instructions missing', async () => {
   ).rejects.toThrow('instructions must be a non-empty string');
   expect(createResponse).not.toHaveBeenCalled();
 });
+
+test('throws when cvFileId missing', async () => {
+  await expect(
+    requestEnhancedCV({ jobDescFileId: 'jd', instructions: 'x' })
+  ).rejects.toThrow('cvFileId is required');
+  expect(createResponse).not.toHaveBeenCalled();
+});
+
+test('throws when jobDescFileId missing', async () => {
+  await expect(
+    requestEnhancedCV({ cvFileId: 'cv', instructions: 'x' })
+  ).rejects.toThrow('jobDescFileId is required');
+  expect(createResponse).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- Require both `cvFileId` and `jobDescFileId` when requesting an enhanced CV
- Add tests for missing `cvFileId` and `jobDescFileId` cases

## Testing
- `npm test tests/openaiClientInstructions.test.js` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bbb2c492a8832bbe2510e638c0516e