### PR TITLE
Handle designation mismatch in UI

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,7 +10,6 @@ function App() {
   const [error, setError] = useState('')
   const [isProcessing, setIsProcessing] = useState(false)
   const [designationOverride, setDesignationOverride] = useState('')
-  const [showDesignationInput, setShowDesignationInput] = useState(false)
   const [expOptions, setExpOptions] = useState([])
   const [eduOptions, setEduOptions] = useState([])
   const [certOptions, setCertOptions] = useState([])
@@ -81,10 +80,6 @@ function App() {
           checked: false
         }))
       )
-      if (!data.designationMatch) {
-        alert('Designation mismatch detected. Please enter a revised designation.')
-        setShowDesignationInput(true)
-      }
     } catch (err) {
       setError(err.message || 'Something went wrong.')
     } finally {
@@ -280,8 +275,20 @@ function App() {
         <div className="mt-6 w-full max-w-md p-4 bg-gradient-to-r from-white to-purple-50 rounded shadow">
           <p className="text-purple-800 mb-2">ATS Score: {result.atsScore}%</p>
           <p className="text-purple-800 mb-2">
-            Designation: {result.originalTitle || 'N/A'} vs {result.jobTitle || 'N/A'} ({result.designationMatch ? 'Match' : 'Mismatch'})
+            Designation: {result.originalTitle || 'N/A'} vs {result.jobTitle || 'N/A'}
           </p>
+          {!result.designationMatch && (
+            <div className="mb-2 text-red-600">
+              <p className="mb-2">Designation mismatch</p>
+              <input
+                type="text"
+                placeholder="Revised Designation"
+                value={designationOverride}
+                onChange={(e) => setDesignationOverride(e.target.value)}
+                className="w-full p-2 border border-purple-300 rounded"
+              />
+            </div>
+          )}
           {skills.length > 0 && (
             <div className="text-purple-800 mb-2">
               <p className="mb-2">Missing skills:</p>
@@ -379,17 +386,6 @@ function App() {
         </div>
       )}
 
-      {showDesignationInput && (
-        <div className="mt-4 w-full max-w-md">
-          <input
-            type="text"
-            placeholder="Revised Designation"
-            value={designationOverride}
-            onChange={(e) => setDesignationOverride(e.target.value)}
-            className="w-full p-2 border border-purple-300 rounded mb-4"
-          />
-        </div>
-      )}
     </div>
   )
 }

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -20,7 +20,6 @@ global.fetch = jest.fn(() =>
 )
 
 test('evaluates CV and displays results', async () => {
-  window.alert = jest.fn()
   render(<App />)
   const file = new File(['dummy'], 'resume.pdf', { type: 'application/pdf' })
   fireEvent.change(screen.getByLabelText('Choose File'), {
@@ -31,11 +30,11 @@ test('evaluates CV and displays results', async () => {
   })
   fireEvent.click(screen.getByText('Evaluate me against the JD'))
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
-  expect(window.alert).toHaveBeenCalled()
   expect(await screen.findByText(/ATS Score: 70%/)).toBeInTheDocument()
   expect(
     await screen.findByText(/Designation: Developer vs Senior Developer/)
   ).toBeInTheDocument()
+  expect(await screen.findByText(/Designation mismatch/)).toBeInTheDocument()
   expect(
     await screen.findByPlaceholderText('Revised Designation')
   ).toBeInTheDocument()
@@ -46,7 +45,6 @@ test('evaluates CV and displays results', async () => {
 })
 
 test('allows file to be dropped in drop zone', async () => {
-  window.alert = jest.fn()
   fetch.mockClear()
   render(<App />)
   const dropZone = screen.getByTestId('dropzone')


### PR DESCRIPTION
## Summary
- Remove alert for designation mismatches and show mismatch message inline with original and job titles
- Auto-display revised designation input when job title differs
- Update tests to reflect new mismatch handling

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2c36e1dc832bba812ac4202ee4b8