### PR TITLE
Remove domain whitelist from URL validation

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -19,7 +19,6 @@ import {
   uploadResume,
   parseUserAgent,
   validateUrl,
-  allowedDomains,
   extractText,
   classifyDocument,
   extractName,
@@ -105,17 +104,17 @@ export default function registerProcessCv(app) {
         let { jobDescriptionUrl, linkedinProfileUrl, credlyProfileUrl } = req.body;
         if (!jobDescriptionUrl)
           return next(createError(400, 'jobDescriptionUrl required'));
-        jobDescriptionUrl = validateUrl(jobDescriptionUrl, allowedDomains);
+        jobDescriptionUrl = validateUrl(jobDescriptionUrl);
         if (!jobDescriptionUrl)
           return next(createError(400, 'invalid jobDescriptionUrl'));
 
         if (linkedinProfileUrl) {
-          linkedinProfileUrl = validateUrl(linkedinProfileUrl, allowedDomains);
+          linkedinProfileUrl = validateUrl(linkedinProfileUrl);
           if (!linkedinProfileUrl)
             return next(createError(400, 'invalid linkedinProfileUrl'));
         }
         if (credlyProfileUrl) {
-          credlyProfileUrl = validateUrl(credlyProfileUrl, ['credly.com']);
+          credlyProfileUrl = validateUrl(credlyProfileUrl);
           if (!credlyProfileUrl)
             return next(createError(400, 'invalid credlyProfileUrl'));
         }
@@ -355,16 +354,16 @@ export default function registerProcessCv(app) {
     if (!linkedinProfileUrl) {
       return next(createError(400, 'linkedinProfileUrl required'));
     }
-    jobDescriptionUrl = validateUrl(jobDescriptionUrl, allowedDomains);
+    jobDescriptionUrl = validateUrl(jobDescriptionUrl);
     if (!jobDescriptionUrl) {
       return next(createError(400, 'invalid jobDescriptionUrl'));
     }
-    linkedinProfileUrl = validateUrl(linkedinProfileUrl, ['linkedin.com']);
+    linkedinProfileUrl = validateUrl(linkedinProfileUrl);
     if (!linkedinProfileUrl) {
       return next(createError(400, 'invalid linkedinProfileUrl'));
     }
     if (credlyProfileUrl) {
-      credlyProfileUrl = validateUrl(credlyProfileUrl, ['credly.com']);
+      credlyProfileUrl = validateUrl(credlyProfileUrl);
       if (!credlyProfileUrl) {
         return next(createError(400, 'invalid credlyProfileUrl'));
       }
@@ -750,14 +749,14 @@ export default function registerProcessCv(app) {
         createError(400, 'existingCvKey or existingCvTextKey required')
       );
 
-    jobDescriptionUrl = validateUrl(jobDescriptionUrl, allowedDomains);
+    jobDescriptionUrl = validateUrl(jobDescriptionUrl);
     if (!jobDescriptionUrl)
       return next(createError(400, 'invalid jobDescriptionUrl'));
-    linkedinProfileUrl = validateUrl(linkedinProfileUrl, ['linkedin.com']);
+    linkedinProfileUrl = validateUrl(linkedinProfileUrl);
     if (!linkedinProfileUrl)
       return next(createError(400, 'invalid linkedinProfileUrl'));
     if (credlyProfileUrl) {
-      credlyProfileUrl = validateUrl(credlyProfileUrl, ['credly.com']);
+      credlyProfileUrl = validateUrl(credlyProfileUrl);
       if (!credlyProfileUrl)
         return next(createError(400, 'invalid credlyProfileUrl'));
     }
@@ -941,14 +940,14 @@ export default function registerProcessCv(app) {
       if (!linkedinProfileUrl)
         return next(createError(400, 'linkedinProfileUrl required'));
 
-      jobDescriptionUrl = validateUrl(jobDescriptionUrl, allowedDomains);
+      jobDescriptionUrl = validateUrl(jobDescriptionUrl);
       if (!jobDescriptionUrl)
         return next(createError(400, 'invalid jobDescriptionUrl'));
-      linkedinProfileUrl = validateUrl(linkedinProfileUrl, ['linkedin.com']);
+      linkedinProfileUrl = validateUrl(linkedinProfileUrl);
       if (!linkedinProfileUrl)
         return next(createError(400, 'invalid linkedinProfileUrl'));
       if (credlyProfileUrl) {
-        credlyProfileUrl = validateUrl(credlyProfileUrl, ['credly.com']);
+        credlyProfileUrl = validateUrl(credlyProfileUrl);
         if (!credlyProfileUrl)
           return next(createError(400, 'invalid credlyProfileUrl'));
       }
@@ -1110,14 +1109,14 @@ export default function registerProcessCv(app) {
           createError(400, 'existingCvKey or existingCvTextKey required')
         );
 
-      jobDescriptionUrl = validateUrl(jobDescriptionUrl, allowedDomains);
+      jobDescriptionUrl = validateUrl(jobDescriptionUrl);
       if (!jobDescriptionUrl)
         return next(createError(400, 'invalid jobDescriptionUrl'));
-      linkedinProfileUrl = validateUrl(linkedinProfileUrl, ['linkedin.com']);
+      linkedinProfileUrl = validateUrl(linkedinProfileUrl);
       if (!linkedinProfileUrl)
         return next(createError(400, 'invalid linkedinProfileUrl'));
       if (credlyProfileUrl) {
-        credlyProfileUrl = validateUrl(credlyProfileUrl, ['credly.com']);
+        credlyProfileUrl = validateUrl(credlyProfileUrl);
         if (!credlyProfileUrl)
           return next(createError(400, 'invalid credlyProfileUrl'));
       }

--- a/server.js
+++ b/server.js
@@ -85,12 +85,10 @@ function createRateLimiter({ windowMs, max } = {}) {
   );
 }
 
-const allowedDomains = ['indeed.com', 'linkedin.com'];
-
-function validateUrl(input, whitelist = []) {
+function validateUrl(input) {
   try {
     const url = new URL(String(input));
-    if (url.protocol !== 'https:') return null;
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
     const host = url.hostname.toLowerCase();
     if (
       net.isIP(host) ||
@@ -104,11 +102,6 @@ function validateUrl(input, whitelist = []) {
       /^fd00:/i.test(host) ||
       /^fe80:/i.test(host) ||
       host === '::1'
-    )
-      return null;
-    if (
-      whitelist.length &&
-      !whitelist.some((d) => host === d || host.endsWith(`.${d}`))
     )
       return null;
     return url.toString();
@@ -273,7 +266,7 @@ const region = process.env.AWS_REGION || 'ap-south-1';
 const REQUEST_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS, 10) || 5000;
 
 async function fetchLinkedInProfile(url) {
-  const valid = validateUrl(url, ['linkedin.com']);
+  const valid = validateUrl(url);
   if (!valid) throw new Error('Invalid LinkedIn URL');
   try {
     const { data: html } = await axios.get(valid, { timeout: REQUEST_TIMEOUT_MS });
@@ -369,7 +362,7 @@ async function fetchLinkedInProfile(url) {
 }
 
 async function fetchCredlyProfile(url) {
-  const valid = validateUrl(url, ['credly.com']);
+  const valid = validateUrl(url);
   if (!valid) throw new Error('Invalid Credly URL');
   try {
     const { data: html } = await axios.get(valid, { timeout: REQUEST_TIMEOUT_MS });
@@ -962,7 +955,6 @@ export {
   uploadResume,
   parseUserAgent,
   validateUrl,
-  allowedDomains,
   extractName,
   sanitizeName,
   region,


### PR DESCRIPTION
## Summary
- simplify URL validation to only allow http/https and block private IPs
- allow any domain for job description and profile links in CV processing

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*
- `npm install` *(fails: 403 Forbidden fetching @aws-sdk/s3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bc49426620832b9c485f5d85ef635f