### PR TITLE
Add Font Awesome and test default skill icons

### DIFF
--- a/templates/2025.html
+++ b/templates/2025.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Resume</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <!-- 2025 template ensures whitespace and tab rendering -->
 </head>
 <body>

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -130,6 +130,24 @@ describe('generatePdf and parsing', () => {
     expect(CL_TEMPLATES).toContain(coverTemplate2);
   });
 
+  test('default skill icons render in HTML for PDF generation', async () => {
+    const setContent = jest.fn();
+    const pdf = jest.fn().mockResolvedValue(Buffer.from('PDF'));
+    const close = jest.fn();
+    const newPage = jest.fn().mockResolvedValue({ setContent, pdf });
+    const launchSpy = jest
+      .spyOn(puppeteer, 'launch')
+      .mockResolvedValue({ newPage, close });
+
+    await generatePdf('Jane Doe\n# Skills\n- JavaScript\n- Python', '2025');
+    expect(setContent).toHaveBeenCalled();
+    const html = setContent.mock.calls[0][0];
+    expect(html).toContain('fa-brands fa-js');
+    expect(html).toContain('fa-brands fa-python');
+
+    launchSpy.mockRestore();
+  });
+
   test('script tags render as text', () => {
     const tokens = parseContent('Jane Doe\n- uses <script>alert(1)</script> safely')
       .sections[0].items[0];


### PR DESCRIPTION
## Summary
- Load Font Awesome stylesheet in 2025 resume template for skill icons
- Add test ensuring default skill icons render in generated PDF HTML

## Testing
- `npm test -- tests/generatePdf.test.js` *(fails: Cannot find package '@babel/preset-env')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aws-sdk%2fs3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bce00b73b0832b9e2cd60370196841