### PR TITLE
Add 2025 style cover letter template and PDF generation

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -38,7 +38,8 @@ import {
   region,
   REQUEST_TIMEOUT_MS,
   sanitizeGeneratedText,
-  parseAiJson
+  parseAiJson,
+  generatePdf
 } from '../server.js';
 
 const createError = (status, message) => {
@@ -933,6 +934,7 @@ export default function registerProcessCv(app) {
         credlyProfileUrl,
         existingCvTextKey,
         selectedCertifications,
+        coverTemplate,
       } = req.body;
 
       if (!jobDescriptionUrl)
@@ -961,6 +963,10 @@ export default function registerProcessCv(app) {
           if (Array.isArray(arr)) selectedCertificationsArr = arr;
         }
       } catch {}
+
+      let coverTemplateId = coverTemplate;
+      if (!CL_TEMPLATES.includes(coverTemplateId))
+        coverTemplateId = CL_TEMPLATES[0];
 
       let originalText = '';
       let cvBuffer;
@@ -1036,7 +1042,10 @@ export default function registerProcessCv(app) {
         defaultHeading: '',
       });
 
-      const clPdf = await convertToPdf(sanitizedCoverLetter);
+      const clPdf = await generatePdf(sanitizedCoverLetter, coverTemplateId, {
+        skipRequiredSections: true,
+        defaultHeading: '',
+      });
       const date = new Date().toISOString().split('T')[0];
       const key = path.join(
         sanitizedName,
@@ -1250,7 +1259,10 @@ export default function registerProcessCv(app) {
         skipRequiredSections: true,
         defaultHeading: '',
       });
-      const coverBuffer = await convertToPdf(sanitizedCover);
+      const coverBuffer = await generatePdf(sanitizedCover, coverTemplate1, {
+        skipRequiredSections: true,
+        defaultHeading: '',
+      });
       const date = new Date().toISOString().split('T')[0];
       const coverKey = path.join(
         sanitizedName,

--- a/server.js
+++ b/server.js
@@ -137,7 +137,7 @@ const upload = multer({
 const uploadResume = upload.single('resume');
 
 const CV_TEMPLATES = ['modern', 'ucmo', 'professional', 'vibrant', '2025', 'sleek'];
-const CL_TEMPLATES = ['cover_modern', 'cover_classic'];
+const CL_TEMPLATES = ['cover_modern', 'cover_classic', 'cover_2025'];
 const TEMPLATE_IDS = CV_TEMPLATES; // Backwards compatibility
 const ALL_TEMPLATES = [...CV_TEMPLATES, ...CL_TEMPLATES];
 

--- a/services/generatePdf.js
+++ b/services/generatePdf.js
@@ -18,7 +18,8 @@ const ALL_TEMPLATES = [
   '2025',
   'sleek',
   'cover_modern',
-  'cover_classic'
+  'cover_classic',
+  'cover_2025'
 ];
 
 function escapeHtml(str = '') {

--- a/templates/cover_2025.css
+++ b/templates/cover_2025.css
@@ -1,0 +1,26 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+
+:root {
+  --accent: #1f3c5d;
+}
+
+body {
+  font-family: 'Inter', sans-serif;
+  margin: 2.5rem;
+  color: #333;
+  line-height: 1.6;
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--accent);
+  margin-bottom: 1.5rem;
+}
+
+p {
+  margin: 0 0 1rem 0;
+}

--- a/templates/cover_2025.html
+++ b/templates/cover_2025.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Cover Letter</title>
+</head>
+<body>
+  <h1>{{name}}</h1>
+  {{#each sections}}
+    {{#each items}}
+      <p>{{{this}}}</p>
+    {{/each}}
+  {{/each}}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add professional 2025 HTML/CSS cover letter templates
- switch cover letter generation to use `generatePdf` with templates
- register new cover letter template in template lists

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*
- `npm install --no-save @babel/preset-env` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4d4444d8832b97e4453016486c0d