### PR TITLE
Rename default DynamoDB table to ResumeForgeLogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The server relies on the following environment variables:
   "GEMINI_API_KEY": "<api-key>",
   "OPENAI_API_KEY": "<api-key>",
   "S3_BUCKET": "resume-forge-data",
+  "DYNAMO_TABLE": "ResumeForgeLogs",
   "REQUEST_TIMEOUT_MS": "5000",
   "TRUST_PROXY": "1",
   "ENFORCE_HTTPS": "true"
@@ -26,6 +27,9 @@ JSON structure. If neither `SECRET_ID` nor `local-secrets.json` is present, the 
 
 `S3_BUCKET` defines where uploads and logs are stored. If it is not set in the environment or secret, the server falls back to
 `resume-forge-data`, which is suitable for local development.
+
+`DYNAMO_TABLE` specifies the DynamoDB table used for logging. If absent from the environment or secret, it defaults to
+`ResumeForgeLogs`.
 
 `REQUEST_TIMEOUT_MS` sets the timeout in milliseconds for outbound HTTP requests when fetching external profiles and job descriptions. It defaults to `5000`.
 
@@ -66,7 +70,7 @@ Minimal permissions required by the server:
 ```
 
 ## DynamoDB Table
-Evaluation and session metadata are stored in a DynamoDB table (default name `ResumeForge`).
+Evaluation and session metadata are stored in a DynamoDB table (default name `ResumeForgeLogs`).
 Each item includes:
 
 - `jobId` – primary key for the log entry.

--- a/services/dynamo.js
+++ b/services/dynamo.js
@@ -72,9 +72,9 @@ export async function logEvaluation({
   if (!tableName) {
     try {
       const secrets = await getSecrets();
-      tableName = secrets.DYNAMO_TABLE || 'ResumeForge';
+      tableName = secrets.DYNAMO_TABLE || 'ResumeForgeLogs';
     } catch {
-      tableName = 'ResumeForge';
+      tableName = 'ResumeForgeLogs';
     }
   }
   await ensureTable(client, tableName);
@@ -132,9 +132,9 @@ export async function logSession({
   if (!tableName) {
     try {
       const secrets = await getSecrets();
-      tableName = secrets.DYNAMO_TABLE || 'ResumeForge';
+      tableName = secrets.DYNAMO_TABLE || 'ResumeForgeLogs';
     } catch {
-      tableName = 'ResumeForge';
+      tableName = 'ResumeForgeLogs';
     }
   }
   await ensureTable(client, tableName);
@@ -180,9 +180,9 @@ export async function cleanupOldRecords({ retentionDays = 30 } = {}) {
   if (!tableName) {
     try {
       const secrets = await getSecrets();
-      tableName = secrets.DYNAMO_TABLE || 'ResumeForge';
+      tableName = secrets.DYNAMO_TABLE || 'ResumeForgeLogs';
     } catch {
-      tableName = 'ResumeForge';
+      tableName = 'ResumeForgeLogs';
     }
   }
   try {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -398,7 +398,7 @@ describe('/api/process-cv', () => {
       ([cmd]) => cmd.__type === 'PutItemCommand'
     );
     expect(putCall).toBeTruthy();
-    expect(putCall[0].input.TableName).toBe('ResumeForge');
+    expect(putCall[0].input.TableName).toBe('ResumeForgeLogs');
     expect(putCall[0].input.Item.jobId.S).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
     );


### PR DESCRIPTION
## Summary
- default DynamoDB table renamed to `ResumeForgeLogs`
- document new `DYNAMO_TABLE` variable and table name in README
- adjust tests for new table name

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68bd2d2e5fd8832ba8b1a181ed074089