### PR TITLE
feat: add Gemini fallback for enhanced CV

### DIFF
--- a/tests/openaiClientGeminiFallback.test.js
+++ b/tests/openaiClientGeminiFallback.test.js
@@ -27,7 +27,7 @@ afterEach(() => {
 test('requestEnhancedCV falls back to Gemini on failure', async () => {
   createResponse.mockRejectedValueOnce(new Error('openai fail'));
   generateContentMock.mockResolvedValueOnce({
-    response: { text: () => '{"cv_version1":"a","cv_version2":"b"}' }
+    response: { text: () => '{"cvVersion1":"a","coverLetter1":"b"}' }
   });
   const result = await requestEnhancedCV({
     cvFileId: 'cv',
@@ -35,7 +35,9 @@ test('requestEnhancedCV falls back to Gemini on failure', async () => {
     instructions: 'instr'
   });
   expect(generateContentMock).toHaveBeenCalledTimes(1);
-  expect(result).toBe('{"cv_version1":"a","cv_version2":"b"}');
+  const parsed = JSON.parse(result);
+  expect(parsed).toHaveProperty('cv_version1', 'a');
+  expect(parsed).toHaveProperty('cover_letter1', 'b');
 });
 
 test('requestCoverLetter falls back to Gemini on failure', async () => {


### PR DESCRIPTION
## Summary
- fall back to Gemini when OpenAI CV enhancement fails
- normalize Gemini JSON to match OpenAI schema
- test EnhancedCV fallback and key normalization

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found; Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68bd4bba8750832b8f96f08c563c9f55