### PR TITLE
Require LinkedIn URL for evaluation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -72,10 +72,13 @@ function App() {
     setError('')
     setDesignationOverride('')
     try {
+      if (!linkedinUrl.trim()) {
+        throw new Error('LinkedIn profile URL is required.')
+      }
       const formData = new FormData()
       formData.append('resume', cvFile)
       formData.append('jobDescriptionUrl', jobUrl)
-      if (linkedinUrl) formData.append('linkedinProfileUrl', linkedinUrl)
+      formData.append('linkedinProfileUrl', linkedinUrl)
       if (credlyUrl.trim())
         formData.append('credlyProfileUrl', credlyUrl.trim())
       if (nameOverride) formData.append('applicantName', nameOverride)
@@ -125,7 +128,7 @@ function App() {
     }
   }
 
-  const disabled = !jobUrl || !cvFile || isProcessing
+  const disabled = !jobUrl || !cvFile || !linkedinUrl || isProcessing
 
   const handleSkillChange = (idx, value) => {
     setSkills((prev) => prev.map((s, i) => (i === idx ? value : s)))

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -143,11 +143,12 @@ export default function registerProcessCv(app, generativeModel) {
         if (!jobDescriptionUrl)
           return next(createError(400, 'invalid jobDescriptionUrl'));
 
-        if (linkedinProfileUrl) {
-          linkedinProfileUrl = validateUrl(linkedinProfileUrl);
-          if (!linkedinProfileUrl)
-            return next(createError(400, 'invalid linkedinProfileUrl'));
-        }
+        if (!linkedinProfileUrl)
+          return next(createError(400, 'linkedinProfileUrl required'));
+        linkedinProfileUrl = validateUrl(linkedinProfileUrl);
+        if (!linkedinProfileUrl)
+          return next(createError(400, 'invalid linkedinProfileUrl'));
+
         if (credlyProfileUrl) {
           credlyProfileUrl = validateUrl(credlyProfileUrl);
           if (!credlyProfileUrl)


### PR DESCRIPTION
## Summary
- Require `linkedinProfileUrl` for evaluation requests and validate its format
- Surface client error when LinkedIn profile URL is missing and disable submit until provided

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68bc65644bc0832b8f179118f4acbe62