### PR TITLE
Clarify message for unrecognized document type

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -290,7 +290,10 @@ export default function registerProcessCv(app, generativeModel) {
           });
           return res
             .status(400)
-            .json({ error: 'Document type could not be determined.' });
+            .json({
+              error:
+                "The document type couldn't be recognized; please upload a CV.",
+            });
         }
         const applicantName =
           req.body.applicantName || (await extractName(resumeText));
@@ -606,7 +609,12 @@ export default function registerProcessCv(app, generativeModel) {
         );
       }
       if (docType === 'unknown') {
-        return next(createError(400, 'Document type could not be determined.'));
+        return next(
+          createError(
+            400,
+            "The document type couldn't be recognized; please upload a CV."
+          )
+        );
       }
       const lines = originalText
         .split(/\r?\n/)


### PR DESCRIPTION
## Summary
- Return a clearer error when the uploaded document's type can't be determined, instructing users to provide a CV
- Test rejection of unrecognized document types during evaluation

## Testing
- `npm test tests/evaluateRejectNonResume.test.js` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bd417e8e1c832b947aed714f1ff0e6