### PR TITLE
test: verify linkedin QR inclusion in PDF

### DIFF
--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -166,6 +166,25 @@ describe('generatePdf and parsing', () => {
     launchSpy.mockRestore();
   });
 
+  test('includes LinkedIn QR image when LinkedIn contact provided', async () => {
+    const setContent = jest.fn();
+    const pdf = jest.fn().mockResolvedValue(Buffer.from('PDF'));
+    const close = jest.fn();
+    const newPage = jest.fn().mockResolvedValue({ setContent, pdf });
+    const launchSpy = jest
+      .spyOn(puppeteer, 'launch')
+      .mockResolvedValue({ newPage, close });
+
+    await generatePdf('text', '2025', {
+      linkedinProfileUrl: 'https://www.linkedin.com/in/test'
+    });
+    expect(setContent).toHaveBeenCalled();
+    const html = setContent.mock.calls[0][0];
+    expect(html).toMatch(/<img[^>]+alt="LinkedIn QR code"/);
+
+    launchSpy.mockRestore();
+  });
+
   test('script tags render as text', () => {
     const tokens = parseContent('Jane Doe\n- uses <script>alert(1)</script> safely')
       .sections[0].items[0];


### PR DESCRIPTION
## Summary
- add regression test confirming 2025 PDF template embeds a LinkedIn QR image when contact info includes a LinkedIn link

## Testing
- `npm test tests/generatePdf.test.js` *(fails: Cannot find package '@babel/preset-env')*
- `npm install @babel/preset-env @babel/preset-react` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aws-sdk%2fs3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1e826c60832b824853608497a576