### PR TITLE
Allow public IP addresses in URL validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Each item includes:
 - Allowed file types: `.pdf`, `.docx`
 - Legacy `.doc` files are rejected.
 
+## URL Validation
+Only `http://` and `https://` URLs are accepted for job descriptions and profile links. The host must not resolve to `localhost` or a private/internal IP address (e.g. `10.x.x.x`, `192.168.x.x`, `172.16-31.x.x`, `127.0.0.0/8`, `169.254.x.x`, or IPv6 ranges like `fd00::/8`, `fc00::/7`, `fe80::/10`, and `::1`). Public IP addresses are allowed.
+
 ## Templates
 `/api/process-cv` supports several template parameters for selecting the resume layout:
 

--- a/server.js
+++ b/server.js
@@ -69,20 +69,27 @@ function validateUrl(input) {
     const url = new URL(String(input));
     if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
     const host = url.hostname.toLowerCase();
-    if (
-      net.isIP(host) ||
-      host === 'localhost' ||
-      /^10\./.test(host) ||
-      /^127\./.test(host) ||
-      /^169\.254\./.test(host) ||
-      /^192\.168\./.test(host) ||
-      /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(host) ||
-      /^fc00:/i.test(host) ||
-      /^fd00:/i.test(host) ||
-      /^fe80:/i.test(host) ||
-      host === '::1'
-    )
-      return null;
+    if (host === 'localhost') return null;
+    const ipVersion = net.isIP(host);
+    if (ipVersion === 4) {
+      if (
+        /^0\./.test(host) ||
+        /^10\./.test(host) ||
+        /^127\./.test(host) ||
+        /^169\.254\./.test(host) ||
+        /^192\.168\./.test(host) ||
+        /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(host)
+      )
+        return null;
+    } else if (ipVersion === 6) {
+      if (
+        /^fc00:/i.test(host) ||
+        /^fd00:/i.test(host) ||
+        /^fe80:/i.test(host) ||
+        host === '::1'
+      )
+        return null;
+    }
     return url.toString();
   } catch {
     return null;

--- a/tests/validateUrl.test.js
+++ b/tests/validateUrl.test.js
@@ -1,0 +1,24 @@
+import { validateUrl } from '../server.js';
+
+describe('validateUrl', () => {
+  test('allows public IPv4 address', () => {
+    const url = 'http://8.8.8.8';
+    expect(validateUrl(url)).toBe(new URL(url).toString());
+  });
+
+  test('allows public IPv6 address', () => {
+    const url = 'http://[2001:4860:4860::8888]';
+    expect(validateUrl(url)).toBe(new URL(url).toString());
+  });
+
+  test.each([
+    'http://localhost',
+    'http://10.0.0.1',
+    'http://172.16.0.1',
+    'http://192.168.0.1',
+    'http://[fd00::1]',
+    'http://[::1]'
+  ])('blocks private or internal host %s', (url) => {
+    expect(validateUrl(url)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- allow public IP addresses in `validateUrl` while blocking private or local ranges
- document URL validation rules in README
- add tests covering public and private IP address handling

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68bd1958ae50832ba4dfa7c9fffb8756