### PR TITLE
Nest cover letters under dedicated folder

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -1758,6 +1758,7 @@ export default function registerProcessCv(app, generativeModel) {
         sanitizedName,
         'enhanced',
         coverDate,
+        'cover_letter',
         `${Date.now()}-cover_letter.pdf`
       );
       await s3.send(

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -369,7 +369,7 @@ describe('/api/process-cv', () => {
 
     res2.body.urls.forEach(({ type, url }) => {
       if (type.startsWith('cover_letter')) {
-        expect(url).toContain(`/${sanitized}/enhanced/${date}/`);
+        expect(url).toContain(`/${sanitized}/enhanced/${date}/cover_letter/`);
         expect(url).toContain('cover_letter');
       } else {
         expect(url).toContain(`/${sanitized}/enhanced/cv/${date}/`);
@@ -382,11 +382,13 @@ describe('/api/process-cv', () => {
     expect(pdfKeys).toHaveLength(5);
     const cvPrefix = `${sanitized}/cv/${date}/`;
     const enhancedCvPrefix = `${sanitized}/enhanced/cv/${date}/`;
+    const coverLetterPrefix = `${sanitized}/enhanced/${date}/cover_letter/`;
     const enhancedPrefix = `${sanitized}/enhanced/${date}/`;
     pdfKeys.forEach((k) => {
       expect(
         k.startsWith(cvPrefix) ||
           k.startsWith(enhancedCvPrefix) ||
+          k.startsWith(coverLetterPrefix) ||
           k.startsWith(enhancedPrefix)
       ).toBe(true);
     });


### PR DESCRIPTION
## Summary
- Store cover letters under a `cover_letter` subdirectory in S3 key creation
- Adjust tests to expect new cover letter folder structure

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bd462f3dbc832b90d70385afecff0d