### PR TITLE
chore: remove unused original title variable

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -343,9 +343,6 @@ export default function registerProcessCv(app) {
         linkedinData.certifications || []
       );
 
-      const originalTitle =
-        resumeExperience[0]?.title || linkedinExperience[0]?.title || '';
-
       const sections = collectSectionText(text, linkedinData, credlyCertifications);
       const improvedSections = await improveSections(sections, jobDescription);
       const improvedCv = [


### PR DESCRIPTION
## Summary
- remove unused `originalTitle` declaration from processCv route

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env' imported from babel-virtual-resolve-base.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb3671c70832baf149019fb7bf40b