### PR TITLE
Make CV refinement iteration limit configurable

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -94,9 +94,20 @@ export default function registerProcessCv(app) {
       return next(createError(500, 'failed to load configuration'));
     }
 
-    let { jobDescriptionUrl, linkedinProfileUrl, credlyProfileUrl, existingCvKey, iteration } = req.body;
+    let {
+      jobDescriptionUrl,
+      linkedinProfileUrl,
+      credlyProfileUrl,
+      existingCvKey,
+      iteration,
+    } = req.body;
     iteration = parseInt(iteration) || 0;
-    if (iteration >= 2) return next(createError(400, 'max improvements reached'));
+    const maxIterations = parseInt(
+      process.env.MAX_ITERATIONS || secrets.MAX_ITERATIONS || 0,
+      10
+    );
+    if (maxIterations && iteration >= maxIterations)
+      return next(createError(400, 'max improvements reached'));
     const ipAddress =
       (req.headers['x-forwarded-for'] || '')
         .split(',')
@@ -436,7 +447,12 @@ export default function registerProcessCv(app) {
       iteration,
     } = req.body;
     iteration = parseInt(iteration) || 0;
-    if (iteration >= 2) return next(createError(400, 'max improvements reached'));
+    const maxIterations = parseInt(
+      process.env.MAX_ITERATIONS || secrets.MAX_ITERATIONS || 0,
+      10
+    );
+    if (maxIterations && iteration >= maxIterations)
+      return next(createError(400, 'max improvements reached'));
     if (!metric) return next(createError(400, 'metric required'));
     if (!jobDescriptionUrl)
       return next(createError(400, 'jobDescriptionUrl required'));


### PR DESCRIPTION
## Summary
- Replace hard-coded iteration cap with configurable `MAX_ITERATIONS`
- Expand process CV tests to cover configurable iteration limit
- Adjust improve metric test for new iteration cap

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install` *(fails: 403 Forbidden reaching registry)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf5fd89bc832b8b8ca135edcd9578