### PR TITLE
feat: show selected file label in dropzone

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -296,8 +296,15 @@ function App() {
         onDrop={handleDrop}
         onClick={() => fileInputRef.current && fileInputRef.current.click()}
       >
-        <p>Drag & drop your CV here or click to browse</p>
+        <p>Drag & drop your CV here or</p>
+        <label
+          htmlFor="cv-upload"
+          className="block mt-2 underline cursor-pointer break-words"
+        >
+          Browse... {cvFile ? cvFile.name : 'No file selected.'}
+        </label>
         <input
+          id="cv-upload"
           ref={fileInputRef}
           type="file"
           accept=".pdf,.docx"

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -68,6 +68,19 @@ test('evaluates CV and displays results', async () => {
   expect(skillInputs.length).toBe(2)
 })
 
+test('updates file label on selection', () => {
+  render(<App />)
+  expect(screen.getByText('Browse... No file selected.')).toBeInTheDocument()
+  const file = new File(['dummy'], 'resume.pdf', { type: 'application/pdf' })
+  fireEvent.change(
+    screen.getByLabelText('Choose File', { selector: 'input', hidden: true }),
+    {
+      target: { files: [file] }
+    }
+  )
+  expect(screen.getByText('Browse... resume.pdf')).toBeInTheDocument()
+})
+
 test('allows file to be dropped in drop zone', async () => {
   fetch.mockResolvedValueOnce({
     ok: true,


### PR DESCRIPTION
## Summary
- display a visible file chooser label in the drag-and-drop area that updates with the selected filename
- test that the dropzone label reflects the chosen file

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env'...)*
- `npm install` *(fails: 403 Forbidden for @aws-sdk/s3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bd144df258832bb680788c49ce7f59