### PR TITLE
Clarify non-CV upload message

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -273,7 +273,7 @@ export default function registerProcessCv(app, generativeModel) {
           return res
             .status(400)
             .json({
-              error: `You have uploaded a ${docType} and not a CV – please upload the correct CV`,
+              error: `You have uploaded a ${docType}. Please upload a CV only.`,
             });
         }
         const applicantName =
@@ -585,7 +585,7 @@ export default function registerProcessCv(app, generativeModel) {
         return next(
           createError(
             400,
-            `You have uploaded a ${docType} and not a CV – please upload the correct CV`
+            `You have uploaded a ${docType}. Please upload a CV only.`
           )
         );
       }

--- a/tests/evaluateRejectNonResume.test.js
+++ b/tests/evaluateRejectNonResume.test.js
@@ -50,7 +50,7 @@ describe('/api/evaluate non-resume', () => {
       .attach('resume', Buffer.from('dummy'), 'file.pdf');
     expect(res.status).toBe(400);
     expect(res.text).toBe(
-      `You have uploaded a ${docType} and not a CV – please upload the correct CV`
+      `You have uploaded a ${docType}. Please upload a CV only.`
     );
     const { logEvaluation } = await import('../services/dynamo.js');
     expect(logEvaluation).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- clarify rejection message when a non-CV document is uploaded
- update corresponding test expectation

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aws-sdk%2fs3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3a410070832b8d4eae6143fbc89c