### PR TITLE
feat: log S3 key with evaluations

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -189,6 +189,8 @@ export default function registerProcessCv(app, generativeModel) {
       } catch {}
       try {
         if (!req.file) return next(createError(400, 'resume file required'));
+        const cvKey =
+          req.file.key || req.file.filename || req.file.originalname || '';
         let { jobDescriptionUrl, linkedinProfileUrl, credlyProfileUrl } = req.body;
         if (!jobDescriptionUrl)
           return next(createError(400, 'jobDescriptionUrl required'));
@@ -228,6 +230,7 @@ export default function registerProcessCv(app, generativeModel) {
             jobDescriptionUrl,
             linkedinProfileUrl,
             credlyProfileUrl,
+            cvKey,
             docType,
           });
           return res
@@ -354,6 +357,7 @@ export default function registerProcessCv(app, generativeModel) {
           jobDescriptionUrl,
           linkedinProfileUrl,
           credlyProfileUrl,
+          cvKey,
           docType: 'resume',
         });
 

--- a/services/dynamo.js
+++ b/services/dynamo.js
@@ -57,6 +57,7 @@ export async function logEvaluation({
   jobDescriptionUrl = '',
   linkedinProfileUrl = '',
   credlyProfileUrl = '',
+  cvKey = '',
   docType = '',
 }) {
   const client = new DynamoDBClient({ region });
@@ -97,6 +98,7 @@ export async function logEvaluation({
   addString('device', device);
   addString('jobDescriptionUrl', jobDescriptionUrl);
   addString('credlyProfileUrl', credlyProfileUrl);
+  addString('cvKey', cvKey);
   addString('docType', docType);
 
   await client.send(new PutItemCommand({ TableName: tableName, Item: item }));

--- a/tests/dynamoLogEvaluation.test.js
+++ b/tests/dynamoLogEvaluation.test.js
@@ -30,6 +30,7 @@ describe('logEvaluation optional fields', () => {
       userAgent: 'ua',
       jobDescriptionUrl: 'https://example.com/job',
       linkedinProfileUrl: 'https://linkedin.com/in/example',
+      cvKey: 's3/key',
       docType: 'resume',
     });
 
@@ -40,6 +41,7 @@ describe('logEvaluation optional fields', () => {
       S: 'https://linkedin.com/in/example',
     });
     expect(putCall[0].input.Item.location).toEqual({ S: 'City, Country' });
+    expect(putCall[0].input.Item.cvKey).toEqual({ S: 's3/key' });
   });
 
   test('omits linkedinProfileUrl when not provided', async () => {
@@ -52,6 +54,7 @@ describe('logEvaluation optional fields', () => {
       ipAddress: 'ip',
       userAgent: 'ua',
       jobDescriptionUrl: 'https://example.com/job',
+      cvKey: 'another/key',
       docType: 'resume',
     });
 

--- a/tests/evaluateLinkedInDiff.test.js
+++ b/tests/evaluateLinkedInDiff.test.js
@@ -61,6 +61,7 @@ describe('/api/evaluate LinkedIn diff', () => {
       expect.objectContaining({
         docType: 'resume',
         linkedinProfileUrl: 'https://linkedin.com/in/example',
+        cvKey: expect.any(String),
       })
     );
   });

--- a/tests/evaluateRejectNonResume.test.js
+++ b/tests/evaluateRejectNonResume.test.js
@@ -34,6 +34,7 @@ describe('/api/evaluate non-resume', () => {
     const res = await request(app)
       .post('/api/evaluate')
       .field('jobDescriptionUrl', 'https://example.com/job')
+      .field('linkedinProfileUrl', 'https://linkedin.com/in/example')
       .attach('resume', Buffer.from('dummy'), 'file.pdf');
     expect(res.status).toBe(400);
     expect(res.text).toBe(
@@ -41,7 +42,11 @@ describe('/api/evaluate non-resume', () => {
     );
     const { logEvaluation } = await import('../services/dynamo.js');
     expect(logEvaluation).toHaveBeenCalledWith(
-      expect.objectContaining({ docType, linkedinProfileUrl: undefined })
+      expect.objectContaining({
+        docType,
+        linkedinProfileUrl: 'https://linkedin.com/in/example',
+        cvKey: expect.any(String),
+      })
     );
   });
 });


### PR DESCRIPTION
## Summary
- track uploaded resume's S3 key in `logEvaluation`
- supply S3 key to `logEvaluation` calls after uploading the resume
- test that DynamoDB records the S3 key

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68bcea15a298832baefcef62c84423b6