### PR TITLE
feat: add timeout for AI requests

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -938,6 +938,11 @@ export default function registerProcessCv(app, generativeModel) {
           console.error('failed to log error', e);
         }
       }
+      if (err.code === 'AI_TIMEOUT') {
+        return next(
+          createError(504, 'The AI service took too long to respond. Please try again later.')
+        );
+      }
       return next(createError(500, 'processing failed'));
     }
   });
@@ -977,6 +982,11 @@ export default function registerProcessCv(app, generativeModel) {
         res.json({ suggestion });
       } catch (err) {
         console.error('fix metric failed', err);
+        if (err.code === 'AI_TIMEOUT') {
+          return next(
+            createError(504, 'The AI service took too long to respond. Please try again later.')
+          );
+        }
         next(createError(500, 'failed to fix metric'));
       }
     }
@@ -1178,6 +1188,11 @@ export default function registerProcessCv(app, generativeModel) {
       });
     } catch (err) {
       console.error('metric improvement failed', err);
+      if (err.code === 'AI_TIMEOUT') {
+        return next(
+          createError(504, 'The AI service took too long to respond. Please try again later.')
+        );
+      }
       next(createError(500, 'failed to improve metric'));
     }
   });
@@ -1312,6 +1327,12 @@ export default function registerProcessCv(app, generativeModel) {
           credlyFileId: credlyFile?.id,
         });
       } catch (err) {
+        if (err.code === 'AI_TIMEOUT') {
+          console.error('cover letter generation timed out', err);
+          return next(
+            createError(504, 'The AI service took too long to respond. Please try again later.')
+          );
+        }
         console.error('cover letter generation failed', err);
         return next(createError(500, 'cover letter generation failed'));
       }
@@ -1537,6 +1558,12 @@ export default function registerProcessCv(app, generativeModel) {
           credlyFileId: credlyFile?.id,
         });
       } catch (err) {
+        if (err.code === 'AI_TIMEOUT') {
+          console.error('cover letter generation timed out', err);
+          return next(
+            createError(504, 'The AI service took too long to respond. Please try again later.')
+          );
+        }
         console.error('cover letter generation failed', err);
         return next(createError(500, 'cover letter generation failed'));
       }


### PR DESCRIPTION
## Summary
- timeout AI client requests after 10s
- surface AI timeout errors in API routes

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env' imported from /workspace/ResumeForge/babel-virtual-resolve-base.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bd06b42e7c832b8f9704728ccc9ce1