### PR TITLE
feat: show ATS metric statuses

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from 'react'
 import skillResources from './skillResources'
+import { getScoreStatus } from './scoreStatus'
 
 const metricTips = {
   layoutSearchability: 'Use bullet points for better scanning.',
@@ -294,18 +295,21 @@ function App() {
             <div className="text-purple-800 mb-2">
               <p className="font-semibold mb-1">ATS Breakdown</p>
               <ul>
-                {Object.entries(result.atsMetrics).map(([metric, score]) => (
-                  <li key={metric} className="mb-1">
-                    <span>
-                      {formatMetricName(metric)}: {score}%
-                    </span>
-                    {score < 70 && metricTips[metric] && (
-                      <span className="block text-sm text-purple-600">
-                        {metricTips[metric]}
+                {Object.entries(result.atsMetrics).map(([metric, score]) => {
+                  const status = getScoreStatus(score)
+                  return (
+                    <li key={metric} className="mb-1">
+                      <span>
+                        {formatMetricName(metric)}: {score}% ({status})
                       </span>
-                    )}
-                  </li>
-                ))}
+                      {score < 70 && metricTips[metric] && (
+                        <span className="block text-sm text-purple-600">
+                          {metricTips[metric]}
+                        </span>
+                      )}
+                    </li>
+                  )
+                })}
               </ul>
             </div>
           )}

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -47,7 +47,10 @@ test('evaluates CV and displays results', async () => {
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
   expect(await screen.findByText(/ATS Score: 70%/)).toBeInTheDocument()
   expect(
-    await screen.findByText(/Layout Searchability: 50%/)
+    await screen.findByText(/Layout Searchability: 50% \(Needs Improvement\)/)
+  ).toBeInTheDocument()
+  expect(
+    await screen.findByText(/Crispness: 90% \(Good\)/)
   ).toBeInTheDocument()
   expect(
     await screen.findByText('Include email, phone, and LinkedIn.')

--- a/client/src/scoreStatus.js
+++ b/client/src/scoreStatus.js
@@ -1,0 +1,5 @@
+export function getScoreStatus(score = 0) {
+  if (score >= 80) return 'Good'
+  if (score >= 60) return 'Average'
+  return 'Needs Improvement'
+}


### PR DESCRIPTION
## Summary
- add `getScoreStatus` helper to map scores to Good/Average/Needs Improvement
- display score status in ATS Breakdown and update tests

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc662a66a0832baee17582f5b75dab