### PR TITLE
feat: add drag-and-drop CV upload

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -18,15 +18,33 @@ function App() {
   const [cvTextKey, setCvTextKey] = useState('')
   const [finalScore, setFinalScore] = useState(null)
   const [improvement, setImprovement] = useState(null)
+  const [isDragging, setIsDragging] = useState(false)
   const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
 
   const handleFileChange = (e) => {
-    const file = e.target.files[0]
+    const file = e.target ? e.target.files[0] : e
     if (file && !file.name.toLowerCase().match(/\.(pdf|docx)$/)) {
       setError('Only PDF or DOCX files are supported.')
       return
     }
     setCvFile(file)
+  }
+
+  const handleDragOver = (e) => {
+    e.preventDefault()
+    setIsDragging(true)
+  }
+
+  const handleDragLeave = (e) => {
+    e.preventDefault()
+    setIsDragging(false)
+  }
+
+  const handleDrop = (e) => {
+    e.preventDefault()
+    setIsDragging(false)
+    const file = e.dataTransfer.files[0]
+    if (file) handleFileChange(file)
   }
 
   const handleSubmit = async () => {
@@ -198,13 +216,22 @@ function App() {
         Upload your CV and provide the job description URL to evaluate how well it matches.
       </p>
 
-      <input
-        type="file"
-        accept=".pdf,.docx"
-        onChange={handleFileChange}
-        className="mb-4"
-        aria-label="Choose File"
-      />
+      <div
+        data-testid="dropzone"
+        className={`mb-4 p-4 border-2 border-dashed rounded ${
+          isDragging ? 'border-blue-500 bg-blue-100' : 'border-purple-300'
+        }`}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        <input
+          type="file"
+          accept=".pdf,.docx"
+          onChange={handleFileChange}
+          aria-label="Choose File"
+        />
+      </div>
 
       <input
         type="url"

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -44,3 +44,26 @@ test('evaluates CV and displays results', async () => {
   const skillInputs = await screen.findAllByPlaceholderText('Skill')
   expect(skillInputs.length).toBe(2)
 })
+
+test('allows file to be dropped in drop zone', async () => {
+  window.alert = jest.fn()
+  fetch.mockClear()
+  render(<App />)
+  const dropZone = screen.getByTestId('dropzone')
+  const file = new File(['dummy'], 'resume.pdf', { type: 'application/pdf' })
+  fireEvent.drop(dropZone, { dataTransfer: { files: [file] } })
+  fireEvent.change(screen.getByPlaceholderText('Job Description URL'), {
+    target: { value: 'https://indeed.com/job' }
+  })
+  fireEvent.click(screen.getByText('Evaluate me against the JD'))
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
+})
+
+test('highlights drop zone on drag over', () => {
+  render(<App />)
+  const dropZone = screen.getByTestId('dropzone')
+  fireEvent.dragOver(dropZone)
+  expect(dropZone.className).toMatch('border-blue-500')
+  fireEvent.dragLeave(dropZone)
+  expect(dropZone.className).not.toMatch('border-blue-500')
+})


### PR DESCRIPTION
## Summary
- support dragging a resume file into a highlighted drop zone
- track drag state to toggle Tailwind border and background
- test drag-and-drop behavior and highlighting

## Testing
- `npm install @babel/preset-env @babel/preset-react` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aws-sdk%2fs3-request-presigner)*
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc20f70058832b950f10358e1cd2d5