### PR TITLE
Store request metadata in plain text

### DIFF
--- a/services/dynamo.js
+++ b/services/dynamo.js
@@ -6,7 +6,6 @@ import {
   ScanCommand,
   DeleteItemCommand
 } from '@aws-sdk/client-dynamodb';
-import { createHash } from 'crypto';
 import { getSecrets } from '../config/secrets.js';
 import { region } from '../server.js';
 
@@ -50,10 +49,6 @@ async function ensureTable(client, tableName) {
   }
 }
 
-function hash(value = '') {
-  return createHash('sha256').update(String(value)).digest('hex');
-}
-
 export async function logEvaluation({
   jobId,
   ipAddress = '',
@@ -90,23 +85,17 @@ export async function logEvaluation({
     }
   };
 
-  const addHash = (key, value) => {
-    if (typeof value === 'string' && value.trim()) {
-      item[key] = { S: hash(value) };
-    }
-  };
-
   const location = await resolveLocation(ipAddress);
-  addHash('ipHash', ipAddress);
+  addString('ipAddress', ipAddress);
   addString('location', location);
   addString('userAgent', userAgent);
   addString('browser', browser);
   addString('os', os);
   addString('device', device);
-  addHash('jobDescriptionHash', jobDescriptionUrl);
-  addHash('linkedinProfileHash', linkedinProfileUrl);
-  addHash('credlyProfileHash', credlyProfileUrl);
-  addHash('cvKeyHash', cvKey);
+  addString('jobDescriptionUrl', jobDescriptionUrl);
+  addString('linkedinProfileUrl', linkedinProfileUrl);
+  addString('credlyProfileUrl', credlyProfileUrl);
+  addString('cvKey', cvKey);
   addString('docType', docType);
 
   await client.send(new PutItemCommand({ TableName: tableName, Item: item }));
@@ -152,24 +141,18 @@ export async function logSession({
     }
   };
 
-  const addHash = (key, value) => {
-    if (typeof value === 'string' && value.trim()) {
-      item[key] = { S: hash(value) };
-    }
-  };
-
   const location = await resolveLocation(ipAddress);
-  addHash('ipHash', ipAddress);
+  addString('ipAddress', ipAddress);
   addString('location', location);
   addString('userAgent', userAgent);
   addString('browser', browser);
   addString('os', os);
   addString('device', device);
-  addHash('jobDescriptionHash', jobDescriptionUrl);
-  addHash('linkedinProfileHash', linkedinProfileUrl);
-  addHash('credlyProfileHash', credlyProfileUrl);
-  addHash('cvKeyHash', cvKey);
-  addHash('coverLetterKeyHash', coverLetterKey);
+  addString('jobDescriptionUrl', jobDescriptionUrl);
+  addString('linkedinProfileUrl', linkedinProfileUrl);
+  addString('credlyProfileUrl', credlyProfileUrl);
+  addString('cvKey', cvKey);
+  addString('coverLetterKey', coverLetterKey);
 
   await client.send(new PutItemCommand({ TableName: tableName, Item: item }));
 }

--- a/tests/dynamoLogEvaluation.test.js
+++ b/tests/dynamoLogEvaluation.test.js
@@ -1,5 +1,4 @@
 import { jest } from '@jest/globals';
-import { createHash } from 'crypto';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { logEvaluation } from '../services/dynamo.js';
 
@@ -20,9 +19,7 @@ describe('logEvaluation optional fields', () => {
     jest.restoreAllMocks();
   });
 
-  const hash = (v) => createHash('sha256').update(v).digest('hex');
-
-  test('includes hashed urls when provided', async () => {
+  test('includes plain urls when provided', async () => {
     const sendMock = jest
       .spyOn(DynamoDBClient.prototype, 'send')
       .mockResolvedValue({});
@@ -40,15 +37,18 @@ describe('logEvaluation optional fields', () => {
     const putCall = sendMock.mock.calls.find(
       ([cmd]) => cmd.__type === 'PutItemCommand'
     );
-    expect(putCall[0].input.Item.linkedinProfileHash).toEqual({
-      S: hash('https://linkedin.com/in/example'),
+    expect(putCall[0].input.Item.jobDescriptionUrl).toEqual({
+      S: 'https://example.com/job',
     });
-    expect(putCall[0].input.Item.cvKeyHash).toEqual({ S: hash('s3/key') });
-    expect(putCall[0].input.Item.ipHash).toEqual({ S: hash('ip') });
+    expect(putCall[0].input.Item.linkedinProfileUrl).toEqual({
+      S: 'https://linkedin.com/in/example',
+    });
+    expect(putCall[0].input.Item.cvKey).toEqual({ S: 's3/key' });
+    expect(putCall[0].input.Item.ipAddress).toEqual({ S: 'ip' });
     expect(putCall[0].input.Item.location).toEqual({ S: 'City, Country' });
   });
 
-  test('omits linkedinProfileHash when not provided', async () => {
+  test('omits linkedinProfileUrl when not provided', async () => {
     const sendMock = jest
       .spyOn(DynamoDBClient.prototype, 'send')
       .mockResolvedValue({});
@@ -65,8 +65,8 @@ describe('logEvaluation optional fields', () => {
     const putCall = sendMock.mock.calls.find(
       ([cmd]) => cmd.__type === 'PutItemCommand'
     );
-    expect(putCall[0].input.Item.linkedinProfileHash).toBeUndefined();
-    expect(putCall[0].input.Item.ipHash).toEqual({ S: hash('ip') });
+    expect(putCall[0].input.Item.linkedinProfileUrl).toBeUndefined();
+    expect(putCall[0].input.Item.ipAddress).toEqual({ S: 'ip' });
     expect(putCall[0].input.Item.location).toEqual({ S: 'City, Country' });
   });
 });

--- a/tests/dynamoLogSession.test.js
+++ b/tests/dynamoLogSession.test.js
@@ -1,5 +1,4 @@
 import { jest } from '@jest/globals';
-import { createHash } from 'crypto';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { logSession } from '../services/dynamo.js';
 
@@ -20,7 +19,7 @@ describe('logSession location field', () => {
     jest.restoreAllMocks();
   });
 
-  test('includes hashed IP and location derived from IP', async () => {
+  test('includes IP and location derived from IP', async () => {
     const sendMock = jest
       .spyOn(DynamoDBClient.prototype, 'send')
       .mockResolvedValue({});
@@ -30,8 +29,7 @@ describe('logSession location field', () => {
     const putCall = sendMock.mock.calls.find(
       ([cmd]) => cmd.__type === 'PutItemCommand'
     );
-    const hash = createHash('sha256').update('1.2.3.4').digest('hex');
-    expect(putCall[0].input.Item.ipHash).toEqual({ S: hash });
+    expect(putCall[0].input.Item.ipAddress).toEqual({ S: '1.2.3.4' });
     expect(putCall[0].input.Item.location).toEqual({ S: 'City, Country' });
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,7 +1,6 @@
 import { jest } from '@jest/globals';
 import request from 'supertest';
 import fs from 'fs';
-import { createHash } from 'crypto';
 import {
   uploadFile,
   requestEnhancedCV,
@@ -402,11 +401,10 @@ describe('/api/process-cv', () => {
     expect(putCall[0].input.Item.jobId.S).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
     );
-    const hash = (v) => createHash('sha256').update(v).digest('hex');
-    expect(putCall[0].input.Item.linkedinProfileHash.S).toBe(
-      hash('https://linkedin.com/in/example')
+    expect(putCall[0].input.Item.linkedinProfileUrl.S).toBe(
+      'https://linkedin.com/in/example'
     );
-    expect(putCall[0].input.Item.ipHash.S).toBe(hash('203.0.113.42'));
+    expect(putCall[0].input.Item.ipAddress.S).toBe('203.0.113.42');
     expect(putCall[0].input.Item.location.S).toBe('Test City, Test Country');
     expect(putCall[0].input.Item.userAgent.S).toContain('iPhone');
     expect(putCall[0].input.Item.os.S).toBe('iOS');


### PR DESCRIPTION
## Summary
- stop hashing IP addresses, URLs, and S3 keys in DynamoDB logger
- record `ipAddress`, `jobDescriptionUrl`, `cvKey`, and related fields directly
- update tests for plain-text expectations

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*


------
https://chatgpt.com/codex/tasks/task_e_68bd2fd3e3a8832b8513704f91b96acd