### PR TITLE
Validate URLs via DNS resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "transform": {
       "^.+\\.jsx?$": ["babel-jest", {"presets": ["@babel/preset-env", "@babel/preset-react"]}]
     },
+    "setupFiles": ["<rootDir>/tests/setupDnsMock.js"],
     "moduleNameMapper": {
       "^@google/generative-ai$": "<rootDir>/tests/mocks/google-generative-ai.js",
       "^@aws-sdk/client-dynamodb$": "<rootDir>/tests/mocks/aws-sdk-client-dynamodb.js",

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -60,7 +60,7 @@ export async function fetchJobDescription(
   url,
   { timeout = DEFAULT_FETCH_TIMEOUT_MS, userAgent = DEFAULT_USER_AGENT } = {},
 ) {
-  const valid = validateUrl(url);
+  const valid = await validateUrl(url);
   if (!valid) throw new Error('Invalid URL');
   try {
     const { data } = await axios.get(valid, {
@@ -231,18 +231,18 @@ export default function registerProcessCv(app, generativeModel) {
         let { jobDescriptionUrl, linkedinProfileUrl, credlyProfileUrl } = req.body;
         if (!jobDescriptionUrl)
           return next(createError(400, 'jobDescriptionUrl required'));
-        jobDescriptionUrl = validateUrl(jobDescriptionUrl);
+        jobDescriptionUrl = await validateUrl(jobDescriptionUrl);
         if (!jobDescriptionUrl)
           return next(createError(400, 'invalid jobDescriptionUrl'));
 
         if (!linkedinProfileUrl)
           return next(createError(400, 'linkedinProfileUrl required'));
-        linkedinProfileUrl = validateUrl(linkedinProfileUrl);
+        linkedinProfileUrl = await validateUrl(linkedinProfileUrl);
         if (!linkedinProfileUrl)
           return next(createError(400, 'invalid linkedinProfileUrl'));
 
         if (credlyProfileUrl) {
-          credlyProfileUrl = validateUrl(credlyProfileUrl);
+          credlyProfileUrl = await validateUrl(credlyProfileUrl);
           if (!credlyProfileUrl)
             return next(createError(400, 'invalid credlyProfileUrl'));
         }
@@ -571,16 +571,16 @@ export default function registerProcessCv(app, generativeModel) {
     if (!linkedinProfileUrl) {
       return next(createError(400, 'linkedinProfileUrl required'));
     }
-    jobDescriptionUrl = validateUrl(jobDescriptionUrl);
+    jobDescriptionUrl = await validateUrl(jobDescriptionUrl);
     if (!jobDescriptionUrl) {
       return next(createError(400, 'invalid jobDescriptionUrl'));
     }
-    linkedinProfileUrl = validateUrl(linkedinProfileUrl);
+    linkedinProfileUrl = await validateUrl(linkedinProfileUrl);
     if (!linkedinProfileUrl) {
       return next(createError(400, 'invalid linkedinProfileUrl'));
     }
     if (credlyProfileUrl) {
-      credlyProfileUrl = validateUrl(credlyProfileUrl);
+      credlyProfileUrl = await validateUrl(credlyProfileUrl);
       if (!credlyProfileUrl) {
         return next(createError(400, 'invalid credlyProfileUrl'));
       }
@@ -1044,7 +1044,7 @@ export default function registerProcessCv(app, generativeModel) {
         if (!metric) return next(createError(400, 'metric required'));
         if (!jobDescriptionUrl)
           return next(createError(400, 'jobDescriptionUrl required'));
-        jobDescriptionUrl = validateUrl(jobDescriptionUrl);
+        jobDescriptionUrl = await validateUrl(jobDescriptionUrl);
         if (!jobDescriptionUrl)
           return next(createError(400, 'invalid jobDescriptionUrl'));
         const userAgent = req.headers['user-agent'] || DEFAULT_USER_AGENT;
@@ -1092,7 +1092,7 @@ export default function registerProcessCv(app, generativeModel) {
         if (gap) {
           if (!jobDescriptionUrl)
             return next(createError(400, 'jobDescriptionUrl required'));
-          jobDescriptionUrl = validateUrl(jobDescriptionUrl);
+          jobDescriptionUrl = await validateUrl(jobDescriptionUrl);
           if (!jobDescriptionUrl)
             return next(createError(400, 'invalid jobDescriptionUrl'));
           const userAgent = req.headers['user-agent'] || DEFAULT_USER_AGENT;
@@ -1115,7 +1115,7 @@ export default function registerProcessCv(app, generativeModel) {
         if (!req.file) return next(createError(400, 'resume file required'));
         if (!jobDescriptionUrl)
           return next(createError(400, 'jobDescriptionUrl required'));
-        jobDescriptionUrl = validateUrl(jobDescriptionUrl);
+        jobDescriptionUrl = await validateUrl(jobDescriptionUrl);
         if (!jobDescriptionUrl)
           return next(createError(400, 'invalid jobDescriptionUrl'));
         const userAgent = req.headers['user-agent'] || DEFAULT_USER_AGENT;
@@ -1197,14 +1197,14 @@ export default function registerProcessCv(app, generativeModel) {
         createError(400, 'existingCvKey or existingCvTextKey required')
       );
 
-    jobDescriptionUrl = validateUrl(jobDescriptionUrl);
+    jobDescriptionUrl = await validateUrl(jobDescriptionUrl);
     if (!jobDescriptionUrl)
       return next(createError(400, 'invalid jobDescriptionUrl'));
-    linkedinProfileUrl = validateUrl(linkedinProfileUrl);
+    linkedinProfileUrl = await validateUrl(linkedinProfileUrl);
     if (!linkedinProfileUrl)
       return next(createError(400, 'invalid linkedinProfileUrl'));
     if (credlyProfileUrl) {
-      credlyProfileUrl = validateUrl(credlyProfileUrl);
+      credlyProfileUrl = await validateUrl(credlyProfileUrl);
       if (!credlyProfileUrl)
         return next(createError(400, 'invalid credlyProfileUrl'));
     }
@@ -1399,14 +1399,14 @@ export default function registerProcessCv(app, generativeModel) {
       if (!linkedinProfileUrl)
         return next(createError(400, 'linkedinProfileUrl required'));
 
-      jobDescriptionUrl = validateUrl(jobDescriptionUrl);
+      jobDescriptionUrl = await validateUrl(jobDescriptionUrl);
       if (!jobDescriptionUrl)
         return next(createError(400, 'invalid jobDescriptionUrl'));
-      linkedinProfileUrl = validateUrl(linkedinProfileUrl);
+      linkedinProfileUrl = await validateUrl(linkedinProfileUrl);
       if (!linkedinProfileUrl)
         return next(createError(400, 'invalid linkedinProfileUrl'));
       if (credlyProfileUrl) {
-        credlyProfileUrl = validateUrl(credlyProfileUrl);
+        credlyProfileUrl = await validateUrl(credlyProfileUrl);
         if (!credlyProfileUrl)
           return next(createError(400, 'invalid credlyProfileUrl'));
       }
@@ -1586,14 +1586,14 @@ export default function registerProcessCv(app, generativeModel) {
           createError(400, 'existingCvKey or existingCvTextKey required')
         );
 
-      jobDescriptionUrl = validateUrl(jobDescriptionUrl);
+      jobDescriptionUrl = await validateUrl(jobDescriptionUrl);
       if (!jobDescriptionUrl)
         return next(createError(400, 'invalid jobDescriptionUrl'));
-      linkedinProfileUrl = validateUrl(linkedinProfileUrl);
+      linkedinProfileUrl = await validateUrl(linkedinProfileUrl);
       if (!linkedinProfileUrl)
         return next(createError(400, 'invalid linkedinProfileUrl'));
       if (credlyProfileUrl) {
-        credlyProfileUrl = validateUrl(credlyProfileUrl);
+        credlyProfileUrl = await validateUrl(credlyProfileUrl);
         if (!credlyProfileUrl)
           return next(createError(400, 'invalid credlyProfileUrl'));
       }

--- a/tests/setupDnsMock.js
+++ b/tests/setupDnsMock.js
@@ -1,0 +1,6 @@
+import dns from 'dns';
+
+jest.spyOn(dns.promises, 'lookup').mockImplementation(async () => ({
+  address: '93.184.216.34', // example.com public IP
+  family: 4
+}));

--- a/tests/validateUrl.test.js
+++ b/tests/validateUrl.test.js
@@ -1,14 +1,15 @@
+import dns from 'dns';
 import { validateUrl } from '../server.js';
 
 describe('validateUrl', () => {
-  test('allows public IPv4 address', () => {
+  test('allows public IPv4 address', async () => {
     const url = 'http://8.8.8.8';
-    expect(validateUrl(url)).toBe(new URL(url).toString());
+    expect(await validateUrl(url)).toBe(new URL(url).toString());
   });
 
-  test('allows public IPv6 address', () => {
+  test('allows public IPv6 address', async () => {
     const url = 'http://[2001:4860:4860::8888]';
-    expect(validateUrl(url)).toBe(new URL(url).toString());
+    expect(await validateUrl(url)).toBe(new URL(url).toString());
   });
 
   test.each([
@@ -18,7 +19,12 @@ describe('validateUrl', () => {
     'http://192.168.0.1',
     'http://[fd00::1]',
     'http://[::1]'
-  ])('blocks private or internal host %s', (url) => {
-    expect(validateUrl(url)).toBeNull();
+  ])('blocks private or internal host %s', async (url) => {
+    expect(await validateUrl(url)).toBeNull();
+  });
+
+  test('blocks domain resolving to private ip', async () => {
+    dns.promises.lookup.mockResolvedValueOnce({ address: '127.0.0.1', family: 4 });
+    await expect(validateUrl('http://evil.com')).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- resolve hostnames via DNS in `validateUrl` and block private IPs
- stub DNS lookup for tests and add malicious domain coverage

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bd4cd1ce8c832baab1094d0a30095e