### PR TITLE
Clarify resume upload formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Each item includes:
 
 ## Upload Restrictions
 - Maximum file size: 5&nbsp;MB
-- Allowed file types: `.pdf`
+- Allowed file types: `.pdf`, `.docx`
 - Legacy `.doc` files are rejected.
 
 ## Templates

--- a/server.js
+++ b/server.js
@@ -152,16 +152,22 @@ if (process.env.ENFORCE_HTTPS === 'true') {
 }
 
 
+// Multer configuration for resume uploads. Accepts PDFs and modern
+// Word documents (.docx) while rejecting legacy .doc files.
 const upload = multer({
   limits: { fileSize: 5 * 1024 * 1024 },
   fileFilter: (req, file, cb) => {
     const ext = path.extname(file.originalname).toLowerCase();
-    const allowed = ['.pdf', '.doc', '.docx'];
-    if (!allowed.includes(ext)) {
-      return cb(new Error('Only .pdf, .doc, .docx files are allowed'));
-    }
     if (ext === '.doc') {
-      return cb(new Error('Legacy .doc files are not supported. Please upload a .pdf or .docx file.'));
+      return cb(
+        new Error(
+          'Legacy .doc files are not supported. Please upload a .pdf or .docx file.'
+        )
+      );
+    }
+    const allowed = ['.pdf', '.docx'];
+    if (!allowed.includes(ext)) {
+      return cb(new Error('Only .pdf and .docx files are allowed'));
     }
     cb(null, true);
   }

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -756,7 +756,7 @@ describe('/api/process-cv', () => {
       .field('applicantName', 'Jane Doe')
       .attach('resume', Buffer.from('text'), 'resume.txt');
     expect(res.status).toBe(400);
-    expect(res.body.error).toBe('Only .pdf, .doc, .docx files are allowed');
+    expect(res.body.error).toBe('Only .pdf and .docx files are allowed');
   });
 
   test('missing job description URL', async () => {


### PR DESCRIPTION
## Summary
- Accept PDF and DOCX resumes while rejecting legacy DOC files in `multer` upload filter
- Document support for `.docx` uploads and update unsupported file type test

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env' and 403 installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0568505c832b98733ac4a35e992b