### PR TITLE
Default to 2025 CV template

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -400,9 +400,8 @@ export default function registerProcessCv(app, generativeModel) {
       return next(createError(500, 'Failed to parse user agent'));
     }
     let defaultCvTemplate =
-      req.body.template || req.query.template || CV_TEMPLATES[0];
-    if (!CV_TEMPLATES.includes(defaultCvTemplate))
-      defaultCvTemplate = CV_TEMPLATES[0];
+      req.body.template || req.query.template || '2025';
+    if (!CV_TEMPLATES.includes(defaultCvTemplate)) defaultCvTemplate = '2025';
     const defaultClTemplate =
       req.body.coverTemplate || req.query.coverTemplate || CL_TEMPLATES[0];
     const selection = selectTemplates({

--- a/server.js
+++ b/server.js
@@ -210,6 +210,7 @@ const TECHNICAL_TERMS = [
   'ansible'
 ];
 function selectTemplates({
+  defaultCvTemplate = '2025',
   defaultClTemplate = CL_TEMPLATES[0],
   template1,
   template2,
@@ -250,10 +251,10 @@ function selectTemplates({
   };
 
   if (!template1 && !template2) {
-    [template1, template2] =
-      CONTRASTING_PAIRS[Math.floor(Math.random() * CONTRASTING_PAIRS.length)];
+    template1 = defaultCvTemplate;
+    template2 = pickContrasting(template1);
   } else {
-    if (!template1) template1 = '2025';
+    if (!template1) template1 = defaultCvTemplate;
     if (!template2) template2 = pickContrasting(template1);
     if (
       template1 === template2 ||

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -101,17 +101,17 @@ describe('generatePdf and parsing', () => {
     }
   );
 
-  test('selectTemplates returns contrasting templates by default', () => {
+  test('selectTemplates returns 2025 and contrasting templates by default', () => {
     const { template1, template2, coverTemplate1, coverTemplate2 } = selectTemplates();
-    expect(CV_TEMPLATES).toContain(template1);
+    expect(template1).toBe('2025');
     expect(CV_TEMPLATES).toContain(template2);
-    expect(template1).not.toBe(template2);
+    expect(template2).not.toBe('2025');
     expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
       CV_TEMPLATE_GROUPS[template2]
     );
-    expect(coverTemplate1).not.toBe(coverTemplate2);
     expect(CL_TEMPLATES).toContain(coverTemplate1);
     expect(CL_TEMPLATES).toContain(coverTemplate2);
+    expect(coverTemplate1).not.toBe(coverTemplate2);
   });
 
   test('providing one template yields a contrasting default', () => {

--- a/tests/selectTemplatesGroup.test.js
+++ b/tests/selectTemplatesGroup.test.js
@@ -3,11 +3,11 @@ import fs from 'fs/promises';
 import path from 'path';
 
 describe('selectTemplates defaults and overrides', () => {
-  test('defaults to contrasting templates when none provided', () => {
+  test('defaults to 2025 and a contrasting template when none provided', () => {
     const { template1, template2 } = selectTemplates();
-    expect(CV_TEMPLATES).toContain(template1);
+    expect(template1).toBe('2025');
     expect(CV_TEMPLATES).toContain(template2);
-    expect(template1).not.toBe(template2);
+    expect(template2).not.toBe('2025');
     expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
       CV_TEMPLATE_GROUPS[template2]
     );


### PR DESCRIPTION
## Summary
- Default CV template falls back to `2025`
- Template selection logic now uses 2025 as the standard starting point
- Adjust tests for updated template defaults

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*
- `npm install` *(fails: 403 Forbidden for @aws-sdk/s3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdeb2cfc0832b9820a592bf653abf