### PR TITLE
Use designation override during CV improvement

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -214,6 +214,8 @@ function App() {
       improveForm.append('selectedEducation', JSON.stringify(selectedEducation))
       improveForm.append('selectedCertifications', JSON.stringify(selectedCertifications))
       improveForm.append('selectedLanguages', JSON.stringify(selectedLanguages))
+      if (designationOverride)
+        improveForm.append('designation', designationOverride)
       const improveResp = await fetch(`${API_BASE_URL}/api/process-cv`, {
         method: 'POST',
         body: improveForm

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -762,6 +762,16 @@ export default function registerProcessCv(app, generativeModel) {
 
       const sections = collectSectionText(text, linkedinData, credlyCertifications);
       const improvedSections = await improveSections(sections, jobDescription);
+      if (jobTitle) {
+        const lines = (improvedSections.experience || '').split('\n');
+        const idx = lines.findIndex((l) => l.trim());
+        if (idx !== -1) {
+          const line = lines[idx];
+          const atIdx = line.toLowerCase().indexOf(' at ');
+          lines[idx] = atIdx !== -1 ? `${jobTitle}${line.slice(atIdx)}` : jobTitle;
+          improvedSections.experience = lines.join('\n');
+        }
+      }
       const resumeSkills = extractResumeSkills(text);
       const projectSummary = await generateProjectSummary(
         jobDescription,


### PR DESCRIPTION
## Summary
- send designation override when improving CV so backend can adjust job title
- apply provided designation to top experience entry to align with job description

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bd03cab134832b95452b4b97ca0c55