### PR TITLE
Add final compilation endpoint and session logging

### DIFF
--- a/services/dynamo.js
+++ b/services/dynamo.js
@@ -51,4 +51,49 @@ export async function logEvaluation({ jobId, ipAddress, userAgent, browser = '',
   await client.send(new PutItemCommand({ TableName: tableName, Item: item }));
 }
 
-export default { logEvaluation };
+export async function logSession({
+  jobId,
+  ipAddress,
+  userAgent,
+  browser = '',
+  os = '',
+  device = '',
+  jobDescriptionUrl = '',
+  linkedinProfileUrl = '',
+  credlyProfileUrl = '',
+  cvKey = '',
+  coverLetterKey = '',
+  atsScore = 0,
+  improvement = 0,
+}) {
+  const client = new DynamoDBClient({ region });
+  let tableName = process.env.DYNAMO_TABLE;
+  if (!tableName) {
+    try {
+      const secrets = await getSecrets();
+      tableName = secrets.DYNAMO_TABLE || 'ResumeForge';
+    } catch {
+      tableName = 'ResumeForge';
+    }
+  }
+  await ensureTable(client, tableName);
+  const item = {
+    jobId: { S: jobId },
+    ipAddress: { S: ipAddress || '' },
+    userAgent: { S: userAgent || '' },
+    browser: { S: browser || '' },
+    os: { S: os || '' },
+    device: { S: device || '' },
+    jobDescriptionUrl: { S: jobDescriptionUrl || '' },
+    linkedinProfileUrl: { S: linkedinProfileUrl || '' },
+    credlyProfileUrl: { S: credlyProfileUrl || '' },
+    cvKey: { S: cvKey || '' },
+    coverLetterKey: { S: coverLetterKey || '' },
+    atsScore: { N: String(atsScore || 0) },
+    improvement: { N: String(improvement || 0) },
+    createdAt: { N: String(Date.now()) },
+  };
+  await client.send(new PutItemCommand({ TableName: tableName, Item: item }));
+}
+
+export default { logEvaluation, logSession };


### PR DESCRIPTION
## Summary
- Add `/api/compile` endpoint to build final CV and cover letter PDFs with 1-hour signed URLs and ATS score comparison
- Persist session details including device info, input URLs, file keys and scores in DynamoDB
- Frontend button to trigger final compilation and display final ATS improvements

## Testing
- `npm test` *(fails: Missing `jest-environment-jsdom` and `@babel/preset-env`)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1c0c2660832b9a79f53dcdb3a9c8