### PR TITLE
Add curated skill resources and tests for new additions links

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from 'react'
+import skillResources from './skillResources'
 
 const metricTips = {
   layoutSearchability: 'Use bullet points for better scanning.',
@@ -444,19 +445,40 @@ function App() {
             <div className="text-purple-800 mt-4">
               <h3 className="font-semibold mb-2">New Additions for Interview Prep</h3>
               <ul className="list-disc list-inside">
-                {newAdditions.map((item, idx) => (
-                  <li key={idx}>
-                    {item}{' '}
-                    <a
-                      href={`https://www.google.com/search?q=${encodeURIComponent(item + ' interview questions')}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 underline"
-                    >
-                      Learning Resources
-                    </a>
-                  </li>
-                ))}
+                {newAdditions.map((item, idx) => {
+                  const resources = skillResources[item.toLowerCase().trim()]
+                  return (
+                    <li key={idx}>
+                      {item}{' '}
+                      {resources ? (
+                        resources.map((r, i) => (
+                          <span key={i}>
+                            <a
+                              href={r.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-blue-600 underline"
+                            >
+                              {r.label}
+                            </a>
+                            {i < resources.length - 1 ? ', ' : ''}
+                          </span>
+                        ))
+                      ) : (
+                        <a
+                          href={`https://www.google.com/search?q=${encodeURIComponent(
+                            item + ' interview questions'
+                          )}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-600 underline"
+                        >
+                          Learning Resources
+                        </a>
+                      )}
+                    </li>
+                  )
+                })}
               </ul>
             </div>
           )}

--- a/client/src/skillResources.js
+++ b/client/src/skillResources.js
@@ -1,0 +1,11 @@
+const skillResources = {
+  aws: [
+    { label: 'AWS Training', url: 'https://aws.amazon.com/training/' },
+    { label: 'AWS Documentation', url: 'https://docs.aws.amazon.com/' }
+  ],
+  react: [
+    { label: 'React Official Tutorial', url: 'https://react.dev/learn' }
+  ]
+}
+
+export default skillResources


### PR DESCRIPTION
## Summary
- Map key skills to curated learning resources
- Display curated resources in new additions section with search fallback
- Test that known skills use the curated link

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc61fa72e0832bbe4a23ed1ff3c6e7