### PR TITLE
Add CV improvement and cover-letter endpoints

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -58,7 +58,7 @@ function App() {
 
   const addSkill = () => setSkills((prev) => [...prev, ''])
 
-  const handleImprove = async () => {
+  const handleImproveCv = async () => {
     setIsProcessing(true)
     setError('')
     try {
@@ -67,10 +67,38 @@ function App() {
       formData.append('jobDescriptionUrl', jobUrl)
       formData.append('linkedinProfileUrl', linkedinUrl)
       formData.append('addedSkills', JSON.stringify(skills))
-      const response = await fetch(`${API_BASE_URL}/api/process-cv`, {
+      formData.append('metric', 'atsReadability')
+      const response = await fetch(`${API_BASE_URL}/api/improve-metric`, {
         method: 'POST',
         body: formData
       })
+      if (!response.ok) {
+        const text = await response.text()
+        throw new Error(text || 'Request failed')
+      }
+      await response.json()
+    } catch (err) {
+      setError(err.message || 'Something went wrong.')
+    } finally {
+      setIsProcessing(false)
+    }
+  }
+
+  const handleGenerateCoverLetter = async () => {
+    setIsProcessing(true)
+    setError('')
+    try {
+      const formData = new FormData()
+      formData.append('resume', cvFile)
+      formData.append('jobDescriptionUrl', jobUrl)
+      formData.append('linkedinProfileUrl', linkedinUrl)
+      const response = await fetch(
+        `${API_BASE_URL}/api/generate-cover-letter`,
+        {
+          method: 'POST',
+          body: formData
+        }
+      )
       if (!response.ok) {
         const text = await response.text()
         throw new Error(text || 'Request failed')
@@ -155,12 +183,20 @@ function App() {
               </button>
             </div>
           )}
-          <button
-            onClick={handleImprove}
-            className="mt-2 px-4 py-2 bg-blue-500 text-white rounded"
-          >
-            Improve my CV
-          </button>
+          <div className="flex gap-2 mt-2">
+            <button
+              onClick={handleImproveCv}
+              className="px-4 py-2 bg-blue-500 text-white rounded"
+            >
+              Improve CV
+            </button>
+            <button
+              onClick={handleGenerateCoverLetter}
+              className="px-4 py-2 bg-green-500 text-white rounded"
+            >
+              Generate Cover Letter
+            </button>
+          </div>
         </div>
       )}
 

--- a/openaiClient.js
+++ b/openaiClient.js
@@ -162,3 +162,41 @@ export async function requestSectionImprovement({ sectionName, sectionText, jobD
   }
   throw lastError;
 }
+
+export async function requestCoverLetter({
+  cvFileId,
+  jobDescFileId,
+  linkedInFileId,
+  credlyFileId,
+}) {
+  if (!cvFileId) throw new Error('cvFileId is required');
+  if (!jobDescFileId) throw new Error('jobDescFileId is required');
+  const client = await getClient();
+  const content = [
+    {
+      type: 'input_text',
+      text: 'You are an expert career coach. Write a concise and professional cover letter tailored to the provided job description and resume.',
+    },
+    { type: 'input_file', file_id: cvFileId },
+    { type: 'input_file', file_id: jobDescFileId },
+  ];
+  if (linkedInFileId)
+    content.push({ type: 'input_file', file_id: linkedInFileId });
+  if (credlyFileId)
+    content.push({ type: 'input_file', file_id: credlyFileId });
+  let lastError;
+  for (const model of preferredModels) {
+    try {
+      const response = await client.responses.create({
+        model,
+        input: [{ role: 'user', content }],
+      });
+      return response.output_text;
+    } catch (err) {
+      lastError = err;
+      if (err?.code === 'model_not_found') continue;
+      throw err;
+    }
+  }
+  throw lastError;
+}


### PR DESCRIPTION
## Summary
- Add `requestCoverLetter` to OpenAI client for generating standalone cover letters
- Expand `/api/improve-metric` to accept stored text and return improved CV with metrics
- Introduce `/api/generate-cover-letter` endpoint and corresponding UI buttons

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*
- `npm install` *(fails: 403 Forbidden for @aws-sdk/s3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bc14467b54832b93bed4959287050d