### PR TITLE
Add resources for additional skills

### DIFF
--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -132,7 +132,7 @@ test('displays new additions section after compile', async () => {
           coverLetterUrl: '',
           atsScore: 80,
           improvement: 10,
-          addedSkills: ['aws'],
+          addedSkills: ['aws', 'python'],
           designation: 'Senior Developer',
         }),
     })
@@ -163,6 +163,7 @@ test('displays new additions section after compile', async () => {
     await screen.findByText('New Additions for Interview Prep')
   ).toBeInTheDocument()
   expect(await screen.findByText('aws')).toBeInTheDocument()
+  expect(await screen.findByText('python')).toBeInTheDocument()
   expect(await screen.findByText('Senior Developer')).toBeInTheDocument()
   expect(await screen.findByText('Project Alpha')).toBeInTheDocument()
   expect(await screen.findByText('AWS Cert - Amazon')).toBeInTheDocument()
@@ -205,7 +206,7 @@ test('shows curated resource link for known skill', async () => {
           coverLetterUrl: '',
           atsScore: 80,
           improvement: 10,
-          addedSkills: ['aws'],
+          addedSkills: ['aws', 'python'],
           designation: 'Senior Developer',
         }),
     })
@@ -232,4 +233,9 @@ test('shows curated resource link for known skill', async () => {
 
   const link = await screen.findByText('AWS Training')
   expect(link).toHaveAttribute('href', 'https://aws.amazon.com/training/')
+  const pyLink = await screen.findByText('Python Official Tutorial')
+  expect(pyLink).toHaveAttribute(
+    'href',
+    'https://docs.python.org/3/tutorial/'
+  )
 })

--- a/client/src/skillResources.js
+++ b/client/src/skillResources.js
@@ -5,6 +5,18 @@ const skillResources = {
   ],
   react: [
     { label: 'React Official Tutorial', url: 'https://react.dev/learn' }
+  ],
+  python: [
+    { label: 'Python Official Tutorial', url: 'https://docs.python.org/3/tutorial/' },
+    { label: 'Real Python Tutorials', url: 'https://realpython.com/' }
+  ],
+  docker: [
+    { label: 'Docker Documentation', url: 'https://docs.docker.com/' },
+    { label: 'Docker Getting Started Guide', url: 'https://docs.docker.com/get-started/' }
+  ],
+  typescript: [
+    { label: 'TypeScript Documentation', url: 'https://www.typescriptlang.org/docs/' },
+    { label: 'TypeScript Handbook', url: 'https://www.typescriptlang.org/docs/handbook/intro.html' }
   ]
 }
 


### PR DESCRIPTION
## Summary
- add Python, Docker, and TypeScript learning resources
- cover new skills in interview-prep resource tests

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install --no-save @babel/preset-env @babel/preset-react babel-jest jest-environment-jsdom @testing-library/react @testing-library/jest-dom` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aws-sdk%2fs3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3aea8730832b9c8cc8de64e15265