### PR TITLE
Default missing LinkedIn URLs when logging to DynamoDB

### DIFF
--- a/services/dynamo.js
+++ b/services/dynamo.js
@@ -56,6 +56,12 @@ export async function logEvaluation({
     createdAt: { N: String(Date.now()) }
   };
 
+  const safeLinkedin =
+    typeof linkedinProfileUrl === 'string' && linkedinProfileUrl.trim()
+      ? linkedinProfileUrl
+      : 'unknown';
+  item.linkedinProfileUrl = { S: safeLinkedin };
+
   const addString = (key, value) => {
     if (typeof value === 'string' && value.trim()) {
       item[key] = { S: value };
@@ -68,7 +74,6 @@ export async function logEvaluation({
   addString('os', os);
   addString('device', device);
   addString('jobDescriptionUrl', jobDescriptionUrl);
-  addString('linkedinProfileUrl', linkedinProfileUrl);
   addString('credlyProfileUrl', credlyProfileUrl);
   addString('docType', docType);
 
@@ -109,6 +114,12 @@ export async function logSession({
     improvement: { N: String(improvement || 0) }
   };
 
+  const safeLinkedin =
+    typeof linkedinProfileUrl === 'string' && linkedinProfileUrl.trim()
+      ? linkedinProfileUrl
+      : 'unknown';
+  item.linkedinProfileUrl = { S: safeLinkedin };
+
   const addString = (key, value) => {
     if (typeof value === 'string' && value.trim()) {
       item[key] = { S: value };
@@ -121,7 +132,6 @@ export async function logSession({
   addString('os', os);
   addString('device', device);
   addString('jobDescriptionUrl', jobDescriptionUrl);
-  addString('linkedinProfileUrl', linkedinProfileUrl);
   addString('credlyProfileUrl', credlyProfileUrl);
   addString('cvKey', cvKey);
   addString('coverLetterKey', coverLetterKey);

--- a/tests/dynamoLogEvaluation.test.js
+++ b/tests/dynamoLogEvaluation.test.js
@@ -50,7 +50,9 @@ describe('logEvaluation optional fields', () => {
     const putCall = sendMock.mock.calls.find(
       ([cmd]) => cmd.__type === 'PutItemCommand'
     );
-    expect(putCall[0].input.Item.linkedinProfileUrl).toBeUndefined();
+    expect(putCall[0].input.Item.linkedinProfileUrl).toEqual({
+      S: 'unknown',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- ensure DynamoDB logging always includes a linkedinProfileUrl, defaulting to `unknown` when none supplied
- verify table schema uses only `jobId` as the partition key
- update tests to expect fallback value

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bc248bb908832b9c1da2b68fb55609