### PR TITLE
feat: configure puppeteer launch options

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -52,6 +52,9 @@ const DEFAULT_USER_AGENT =
 const DEFAULT_FETCH_TIMEOUT_MS =
   parseInt(process.env.JOB_FETCH_TIMEOUT_MS || REQUEST_TIMEOUT_MS, 10);
 
+const PUPPETEER_HEADLESS =
+  process.env.PUPPETEER_HEADLESS === 'false' ? false : 'new';
+
 export async function fetchJobDescription(
   url,
   { timeout = DEFAULT_FETCH_TIMEOUT_MS, userAgent = DEFAULT_USER_AGENT } = {}
@@ -65,8 +68,10 @@ export async function fetchJobDescription(
   } catch (err) {
     // ignore and fallback to puppeteer
   }
-
-  const browser = await puppeteer.launch({ headless: 'new' });
+  const browser = await puppeteer.launch({
+    headless: PUPPETEER_HEADLESS,
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
   try {
     const page = await browser.newPage();
     await page.setUserAgent(userAgent);

--- a/services/generatePdf.js
+++ b/services/generatePdf.js
@@ -33,6 +33,9 @@ const DEFAULT_SKILL_ICONS = {
   aws: 'fa-brands fa-aws'
 };
 
+const PUPPETEER_HEADLESS =
+  process.env.PUPPETEER_HEADLESS === 'false' ? false : 'new';
+
 function proficiencyToLevel(str = '') {
   const s = String(str).toLowerCase();
   if (/native|bilingual/.test(s)) return 100;
@@ -249,7 +252,10 @@ export async function generatePdf(
   let browser;
   try {
     // Launch using Chromium's default sandboxing.
-    browser = await puppeteer.launch();
+    browser = await puppeteer.launch({
+      headless: PUPPETEER_HEADLESS,
+      args: ['--no-sandbox', '--disable-setuid-sandbox']
+    });
     const page = await browser.newPage();
     await page.setContent(html, { waitUntil: 'networkidle0' });
     const pdfBuffer = await page.pdf({ format: 'A4', printBackground: true });


### PR DESCRIPTION
## Summary
- make puppeteer headless mode configurable via PUPPETEER_HEADLESS env var
- disable chromium sandboxing for generatePdf and job description fetch

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aws-sdk%2fs3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf3930c50832b9eb01331b16e501e