### PR TITLE
Use express-rate-limit for request throttling

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cors": "^2.8.5",
     "docx": "^8.0.2",
     "express": "^4.18.2",
+    "express-rate-limit": "^7.0.0",
     "mammoth": "^1.6.0",
     "multer": "^1.4.5-lts.1",
     "pdf-parse": "^1.1.1",


### PR DESCRIPTION
## Summary
- add express-rate-limit dependency
- replace custom rate limiter with express-rate-limit configured by env vars
- test rate limiting and Retry-After header

## Testing
- `npm install express-rate-limit@7` *(fails: 403 Forbidden)*
- `npm test tests/server.test.js` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68bd0cce3a4c832ba22be02c6e204872