### PR TITLE
feat: expose detailed ats metrics

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,18 @@
 import { useState, useRef } from 'react'
 
+const metricTips = {
+  layoutSearchability: 'Use bullet points for better scanning.',
+  atsReadability: 'Simplify language and shorten sentences.',
+  impact: 'Emphasize strong action verbs and results.',
+  crispness: 'Keep sentences concise.',
+  keywordDensity: 'Repeat relevant keywords naturally.',
+  sectionHeadingClarity: 'Use clear section headings like Experience.',
+  contactInfoCompleteness: 'Include email, phone, and LinkedIn.'
+}
+
+const formatMetricName = (name) =>
+  name.replace(/([A-Z])/g, ' $1').replace(/^./, (c) => c.toUpperCase())
+
 function App() {
   const [jobUrl, setJobUrl] = useState('')
   const [cvFile, setCvFile] = useState(null)
@@ -249,6 +262,25 @@ function App() {
       {result && (
         <div className="mt-6 w-full max-w-md p-4 bg-gradient-to-r from-white to-purple-50 rounded shadow">
           <p className="text-purple-800 mb-2">ATS Score: {result.atsScore}%</p>
+          {result.atsMetrics && (
+            <div className="text-purple-800 mb-2">
+              <p className="font-semibold mb-1">ATS Breakdown</p>
+              <ul>
+                {Object.entries(result.atsMetrics).map(([metric, score]) => (
+                  <li key={metric} className="mb-1">
+                    <span>
+                      {formatMetricName(metric)}: {score}%
+                    </span>
+                    {score < 70 && metricTips[metric] && (
+                      <span className="block text-sm text-purple-600">
+                        {metricTips[metric]}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
           <p className="text-purple-800 mb-2">
             Designation: {result.originalTitle || 'N/A'} vs {result.jobTitle || 'N/A'}
             {!result.designationMatch ? ' (Mismatch)' : ''}

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -8,7 +8,16 @@ const mockResponse = {
   jobTitle: 'Senior Developer',
   originalTitle: 'Developer',
   designationMatch: false,
-  missingSkills: ['aws']
+  missingSkills: ['aws'],
+  atsMetrics: {
+    layoutSearchability: 50,
+    atsReadability: 60,
+    impact: 80,
+    crispness: 90,
+    keywordDensity: 40,
+    sectionHeadingClarity: 100,
+    contactInfoCompleteness: 30
+  }
 }
 
 global.fetch = jest.fn(() =>
@@ -34,6 +43,12 @@ test('evaluates CV and displays results', async () => {
   fireEvent.click(screen.getByText('Evaluate me against the JD'))
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
   expect(await screen.findByText(/ATS Score: 70%/)).toBeInTheDocument()
+  expect(
+    await screen.findByText(/Layout Searchability: 50%/)
+  ).toBeInTheDocument()
+  expect(
+    await screen.findByText('Include email, phone, and LinkedIn.')
+  ).toBeInTheDocument()
   expect(
     await screen.findByText(/Designation: Developer vs Senior Developer/)
   ).toBeInTheDocument()

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -232,6 +232,7 @@ export default function registerProcessCv(app) {
 
         res.json({
           atsScore,
+          atsMetrics,
           jobTitle,
           originalTitle,
           designationMatch,

--- a/tests/evaluateMetrics.test.js
+++ b/tests/evaluateMetrics.test.js
@@ -1,0 +1,43 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+jest.unstable_mockModule('axios', () => ({
+  default: { get: jest.fn().mockResolvedValue({ data: '' }) }
+}));
+
+jest.unstable_mockModule('pdf-parse/lib/pdf-parse.js', () => ({
+  default: jest.fn().mockResolvedValue({ text: 'Experience\n- Engineer at Company\nEducation\n- Uni' })
+}));
+
+jest.unstable_mockModule('mammoth', () => ({
+  default: { extractRawText: jest.fn().mockResolvedValue({ value: '' }) }
+}));
+
+jest.unstable_mockModule('../services/dynamo.js', () => ({
+  logEvaluation: jest.fn().mockResolvedValue()
+}));
+
+const serverModule = await import('../server.js');
+const app = serverModule.default;
+
+describe('/api/evaluate metrics', () => {
+  test('returns individual ats metrics', async () => {
+    const res = await request(app)
+      .post('/api/evaluate')
+      .field('jobDescriptionUrl', 'https://indeed.com/job')
+      .attach('resume', Buffer.from('dummy'), 'resume.pdf');
+    expect(res.status).toBe(200);
+    expect(res.body.atsMetrics).toBeDefined();
+    expect(res.body.atsMetrics).toEqual(
+      expect.objectContaining({
+        layoutSearchability: expect.any(Number),
+        atsReadability: expect.any(Number),
+        impact: expect.any(Number),
+        crispness: expect.any(Number),
+        keywordDensity: expect.any(Number),
+        sectionHeadingClarity: expect.any(Number),
+        contactInfoCompleteness: expect.any(Number)
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- include per-category ATS metrics in `/api/evaluate`
- show ATS score breakdown and improvement tips in the client
- add tests for metric output and scoreboard rendering

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bc3a4cc71c832b9c4ac5ac28ac705c