### PR TITLE
Add icons to 2025 template section headings

### DIFF
--- a/templates/2025.css
+++ b/templates/2025.css
@@ -47,6 +47,14 @@ body {
   color: var(--accent);
   border-bottom: 2px solid var(--accent);
   padding-bottom: 4px;
+  display: flex;
+  align-items: center;
+}
+
+.section h2 .section-icon {
+  margin-right: 8px;
+  font-size: 0.9em;
+  color: var(--accent);
 }
 
 .section ul {

--- a/templates/2025.html
+++ b/templates/2025.html
@@ -24,7 +24,7 @@
     <main class="content">
       {{#if skillsMatrix}}
       <section class="section skills-matrix">
-        <h2>Skills</h2>
+        <h2><i class="fa-solid fa-circle section-icon" aria-hidden="true"></i>Skills</h2>
         <div class="skills-grid">
           {{#each skillsMatrix}}
           <div class="skill">
@@ -42,7 +42,7 @@
       {{/if}}
       {{#if languages}}
       <section class="section languages">
-        <h2>Languages</h2>
+        <h2><i class="fa-solid fa-circle section-icon" aria-hidden="true"></i>Languages</h2>
         <div class="languages-grid">
           {{#each languages}}
           <div class="language">
@@ -57,7 +57,7 @@
       {{/if}}
       {{#each sections}}
       <section class="section">
-        {{#if heading}}<h2>{{heading}}</h2>{{/if}}
+        {{#if heading}}<h2><i class="fa-solid fa-circle section-icon" aria-hidden="true"></i>{{heading}}</h2>{{/if}}
         {{#if items}}
           <ul>
             {{#each items}}


### PR DESCRIPTION
## Summary
- Insert Font Awesome icons before each h2 heading in the 2025 resume template
- Style icons for size, color, and alignment while preserving text structure

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bd3cdec738832ba65a3a3e51b860ee