### PR TITLE
Expose missing skills and skill editing UI

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,8 @@ function App() {
   const [jobUrl, setJobUrl] = useState('')
   const [cvFile, setCvFile] = useState(null)
   const [result, setResult] = useState(null)
+  const [skills, setSkills] = useState([])
+  const [linkedinUrl, setLinkedinUrl] = useState('')
   const [error, setError] = useState('')
   const [isProcessing, setIsProcessing] = useState(false)
   const [designationOverride, setDesignationOverride] = useState('')
@@ -36,6 +38,7 @@ function App() {
       }
       const data = await response.json()
       setResult(data)
+      setSkills(data.missingSkills || [])
       if (!data.designationMatch) {
         alert('Designation mismatch detected. Please enter a revised designation.')
         setShowDesignationInput(true)
@@ -48,6 +51,37 @@ function App() {
   }
 
   const disabled = !jobUrl || !cvFile || isProcessing
+
+  const handleSkillChange = (idx, value) => {
+    setSkills((prev) => prev.map((s, i) => (i === idx ? value : s)))
+  }
+
+  const addSkill = () => setSkills((prev) => [...prev, ''])
+
+  const handleImprove = async () => {
+    setIsProcessing(true)
+    setError('')
+    try {
+      const formData = new FormData()
+      formData.append('resume', cvFile)
+      formData.append('jobDescriptionUrl', jobUrl)
+      formData.append('linkedinProfileUrl', linkedinUrl)
+      formData.append('addedSkills', JSON.stringify(skills))
+      const response = await fetch(`${API_BASE_URL}/api/process-cv`, {
+        method: 'POST',
+        body: formData
+      })
+      if (!response.ok) {
+        const text = await response.text()
+        throw new Error(text || 'Request failed')
+      }
+      await response.json()
+    } catch (err) {
+      setError(err.message || 'Something went wrong.')
+    } finally {
+      setIsProcessing(false)
+    }
+  }
 
   return (
     <div className="min-h-screen bg-gradient-to-r from-blue-200 to-purple-300 flex flex-col items-center p-4">
@@ -72,6 +106,14 @@ function App() {
         className="w-full max-w-md p-2 border border-purple-300 rounded mb-4"
       />
 
+      <input
+        type="url"
+        placeholder="LinkedIn Profile URL"
+        value={linkedinUrl}
+        onChange={(e) => setLinkedinUrl(e.target.value)}
+        className="w-full max-w-md p-2 border border-purple-300 rounded mb-4"
+      />
+
       <button
         onClick={handleSubmit}
         disabled={disabled}
@@ -92,11 +134,33 @@ function App() {
           <p className="text-purple-800 mb-2">
             Designation: {result.originalTitle || 'N/A'} vs {result.jobTitle || 'N/A'} ({result.designationMatch ? 'Match' : 'Mismatch'})
           </p>
-          {result.missingSkills && result.missingSkills.length > 0 && (
-            <p className="text-purple-800 mb-2">
-              Missing skills: {result.missingSkills.join(', ')}
-            </p>
+          {skills.length > 0 && (
+            <div className="text-purple-800 mb-2">
+              <p className="mb-2">Missing skills:</p>
+              {skills.map((skill, idx) => (
+                <input
+                  key={idx}
+                  value={skill}
+                  placeholder="Skill"
+                  onChange={(e) => handleSkillChange(idx, e.target.value)}
+                  className="w-full p-2 border border-purple-300 rounded mb-2"
+                />
+              ))}
+              <button
+                type="button"
+                onClick={addSkill}
+                className="px-2 py-1 bg-purple-500 text-white rounded"
+              >
+                Add Skill
+              </button>
+            </div>
           )}
+          <button
+            onClick={handleImprove}
+            className="mt-2 px-4 py-2 bg-blue-500 text-white rounded"
+          >
+            Improve my CV
+          </button>
         </div>
       )}
 

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -39,5 +39,8 @@ test('evaluates CV and displays results', async () => {
   expect(
     await screen.findByPlaceholderText('Revised Designation')
   ).toBeInTheDocument()
-  expect(await screen.findByText(/Missing skills: aws/)).toBeInTheDocument()
+  expect(await screen.findByDisplayValue('aws')).toBeInTheDocument()
+  fireEvent.click(await screen.findByText('Add Skill'))
+  const skillInputs = await screen.findAllByPlaceholderText('Skill')
+  expect(skillInputs.length).toBe(2)
 })


### PR DESCRIPTION
## Summary
- Return array of missing skills from `/api/evaluate`
- Allow `/api/process-cv` to accept extra skills and embed them into generated CV
- Add interactive skills list in UI with ability to add skills and send them for CV improvement

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env' imported from babel-virtual-resolve-base.js)*
- `npm install --no-save @babel/preset-env @babel/preset-react` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aws-sdk%2fs3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bc136b2288832ba51f20cbbf4b1ce7