### PR TITLE
Add presigned CV download links

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -336,6 +336,9 @@ function App() {
                 case 'cover_letter2':
                   label = 'Cover Letter 2 (PDF)'
                   break
+                case 'cv':
+                  label = 'Improved CV (PDF)'
+                  break
                 case 'version1':
                   label = 'CV Version 1 (PDF)'
                   break

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -428,6 +428,11 @@ export default function registerProcessCv(app) {
           ContentType: 'application/pdf',
         })
       );
+      const cvUrl = await getSignedUrl(
+        s3,
+        new GetObjectCommand({ Bucket: bucket, Key: key }),
+        { expiresIn: 3600 }
+      );
       iteration += 1;
       return res.json({
         applicantName,
@@ -445,6 +450,13 @@ export default function registerProcessCv(app) {
         existingCvKey: key,
         iteration,
         bestCvKey: key,
+        urls: [
+          {
+            type: 'cv',
+            url: cvUrl,
+            expiresAt: Date.now() + 3600 * 1000,
+          },
+        ],
       });
 
     } catch (err) {


### PR DESCRIPTION
## Summary
- create a presigned S3 URL for the improved CV after upload
- return CV download info in a `urls` array
- show "Improved CV" links in the UI

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68bc069ad040832b8fc6981953fa217e