### PR TITLE
feat: improve CV dropzone behavior

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 
 function App() {
   const [jobUrl, setJobUrl] = useState('')
@@ -18,6 +18,7 @@ function App() {
   const [finalScore, setFinalScore] = useState(null)
   const [improvement, setImprovement] = useState(null)
   const [isDragging, setIsDragging] = useState(false)
+  const fileInputRef = useRef(null)
   const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
 
   const handleFileChange = (e) => {
@@ -224,16 +225,20 @@ function App() {
         data-testid="dropzone"
         className={`mb-4 p-4 border-2 border-dashed rounded ${
           isDragging ? 'border-blue-500 bg-blue-100' : 'border-purple-300'
-        }`}
+        } cursor-pointer text-center text-purple-700`}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
+        onClick={() => fileInputRef.current && fileInputRef.current.click()}
       >
+        <p>Drag & drop your CV here or click to browse</p>
         <input
+          ref={fileInputRef}
           type="file"
           accept=".pdf,.docx"
           onChange={handleFileChange}
           aria-label="Choose File"
+          className="sr-only"
         />
       </div>
 

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -22,9 +22,12 @@ global.fetch = jest.fn(() =>
 test('evaluates CV and displays results', async () => {
   render(<App />)
   const file = new File(['dummy'], 'resume.pdf', { type: 'application/pdf' })
-  fireEvent.change(screen.getByLabelText('Choose File'), {
-    target: { files: [file] }
-  })
+  fireEvent.change(
+    screen.getByLabelText('Choose File', { selector: 'input', hidden: true }),
+    {
+      target: { files: [file] }
+    }
+  )
   fireEvent.change(screen.getByPlaceholderText('Job Description URL'), {
     target: { value: 'https://indeed.com/job' }
   })
@@ -49,7 +52,13 @@ test('allows file to be dropped in drop zone', async () => {
   render(<App />)
   const dropZone = screen.getByTestId('dropzone')
   const file = new File(['dummy'], 'resume.pdf', { type: 'application/pdf' })
-  fireEvent.drop(dropZone, { dataTransfer: { files: [file] } })
+  const dropEvent = new Event('drop', { bubbles: true })
+  Object.assign(dropEvent, {
+    dataTransfer: { files: [file] },
+    preventDefault: jest.fn()
+  })
+  dropZone.dispatchEvent(dropEvent)
+  expect(dropEvent.preventDefault).toHaveBeenCalled()
   fireEvent.change(screen.getByPlaceholderText('Job Description URL'), {
     target: { value: 'https://indeed.com/job' }
   })
@@ -60,8 +69,15 @@ test('allows file to be dropped in drop zone', async () => {
 test('highlights drop zone on drag over', () => {
   render(<App />)
   const dropZone = screen.getByTestId('dropzone')
-  fireEvent.dragOver(dropZone)
+  const dragOverEvent = new Event('dragover', { bubbles: true })
+  dragOverEvent.preventDefault = jest.fn()
+  dropZone.dispatchEvent(dragOverEvent)
+  expect(dragOverEvent.preventDefault).toHaveBeenCalled()
   expect(dropZone.className).toMatch('border-blue-500')
-  fireEvent.dragLeave(dropZone)
+
+  const dragLeaveEvent = new Event('dragleave', { bubbles: true })
+  dragLeaveEvent.preventDefault = jest.fn()
+  dropZone.dispatchEvent(dragLeaveEvent)
+  expect(dragLeaveEvent.preventDefault).toHaveBeenCalled()
   expect(dropZone.className).not.toMatch('border-blue-500')
 })


### PR DESCRIPTION
## Summary
- add hidden file input and clickable text to drop zone for CV upload
- test drag-and-drop to ensure default behavior is prevented

## Testing
- `npm test` *(fails: cannot find test environment jest-environment-jsdom and @babel/preset-env)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2ea8cc70832b880d3ada6286becb