### PR TITLE
Handle optional URLs in Dynamo logging

### DIFF
--- a/services/dynamo.js
+++ b/services/dynamo.js
@@ -29,8 +29,8 @@ async function ensureTable(client, tableName) {
 
 export async function logEvaluation({
   jobId,
-  ipAddress,
-  userAgent,
+  ipAddress = '',
+  userAgent = '',
   browser = '',
   os = '',
   device = '',
@@ -50,26 +50,35 @@ export async function logEvaluation({
     }
   }
   await ensureTable(client, tableName);
+
   const item = {
     jobId: { S: jobId },
-    ipAddress: { S: ipAddress || '' },
-    userAgent: { S: userAgent || '' },
-    browser: { S: browser || '' },
-    os: { S: os || '' },
-    device: { S: device || '' },
-    jobDescriptionUrl: { S: jobDescriptionUrl || '' },
-    linkedinProfileUrl: { S: linkedinProfileUrl || '' },
-    credlyProfileUrl: { S: credlyProfileUrl || '' },
-    docType: { S: docType || '' },
     createdAt: { N: String(Date.now()) }
   };
+
+  const addString = (key, value) => {
+    if (typeof value === 'string' && value.trim()) {
+      item[key] = { S: value };
+    }
+  };
+
+  addString('ipAddress', ipAddress);
+  addString('userAgent', userAgent);
+  addString('browser', browser);
+  addString('os', os);
+  addString('device', device);
+  addString('jobDescriptionUrl', jobDescriptionUrl);
+  addString('linkedinProfileUrl', linkedinProfileUrl);
+  addString('credlyProfileUrl', credlyProfileUrl);
+  addString('docType', docType);
+
   await client.send(new PutItemCommand({ TableName: tableName, Item: item }));
 }
 
 export async function logSession({
   jobId,
-  ipAddress,
-  userAgent,
+  ipAddress = '',
+  userAgent = '',
   browser = '',
   os = '',
   device = '',
@@ -92,22 +101,31 @@ export async function logSession({
     }
   }
   await ensureTable(client, tableName);
+
   const item = {
     jobId: { S: jobId },
-    ipAddress: { S: ipAddress || '' },
-    userAgent: { S: userAgent || '' },
-    browser: { S: browser || '' },
-    os: { S: os || '' },
-    device: { S: device || '' },
-    jobDescriptionUrl: { S: jobDescriptionUrl || '' },
-    linkedinProfileUrl: { S: linkedinProfileUrl || '' },
-    credlyProfileUrl: { S: credlyProfileUrl || '' },
-    cvKey: { S: cvKey || '' },
-    coverLetterKey: { S: coverLetterKey || '' },
-    atsScore: { N: String(atsScore || 0) },
-    improvement: { N: String(improvement || 0) },
     createdAt: { N: String(Date.now()) },
+    atsScore: { N: String(atsScore || 0) },
+    improvement: { N: String(improvement || 0) }
   };
+
+  const addString = (key, value) => {
+    if (typeof value === 'string' && value.trim()) {
+      item[key] = { S: value };
+    }
+  };
+
+  addString('ipAddress', ipAddress);
+  addString('userAgent', userAgent);
+  addString('browser', browser);
+  addString('os', os);
+  addString('device', device);
+  addString('jobDescriptionUrl', jobDescriptionUrl);
+  addString('linkedinProfileUrl', linkedinProfileUrl);
+  addString('credlyProfileUrl', credlyProfileUrl);
+  addString('cvKey', cvKey);
+  addString('coverLetterKey', coverLetterKey);
+
   await client.send(new PutItemCommand({ TableName: tableName, Item: item }));
 }
 

--- a/tests/dynamoLogEvaluation.test.js
+++ b/tests/dynamoLogEvaluation.test.js
@@ -1,0 +1,56 @@
+import { jest } from '@jest/globals';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { logEvaluation } from '../services/dynamo.js';
+
+describe('logEvaluation optional fields', () => {
+  beforeEach(() => {
+    process.env.DYNAMO_TABLE = 'test';
+  });
+
+  afterEach(() => {
+    delete process.env.DYNAMO_TABLE;
+    jest.restoreAllMocks();
+  });
+
+  test('includes linkedinProfileUrl when provided', async () => {
+    const sendMock = jest
+      .spyOn(DynamoDBClient.prototype, 'send')
+      .mockResolvedValue({});
+
+    await logEvaluation({
+      jobId: '1',
+      ipAddress: 'ip',
+      userAgent: 'ua',
+      jobDescriptionUrl: 'https://example.com/job',
+      linkedinProfileUrl: 'https://linkedin.com/in/example',
+      docType: 'resume',
+    });
+
+    const putCall = sendMock.mock.calls.find(
+      ([cmd]) => cmd.__type === 'PutItemCommand'
+    );
+    expect(putCall[0].input.Item.linkedinProfileUrl).toEqual({
+      S: 'https://linkedin.com/in/example',
+    });
+  });
+
+  test('omits linkedinProfileUrl when not provided', async () => {
+    const sendMock = jest
+      .spyOn(DynamoDBClient.prototype, 'send')
+      .mockResolvedValue({});
+
+    await logEvaluation({
+      jobId: '2',
+      ipAddress: 'ip',
+      userAgent: 'ua',
+      jobDescriptionUrl: 'https://example.com/job',
+      docType: 'resume',
+    });
+
+    const putCall = sendMock.mock.calls.find(
+      ([cmd]) => cmd.__type === 'PutItemCommand'
+    );
+    expect(putCall[0].input.Item.linkedinProfileUrl).toBeUndefined();
+  });
+});
+

--- a/tests/evaluateLinkedInDiff.test.js
+++ b/tests/evaluateLinkedInDiff.test.js
@@ -58,7 +58,10 @@ describe('/api/evaluate LinkedIn diff', () => {
     ]);
     const { logEvaluation } = await import('../services/dynamo.js');
     expect(logEvaluation).toHaveBeenCalledWith(
-      expect.objectContaining({ docType: 'resume' })
+      expect.objectContaining({
+        docType: 'resume',
+        linkedinProfileUrl: 'https://linkedin.com/in/example',
+      })
     );
   });
 });

--- a/tests/evaluateRejectNonResume.test.js
+++ b/tests/evaluateRejectNonResume.test.js
@@ -31,7 +31,10 @@ describe('/api/evaluate non-resume', () => {
     );
     const { logEvaluation } = await import('../services/dynamo.js');
     expect(logEvaluation).toHaveBeenCalledWith(
-      expect.objectContaining({ docType: 'cover letter' })
+      expect.objectContaining({
+        docType: 'cover letter',
+        linkedinProfileUrl: undefined,
+      })
     );
   });
 });


### PR DESCRIPTION
## Summary
- Avoid DynamoDB empty-string errors by adding optional fields only when present in logEvaluation and logSession
- Expand evaluation tests to check logging with/without LinkedIn URLs
- Add unit test ensuring logEvaluation handles LinkedIn URL presence/absence

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found / missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bc22e0f904832bad671638bae70b39