### PR TITLE
Parse GPA from education entries and display in 2025 template

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -336,11 +336,11 @@ export default function registerProcessCv(app, generativeModel) {
               .map((e) => fmtExp(e))
               .filter((e) => e && !resumeExpSet.has(e));
             const resumeEduSet = new Set(
-              resumeEducation.map((e) => e.toLowerCase())
+              resumeEducation.map((e) => e.entry.toLowerCase())
             );
-            missingEducation = linkedinEducation.filter(
-              (e) => e && !resumeEduSet.has(e.toLowerCase())
-            );
+            missingEducation = linkedinEducation
+              .map((e) => e.entry)
+              .filter((e) => e && !resumeEduSet.has(e.toLowerCase()));
             const resumeLangSet = new Set(
               resumeLanguages.map((l) => l.language.toLowerCase())
             );

--- a/server.js
+++ b/server.js
@@ -503,8 +503,12 @@ function collectSectionText(resumeText = '', linkedinData = {}, credlyCertificat
     .filter(Boolean)
     .join('\n');
   const education = [
-    extractEducation(resumeText).join('\n'),
-    extractEducation(linkedinData.education || []).join('\n'),
+    extractEducation(resumeText)
+      .map((e) => e.entry)
+      .join('\n'),
+    extractEducation(linkedinData.education || [])
+      .map((e) => e.entry)
+      .join('\n'),
   ]
     .filter(Boolean)
     .join('\n');

--- a/services/generatePdf.js
+++ b/services/generatePdf.js
@@ -141,6 +141,30 @@ export async function generatePdf(
           });
           return { ...sec, items: grouped };
         }
+        if (heading === 'education' && templateId === '2025') {
+          return {
+            ...sec,
+            items: sec.items.map((tokens) => {
+              const plain = tokens
+                .map((t) => t.text || '')
+                .join('')
+                .trim();
+              const gpaMatch = plain.match(/\bGPA[:\s]*([0-9.]+(?:\/[0-9.]+)?)\b/i);
+              let gpa = null;
+              let html = tokenHtml(tokens, sec.heading);
+              if (gpaMatch) {
+                gpa = gpaMatch[1];
+                const pattern = gpaMatch[0].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                const regex = new RegExp(pattern, 'i');
+                html = html
+                  .replace(regex, '')
+                  .replace(/[,;\-]+\s*$/, '')
+                  .trim();
+              }
+              return { entry: html, gpa };
+            }),
+          };
+        }
         return {
           ...sec,
           items: sec.items.map((tokens) => tokenHtml(tokens, sec.heading)),

--- a/services/parseContent.js
+++ b/services/parseContent.js
@@ -1027,7 +1027,24 @@ function extractExperience(source) {
 
 function extractEducation(source) {
   if (!source) return [];
-  if (Array.isArray(source)) return source.map((s) => String(s));
+
+  const parseEntry = (text = '') => {
+    let gpa = null;
+    const gpaMatch = text.match(/\bGPA[:\s]*([0-9.]+(?:\/[0-9.]+)?)\b/i);
+    if (gpaMatch) {
+      gpa = gpaMatch[1];
+      const gpaText = gpaMatch[0];
+      text = text
+        .replace(gpaText, '')
+        .replace(/[,;\-]+\s*$/, '')
+        .trim();
+    }
+    return { entry: text.trim(), gpa };
+  };
+
+  if (Array.isArray(source)) {
+    return source.map((s) => parseEntry(String(s)));
+  }
   const lines = String(source).split(/\r?\n/);
   const entries = [];
   let inSection = false;
@@ -1044,9 +1061,9 @@ function extractEducation(source) {
     if (inSection) {
       const match = trimmed.match(/^[-*]\s+(.*)/);
       if (match) {
-        entries.push(match[1].trim());
+        entries.push(parseEntry(match[1].trim()));
       } else if (trimmed) {
-        entries.push(trimmed);
+        entries.push(parseEntry(trimmed));
       }
     }
   }

--- a/templates/2025.html
+++ b/templates/2025.html
@@ -71,7 +71,14 @@
                   </ul>
                 </li>
               {{else}}
-                <li>{{{this}}}</li>
+                {{#if this.entry}}
+                  <li>
+                    <span class="edu-entry">{{{this.entry}}}</span>
+                    {{#if this.gpa}}<span class="edu-gpa">GPA: {{this.gpa}}</span>{{/if}}
+                  </li>
+                {{else}}
+                  <li>{{{this}}}</li>
+                {{/if}}
               {{/if}}
             {{/each}}
           </ul>

--- a/tests/extractEducation.test.js
+++ b/tests/extractEducation.test.js
@@ -2,12 +2,17 @@ import { extractEducation } from '../server.js';
 
 describe('extractEducation', () => {
   test('extracts bullet items from resume text', () => {
-    const text = 'Education\n- BSc Computer Science - MIT\n\nExperience';
-    expect(extractEducation(text)).toEqual(['BSc Computer Science - MIT']);
+    const text = 'Education\n- BSc Computer Science - MIT, GPA 3.8\n\nExperience';
+    expect(extractEducation(text)).toEqual([
+      { entry: 'BSc Computer Science - MIT', gpa: '3.8' }
+    ]);
   });
 
   test('extracts from array inputs', () => {
-    const arr = ['Harvard University, MBA', 'MIT, BSc'];
-    expect(extractEducation(arr)).toEqual(arr);
+    const arr = ['Harvard University, GPA: 4.0', 'MIT'];
+    expect(extractEducation(arr)).toEqual([
+      { entry: 'Harvard University', gpa: '4.0' },
+      { entry: 'MIT', gpa: null },
+    ]);
   });
 });

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -148,6 +148,24 @@ describe('generatePdf and parsing', () => {
     launchSpy.mockRestore();
   });
 
+  test('education GPA renders separately in 2025 template', async () => {
+    const setContent = jest.fn();
+    const pdf = jest.fn().mockResolvedValue(Buffer.from('PDF'));
+    const close = jest.fn();
+    const newPage = jest.fn().mockResolvedValue({ setContent, pdf });
+    const launchSpy = jest
+      .spyOn(puppeteer, 'launch')
+      .mockResolvedValue({ newPage, close });
+
+    const text = 'Jane Doe\n# Education\n- MIT, GPA 3.8';
+    await generatePdf(text, '2025');
+    const html = setContent.mock.calls[0][0];
+    expect(html).toContain('class="edu-gpa">GPA: 3.8');
+    expect(html).toContain('edu-entry');
+
+    launchSpy.mockRestore();
+  });
+
   test('script tags render as text', () => {
     const tokens = parseContent('Jane Doe\n- uses <script>alert(1)</script> safely')
       .sections[0].items[0];


### PR DESCRIPTION
## Summary
- detect GPA in education entries and return structured `{entry, gpa}` objects
- render GPA separately in 2025 resume template
- extend tests for GPA parsing and rendering

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found; Cannot find package '@babel/preset-env')*
- `npm install --no-save @babel/preset-env @babel/preset-react jest-environment-jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0ef51ef0832bbf2013f147bfcdd7