### PR TITLE
Hash PII in Dynamo logs and add retention cleanup

### DIFF
--- a/tests/dynamoLogSession.test.js
+++ b/tests/dynamoLogSession.test.js
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import { createHash } from 'crypto';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { logSession } from '../services/dynamo.js';
 
@@ -19,7 +20,7 @@ describe('logSession location field', () => {
     jest.restoreAllMocks();
   });
 
-  test('includes location derived from IP', async () => {
+  test('includes hashed IP and location derived from IP', async () => {
     const sendMock = jest
       .spyOn(DynamoDBClient.prototype, 'send')
       .mockResolvedValue({});
@@ -29,6 +30,8 @@ describe('logSession location field', () => {
     const putCall = sendMock.mock.calls.find(
       ([cmd]) => cmd.__type === 'PutItemCommand'
     );
+    const hash = createHash('sha256').update('1.2.3.4').digest('hex');
+    expect(putCall[0].input.Item.ipHash).toEqual({ S: hash });
     expect(putCall[0].input.Item.location).toEqual({ S: 'City, Country' });
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,6 +1,7 @@
 import { jest } from '@jest/globals';
 import request from 'supertest';
 import fs from 'fs';
+import { createHash } from 'crypto';
 import {
   uploadFile,
   requestEnhancedCV,
@@ -401,20 +402,18 @@ describe('/api/process-cv', () => {
     expect(putCall[0].input.Item.jobId.S).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
     );
-    expect(putCall[0].input.Item.linkedinProfileUrl.S).toBe(
-      'https://linkedin.com/in/example'
+    const hash = (v) => createHash('sha256').update(v).digest('hex');
+    expect(putCall[0].input.Item.linkedinProfileHash.S).toBe(
+      hash('https://linkedin.com/in/example')
     );
-    expect(putCall[0].input.Item.candidateName.S).toBe(res2.body.applicantName);
-    expect(putCall[0].input.Item.ipAddress.S).toBe('203.0.113.42');
+    expect(putCall[0].input.Item.ipHash.S).toBe(hash('203.0.113.42'));
     expect(putCall[0].input.Item.location.S).toBe('Test City, Test Country');
     expect(putCall[0].input.Item.userAgent.S).toContain('iPhone');
     expect(putCall[0].input.Item.os.S).toBe('iOS');
     expect(putCall[0].input.Item.device.S).toBe('iPhone');
     expect(putCall[0].input.Item.browser.S).toBe('Mobile Safari');
-    expect(putCall[0].input.Item.aiOriginalScore.N).toBe('40');
-    expect(putCall[0].input.Item.aiEnhancedScore.N).toBe('80');
-    expect(putCall[0].input.Item.aiSkillsAdded.L).toEqual([{ S: 'skill1' }]);
-    expect(putCall[0].input.Item.improvementSummary.S).toBe('summary');
+    expect(putCall[0].input.Item.atsScore.N).toBe('40');
+    expect(putCall[0].input.Item.improvement.N).toBe('100');
     types = mockDynamoSend.mock.calls.map(([c]) => c.__type);
     expect(types).toEqual(['DescribeTableCommand', 'PutItemCommand']);
   });


### PR DESCRIPTION
## Summary
- Hash or omit IP addresses and URLs before writing evaluation/session logs to DynamoDB
- Add scheduled cleanup task that removes log entries older than the retention window
- Update tests for new hashed fields

## Testing
- `npm test tests/dynamoLogEvaluation.test.js tests/dynamoLogSession.test.js tests/server.test.js` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bd1bd13ec4832b84f194d5c1a12ff2