### PR TITLE
feat: add skill match scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Custom TrueType fonts can be embedded by placing valid `.ttf` files in a `fonts/
 - **Job description scraping limitations:** The job description is retrieved with a simple HTTP GET request; dynamic or access-restricted pages may return empty or blocked content.
 
 ## API Response
-The `/api/process-cv` endpoint returns JSON containing an array of generated files along with match statistics:
+The `/api/process-cv` endpoint returns JSON containing an array of generated files along with match statistics and an estimated chance of selection:
 
 ```json
 {
@@ -124,12 +124,12 @@ The `/api/process-cv` endpoint returns JSON containing an array of generated fil
     { "skill": "aws", "matched": true },
     { "skill": "python", "matched": false }
   ],
-  "addedSkills": ["aws"],
-  "missingSkills": ["python"]
+  "newSkills": ["python"],
+  "chanceOfSelection": 65
 }
 ```
 
-`originalScore` represents the percentage match between the job description and the uploaded resume. `enhancedScore` is the best match achieved by the generated resumes. `table` details how each job skill matched, `addedSkills` shows skills newly matched in the enhanced resume, and `missingSkills` lists skills from the job description still absent.
+`originalScore` represents the percentage match between the job description and the uploaded resume. `enhancedScore` is the best match achieved by the generated resumes. `table` details how each job skill matched. `newSkills` lists job skills not found in the résumé, and `chanceOfSelection` averages the ATS score and skill match percentage to estimate selection likelihood.
 
 S3 keys follow the pattern `sessions/<name>/<id>/generated/<subdir>/<file>.pdf`, where `<subdir>` is `cover_letter/` or `cv/` depending on the file type.
 

--- a/tests/chanceOfSelection.test.js
+++ b/tests/chanceOfSelection.test.js
@@ -1,0 +1,31 @@
+import { calculateMatchScore, extractResumeSkills } from '../server.js';
+import { compareMetrics } from '../services/atsMetrics.js';
+
+describe('chance of selection computation', () => {
+  test('averages match and ATS scores', () => {
+    const jobSkills = ['javascript', 'aws'];
+    const text = 'Worked with JavaScript and AWS on projects.';
+    const resumeSkills = extractResumeSkills(text);
+    const match = calculateMatchScore(jobSkills, resumeSkills);
+    const { improved } = compareMetrics(text, text);
+    const atsScore = Math.round(
+      Object.values(improved).reduce((sum, v) => sum + v, 0) /
+        Object.keys(improved).length
+    );
+    const chanceOfSelection = Math.round((match.score + atsScore) / 2);
+    expect(match.table).toEqual([
+      { skill: 'javascript', matched: true },
+      { skill: 'aws', matched: true }
+    ]);
+    expect(match.newSkills).toEqual([]);
+    expect(typeof chanceOfSelection).toBe('number');
+  });
+
+  test('lists job skills missing from resume', () => {
+    const jobSkills = ['javascript', 'aws'];
+    const text = 'I know JavaScript.';
+    const resumeSkills = extractResumeSkills(text);
+    const match = calculateMatchScore(jobSkills, resumeSkills);
+    expect(match.newSkills).toEqual(['aws']);
+  });
+});


### PR DESCRIPTION
## Summary
- compute resume skill match and ATS chance-of-selection
- document new API response fields
- add unit tests for chance-of-selection logic

## Testing
- `npm test` *(fails: jest-environment-jsdom missing and @babel/preset-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbde43dd44832bb08932658a25a327