### PR TITLE
refactor: import requestEnhancedCV

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -5,8 +5,11 @@ import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { getSecrets } from '../config/secrets.js';
 import { logEvent } from '../logger.js';
-import { requestSectionImprovement } from '../openaiClient.js';
-import { uploadFile as openaiUploadFile } from '../openaiClient.js';
+import {
+  requestSectionImprovement,
+  uploadFile as openaiUploadFile,
+  requestEnhancedCV,
+} from '../openaiClient.js';
 import { compareMetrics } from '../services/atsMetrics.js';
 import { convertToPdf } from '../lib/convertToPdf.js';
 


### PR DESCRIPTION
## Summary
- unify OpenAI client imports in `processCv` to also include `requestEnhancedCV`

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*
- `npm install` *(fails: 403 Forbidden while retrieving packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfe459a90832baaae7f3bd592fdf4