### PR TITLE
Handle invalid CV errors and improve 400 response handling

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -106,15 +106,18 @@ function App() {
       })
       if (response.status === 400) {
         let data
+        let text
         try {
           data = await response.json()
-        } catch {}
+        } catch {
+          text = await response.text()
+        }
         if (data?.nameRequired) {
           setShowNameModal(true)
           return
         }
-        const text = data?.error || 'Request failed'
-        setError(text)
+        const errText = data?.error || text || 'Request failed'
+        setError(errText)
         return
       }
       if (!response.ok) {

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -272,9 +272,9 @@ export default function registerProcessCv(app, generativeModel) {
           });
           return res
             .status(400)
-            .send(
-              `You have uploaded a ${docType} and not a CV – please upload the correct CV`
-            );
+            .json({
+              error: `You have uploaded a ${docType} and not a CV – please upload the correct CV`,
+            });
         }
         const applicantName =
           req.body.applicantName || (await extractName(resumeText));


### PR DESCRIPTION
## Summary
- Return structured JSON errors when non-CV files are uploaded
- Surface raw text from 400 responses if JSON parsing fails on the client

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env'; 47 failed suites)*
- `npm install @babel/preset-env` *(fails: 403 Forbidden retrieving @aws-sdk/s3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bd29138cc4832b92d4fbee6055f74b