### PR TITLE
Upload evaluated resumes to S3 and log key

### DIFF
--- a/tests/evaluateLinkedInDiff.test.js
+++ b/tests/evaluateLinkedInDiff.test.js
@@ -19,6 +19,22 @@ jest.unstable_mockModule('../services/dynamo.js', () => ({
   logEvaluation: jest.fn().mockResolvedValue()
 }));
 
+const mockS3Send = jest.fn().mockResolvedValue({});
+jest.unstable_mockModule('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(() => ({ send: mockS3Send })),
+  PutObjectCommand: jest.fn((input) => ({ input })),
+  GetObjectCommand: jest.fn((input) => ({ input })),
+}));
+
+jest.unstable_mockModule('../config/secrets.js', () => ({
+  getSecrets: jest.fn().mockResolvedValue({}),
+}));
+
+jest.unstable_mockModule('../openaiClient.js', () => ({
+  classifyDocument: jest.fn().mockResolvedValue('resume'),
+  requestAtsAnalysis: jest.fn().mockRejectedValue(new Error('no ai')),
+}));
+
 const serverModule = await import('../server.js');
 const app = serverModule.default;
 jest

--- a/tests/evaluateRejectNonResume.test.js
+++ b/tests/evaluateRejectNonResume.test.js
@@ -17,11 +17,23 @@ jest.unstable_mockModule('../services/dynamo.js', () => ({
   logEvaluation: jest.fn().mockResolvedValue()
 }));
 
+const mockS3Send = jest.fn().mockResolvedValue({});
+jest.unstable_mockModule('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(() => ({ send: mockS3Send })),
+  PutObjectCommand: jest.fn((input) => ({ input })),
+  GetObjectCommand: jest.fn((input) => ({ input })),
+}));
+
+jest.unstable_mockModule('../config/secrets.js', () => ({
+  getSecrets: jest.fn().mockResolvedValue({}),
+}));
+
 jest.unstable_mockModule('../openaiClient.js', () => ({
   uploadFile: jest.fn(),
   requestSectionImprovement: jest.fn(),
   requestEnhancedCV: jest.fn(),
   requestCoverLetter: jest.fn(),
+  requestAtsAnalysis: jest.fn(),
   classifyDocument: jest.fn(),
 }));
 

--- a/tests/evaluateS3Upload.test.js
+++ b/tests/evaluateS3Upload.test.js
@@ -1,0 +1,62 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+const mockS3Send = jest.fn().mockResolvedValue({});
+const PutObjectCommand = jest.fn((input) => ({ input }));
+jest.unstable_mockModule('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(() => ({ send: mockS3Send })),
+  PutObjectCommand,
+  GetObjectCommand: jest.fn((input) => ({ input })),
+}));
+
+jest.unstable_mockModule('axios', () => ({
+  default: { get: jest.fn().mockResolvedValue({ data: '' }) },
+}));
+
+jest.unstable_mockModule('pdf-parse/lib/pdf-parse.js', () => ({
+  default: jest
+    .fn()
+    .mockResolvedValue({ text: 'John Doe\nExperience\n- Engineer at Company\nEducation\n- Uni' }),
+}));
+
+jest.unstable_mockModule('mammoth', () => ({
+  default: { extractRawText: jest.fn().mockResolvedValue({ value: '' }) },
+}));
+
+jest.unstable_mockModule('../services/dynamo.js', () => ({
+  logEvaluation: jest.fn().mockResolvedValue(),
+}));
+
+jest.unstable_mockModule('../config/secrets.js', () => ({
+  getSecrets: jest.fn().mockResolvedValue({}),
+}));
+
+jest.unstable_mockModule('../openaiClient.js', () => ({
+  classifyDocument: jest.fn().mockResolvedValue('resume'),
+  requestAtsAnalysis: jest.fn().mockRejectedValue(new Error('no ai')),
+}));
+
+const serverModule = await import('../server.js');
+const app = serverModule.default;
+jest.spyOn(serverModule, 'fetchLinkedInProfile').mockResolvedValue({
+  experience: [],
+  education: [],
+  certifications: [],
+  languages: [],
+});
+
+describe('/api/evaluate S3 upload', () => {
+  test('uploads resume to S3 with expected key', async () => {
+    PutObjectCommand.mockClear();
+    const res = await request(app)
+      .post('/api/evaluate')
+      .field('jobDescriptionUrl', 'https://example.com/job')
+      .field('linkedinProfileUrl', 'https://linkedin.com/in/example')
+      .field('applicantName', 'John Doe')
+      .attach('resume', Buffer.from('dummy'), 'resume.pdf');
+    expect(res.status).toBe(200);
+    expect(PutObjectCommand).toHaveBeenCalled();
+    const key = PutObjectCommand.mock.calls[0][0].Key;
+    expect(key).toMatch(/^john_doe\/cv\/\d{4}-\d{2}-\d{2}\/john_doe\.pdf$/);
+  });
+});


### PR DESCRIPTION
## Summary
- Upload candidate CVs to S3 during evaluation and capture their key for logging
- Add S3 upload test ensuring keys follow `<name>/cv/<date>/` format
- Mock S3 and secrets in evaluation tests

## Testing
- `npm test tests/evaluate*.test.js` *(fails: Cannot find package '@babel/preset-env')*
- `npm install --no-save @babel/preset-env @babel/preset-react` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0b6b5220832b86ae7bdc7be1f944