### PR TITLE
Add grammar metric to ATS evaluations

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,7 +10,8 @@ const metricTips = {
   crispness: 'Keep sentences concise.',
   keywordDensity: 'Repeat relevant keywords naturally.',
   sectionHeadingClarity: 'Use clear section headings like Experience.',
-  contactInfoCompleteness: 'Include email, phone, and LinkedIn.'
+  contactInfoCompleteness: 'Include email, phone, and LinkedIn.',
+  grammar: 'Proofread for correct grammar and punctuation.'
 }
 
 const formatMetricName = (name) =>
@@ -20,7 +21,8 @@ const atsBreakdownMetrics = [
   'layoutSearchability',
   'atsReadability',
   'impact',
-  'crispness'
+  'crispness',
+  'grammar'
 ]
 
 const otherQualityMetricCategories = {

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -16,7 +16,8 @@ const mockResponse = {
     crispness: 90,
     keywordDensity: 40,
     sectionHeadingClarity: 100,
-    contactInfoCompleteness: 30
+    contactInfoCompleteness: 30,
+    grammar: 70
   }
 }
 

--- a/openaiClient.js
+++ b/openaiClient.js
@@ -30,6 +30,7 @@ const metricNames = [
   'keywordDensity',
   'sectionHeadingClarity',
   'contactInfoCompleteness',
+  'grammar',
 ];
 
 // Gemini responses may wrap JSON in additional text or code fences.

--- a/services/atsMetrics.js
+++ b/services/atsMetrics.js
@@ -91,6 +91,14 @@ export function scoreContactInfoCompleteness(text) {
   return Math.round(score * 100);
 }
 
+export function scoreGrammar(text) {
+  const sentences = text.split(/[.!?]+/).filter((s) => s.trim().length > 0);
+  if (sentences.length === 0) return 0;
+  const errors = sentences.filter((s) => !/^[A-Z]/.test(s.trim())).length;
+  const score = 100 - (errors / sentences.length) * 100;
+  return Math.max(0, Math.min(100, Math.round(score)));
+}
+
 export function calculateMetrics(text) {
   return {
     layoutSearchability: scoreLayoutSearchability(text),
@@ -99,7 +107,8 @@ export function calculateMetrics(text) {
     crispness: scoreCrispness(text),
     keywordDensity: scoreKeywordDensity(text),
     sectionHeadingClarity: scoreSectionHeadingClarity(text),
-    contactInfoCompleteness: scoreContactInfoCompleteness(text)
+    contactInfoCompleteness: scoreContactInfoCompleteness(text),
+    grammar: scoreGrammar(text),
   };
 }
 

--- a/tests/atsMetrics.test.js
+++ b/tests/atsMetrics.test.js
@@ -12,6 +12,7 @@ describe('ATS metric calculations', () => {
       'keywordDensity',
       'sectionHeadingClarity',
       'contactInfoCompleteness',
+      'grammar',
     ]);
     for (const score of Object.values(metrics)) {
       expect(score).toBeGreaterThanOrEqual(0);

--- a/tests/evaluateMetrics.test.js
+++ b/tests/evaluateMetrics.test.js
@@ -53,7 +53,8 @@ describe('/api/evaluate metrics', () => {
         crispness: expect.any(Number),
         keywordDensity: expect.any(Number),
         sectionHeadingClarity: expect.any(Number),
-        contactInfoCompleteness: expect.any(Number)
+        contactInfoCompleteness: expect.any(Number),
+        grammar: expect.any(Number)
       })
     );
   });

--- a/tests/openaiClientGeminiFallback.test.js
+++ b/tests/openaiClientGeminiFallback.test.js
@@ -57,7 +57,8 @@ test('requestAtsAnalysis falls back to Gemini on failure', async () => {
     crispness: 4,
     keywordDensity: 5,
     sectionHeadingClarity: 6,
-    contactInfoCompleteness: 7
+    contactInfoCompleteness: 7,
+    grammar: 8
   };
   generateContentMock.mockResolvedValueOnce({
     response: { text: () => JSON.stringify(json) }

--- a/tests/openaiClientModels.test.js
+++ b/tests/openaiClientModels.test.js
@@ -42,6 +42,7 @@ test('uses supported model without model_not_found warnings', async () => {
     'keywordDensity',
     'sectionHeadingClarity',
     'contactInfoCompleteness',
+    'grammar',
   ]);
   expect(options.text.format.schema.required).toEqual(
     expect.arrayContaining(['metrics'])


### PR DESCRIPTION
## Summary
- include `grammar` in OpenAI metric schema and validation
- surface grammar score and tips in client metrics display
- add heuristic grammar scoring for ATS fallback

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2ec8dd90832b92f8d9bd74a12f45