### PR TITLE
Use generatePdf for final CV generation

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -780,7 +780,7 @@ export default function registerProcessCv(app, generativeModel) {
       const chanceOfSelection = Math.round(
         (enhancedScore + atsScore) / 2
       );
-      const improvedPdf = await convertToPdf(improvedCv);
+      const improvedPdf = await generatePdf(improvedCv, '2025', {}, generativeModel);
       const ts = Date.now();
       const key = `${enhancedPrefix}cv/${ts}-improved.pdf`;
       const textKey = `${enhancedPrefix}cv/${ts}-improved.txt`;
@@ -1004,7 +1004,7 @@ export default function registerProcessCv(app, generativeModel) {
         bestCv = cvVersion2;
         metricTable = metrics2.table;
       }
-      const pdf = await convertToPdf(bestCv);
+      const pdf = await generatePdf(bestCv, '2025', {}, generativeModel);
       const key = path.join(
         sanitizedName,
         'enhanced',
@@ -1306,7 +1306,7 @@ export default function registerProcessCv(app, generativeModel) {
             new GetObjectCommand({ Bucket: bucket, Key: existingCvTextKey })
           );
           cvText = await textObj.Body.transformToString();
-          cvBuffer = await convertToPdf(cvText);
+          cvBuffer = await generatePdf(cvText, '2025', {}, generativeModel);
         } else if (existingCvKey) {
           const obj = await s3.send(
             new GetObjectCommand({ Bucket: bucket, Key: existingCvKey })


### PR DESCRIPTION
## Summary
- Replace legacy convertToPdf with generatePdf for all final CV outputs
- Render CV PDFs with the 2025 template while preserving existing S3 paths and signed URLs

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env' during Jest setup)*
- `npm install` *(fails: 403 Forbidden when fetching @aws-sdk/s3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bce4a736a0832bae7255938abe3bbc