### PR TITLE
fix: import OpenAI upload helper

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -5,6 +5,7 @@ import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3
 import { getSecrets } from '../config/secrets.js';
 import { logEvent } from '../logger.js';
 import { requestSectionImprovement } from '../openaiClient.js';
+import { uploadFile as openaiUploadFile } from '../openaiClient.js';
 import { compareMetrics } from '../services/atsMetrics.js';
 import { convertToPdf } from '../lib/convertToPdf.js';
 


### PR DESCRIPTION
## Summary
- import OpenAI upload helper in processCv route

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found, Cannot find package '@babel/preset-env')*
- `node server.js` *(fails: Cannot find package '@aws-sdk/s3-request-presigner')*

------
https://chatgpt.com/codex/tasks/task_e_68bbf3f2d8f8832bb122739ec2538eb1