### PR TITLE
feat: add language proficiency support

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -26,6 +26,7 @@ function App() {
   const [expOptions, setExpOptions] = useState([])
   const [eduOptions, setEduOptions] = useState([])
   const [certOptions, setCertOptions] = useState([])
+  const [langOptions, setLangOptions] = useState([])
   const [cvKey, setCvKey] = useState('')
   const [cvTextKey, setCvTextKey] = useState('')
   const [finalScore, setFinalScore] = useState(null)
@@ -99,6 +100,9 @@ function App() {
           checked: false
         }))
       )
+      setLangOptions(
+        (data.missingLanguages || []).map((t) => ({ text: t, checked: false }))
+      )
       if (!data.designationMatch) {
         setDesignationOverride(data.jobTitle || '')
       }
@@ -135,6 +139,7 @@ function App() {
       const selectedCertifications = certOptions
         .filter((o) => o.checked)
         .map((o) => o.data)
+      const selectedLanguages = langOptions.filter((o) => o.checked).map((o) => o.text)
 
       // Step 1: improve CV to obtain keys
       const improveForm = new FormData()
@@ -146,6 +151,7 @@ function App() {
       improveForm.append('selectedExperience', JSON.stringify(selectedExperience))
       improveForm.append('selectedEducation', JSON.stringify(selectedEducation))
       improveForm.append('selectedCertifications', JSON.stringify(selectedCertifications))
+      improveForm.append('selectedLanguages', JSON.stringify(selectedLanguages))
       const improveResp = await fetch(`${API_BASE_URL}/api/process-cv`, {
         method: 'POST',
         body: improveForm
@@ -172,6 +178,7 @@ function App() {
       compileForm.append('selectedExperience', JSON.stringify(selectedExperience))
       compileForm.append('selectedEducation', JSON.stringify(selectedEducation))
       compileForm.append('selectedCertifications', JSON.stringify(selectedCertifications))
+      compileForm.append('selectedLanguages', JSON.stringify(selectedLanguages))
       if (designationOverride)
         compileForm.append('designation', designationOverride)
       const compileResp = await fetch(`${API_BASE_URL}/api/compile`, {
@@ -188,7 +195,7 @@ function App() {
       setCvUrl(data.cvUrl || '')
       setCoverLetterUrl(data.coverLetterUrl || '')
       setNewAdditions(
-        [...(data.addedSkills || []), data.designation].filter(Boolean)
+        [...(data.addedSkills || []), ...(data.addedLanguages || []), data.designation].filter(Boolean)
       )
     } catch (err) {
       setError(err.message || 'Something went wrong.')
@@ -362,6 +369,22 @@ function App() {
                     type="checkbox"
                     checked={opt.checked}
                     onChange={() => toggleOption(setCertOptions)(idx)}
+                    className="mr-2"
+                  />
+                  {opt.text}
+                </label>
+              ))}
+            </div>
+          )}
+          {langOptions.length > 0 && (
+            <div className="text-purple-800 mb-2">
+              <p className="mb-2">LinkedIn languages not in resume:</p>
+              {langOptions.map((opt, idx) => (
+                <label key={idx} className="block">
+                  <input
+                    type="checkbox"
+                    checked={opt.checked}
+                    onChange={() => toggleOption(setLangOptions)(idx)}
                     className="mr-2"
                   />
                   {opt.text}

--- a/openaiClient.js
+++ b/openaiClient.js
@@ -82,6 +82,18 @@ export async function requestEnhancedCV({
       original_score: { type: 'number' },
       enhanced_score: { type: 'number' },
       skills_added: { type: 'array', items: { type: 'string' } },
+      languages: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            language: { type: 'string' },
+            proficiency: { type: 'string' }
+          },
+          required: ['language'],
+          additionalProperties: false
+        }
+      },
       improvement_summary: { type: 'string' },
       metrics: {
         type: 'array',
@@ -106,6 +118,7 @@ export async function requestEnhancedCV({
       'original_score',
       'enhanced_score',
       'skills_added',
+      'languages',
       'improvement_summary',
       'metrics',
     ],

--- a/templates/2025.css
+++ b/templates/2025.css
@@ -94,6 +94,35 @@ body {
     width: 0;
   }
 
+  .languages {
+    grid-column: 1 / -1;
+  }
+
+  .languages-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+  }
+
+  .language-name {
+    font-weight: 600;
+  }
+
+  .language-bar {
+    background: #e0e0e0;
+    border-radius: 4px;
+    height: 8px;
+    margin-top: 4px;
+    overflow: hidden;
+  }
+
+  .language-fill {
+    background: var(--accent);
+    height: 100%;
+    border-radius: 4px;
+    width: 0;
+  }
+
 @media (min-width: 700px) {
   main {
     grid-template-columns: repeat(2, 1fr);

--- a/templates/2025.html
+++ b/templates/2025.html
@@ -36,6 +36,21 @@
         </div>
       </section>
       {{/if}}
+      {{#if languages}}
+      <section class="section languages">
+        <h2>Languages</h2>
+        <div class="languages-grid">
+          {{#each languages}}
+          <div class="language">
+            <span class="language-name">{{this.name}}</span>
+            <div class="language-bar">
+              <div class="language-fill" style="width: {{this.level}}%;"></div>
+            </div>
+          </div>
+          {{/each}}
+        </div>
+      </section>
+      {{/if}}
       {{#each sections}}
       <section class="section">
         {{#if heading}}<h2>{{heading}}</h2>{{/if}}

--- a/tests/fetchLinkedInProfileError.test.js
+++ b/tests/fetchLinkedInProfileError.test.js
@@ -34,7 +34,8 @@ describe('fetchLinkedInProfile error handling', () => {
       experience: [],
       education: [],
       skills: [],
-      certifications: []
+      certifications: [],
+      languages: []
     });
   });
 });

--- a/tests/mocks/openai.js
+++ b/tests/mocks/openai.js
@@ -11,6 +11,7 @@ export const requestEnhancedCV = jest.fn(async () =>
     original_score: 40,
     enhanced_score: 80,
     skills_added: ['skill1'],
+    languages: [],
     improvement_summary: 'summary',
     metrics: [],
   })

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -127,6 +127,7 @@ beforeEach(() => {
       original_score: 40,
       enhanced_score: 80,
       skills_added: ['skill1'],
+      languages: [],
       improvement_summary: 'summary',
     })
   );
@@ -355,6 +356,7 @@ describe('/api/process-cv', () => {
         original_score: 40,
         enhanced_score: 40,
         skills_added: [],
+        languages: [],
         improvement_summary: 'none',
       })
     );
@@ -385,6 +387,7 @@ describe('/api/process-cv', () => {
           original_score: 40,
           enhanced_score: 80,
           skills_added: ['skill1'],
+          languages: [],
           improvement_summary: 'summary',
         })
       )
@@ -397,6 +400,7 @@ describe('/api/process-cv', () => {
           original_score: 80,
           enhanced_score: 90,
           skills_added: ['skill2'],
+          languages: [],
           improvement_summary: 'summary2',
         })
       );


### PR DESCRIPTION
## Summary
- parse LinkedIn and resume languages with proficiency levels
- include language data in AI prompts and generated resumes
- render a Languages section with proficiency bars in 2025 template and surface on frontend

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bc53f97568832b942c480324d628e2