### PR TITLE
Validate job description URLs

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -57,10 +57,12 @@ const PUPPETEER_HEADLESS =
 
 export async function fetchJobDescription(
   url,
-  { timeout = DEFAULT_FETCH_TIMEOUT_MS, userAgent = DEFAULT_USER_AGENT } = {}
+  { timeout = DEFAULT_FETCH_TIMEOUT_MS, userAgent = DEFAULT_USER_AGENT } = {},
 ) {
+  const valid = validateUrl(url);
+  if (!valid) throw new Error('Invalid URL');
   try {
-    const { data } = await axios.get(url, {
+    const { data } = await axios.get(valid, {
       timeout,
       headers: { 'User-Agent': userAgent },
     });
@@ -75,7 +77,7 @@ export async function fetchJobDescription(
   try {
     const page = await browser.newPage();
     await page.setUserAgent(userAgent);
-    await page.goto(url, { timeout, waitUntil: 'networkidle2' });
+    await page.goto(valid, { timeout, waitUntil: 'networkidle2' });
     const content = await page.content();
     return content;
   } finally {

--- a/tests/fetchJobDescription.test.js
+++ b/tests/fetchJobDescription.test.js
@@ -54,4 +54,16 @@ describe('fetchJobDescription', () => {
       waitUntil: 'networkidle2',
     });
   });
+
+  test('rejects invalid URL', async () => {
+    await expect(fetchJobDescription('http:/bad')).rejects.toThrow('Invalid URL');
+    expect(mockAxiosGet).not.toHaveBeenCalled();
+    expect(mockLaunch).not.toHaveBeenCalled();
+  });
+
+  test('rejects private IP URL', async () => {
+    await expect(fetchJobDescription('http://127.0.0.1')).rejects.toThrow('Invalid URL');
+    expect(mockAxiosGet).not.toHaveBeenCalled();
+    expect(mockLaunch).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Sanitize job description URLs in `fetchJobDescription` and reject invalid or private addresses before requests.
- Add tests for malformed and private IP URLs to ensure early rejection.

## Testing
- `npm test tests/fetchJobDescription.test.js` *(fails: Cannot find package '@babel/preset-env')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aws-sdk%2fs3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf43173dc832b9a7b6eaa4d3c05aa