### PR TITLE
Add OpenAI fallback for name extraction

### DIFF
--- a/tests/extractName.test.js
+++ b/tests/extractName.test.js
@@ -1,0 +1,52 @@
+import { jest } from '@jest/globals';
+
+const generateContentMock = jest.fn();
+const openaiExtractNameMock = jest.fn();
+
+jest.unstable_mockModule('../geminiClient.js', () => ({
+  generativeModel: { generateContent: generateContentMock }
+}));
+
+jest.unstable_mockModule('../openaiClient.js', () => ({
+  uploadFile: jest.fn(),
+  requestEnhancedCV: jest.fn(),
+  classifyDocument: jest.fn(),
+  extractName: openaiExtractNameMock
+}));
+
+const { extractName } = await import('../server.js');
+
+afterEach(() => {
+  generateContentMock.mockReset();
+  openaiExtractNameMock.mockReset();
+});
+
+test('uses Gemini name when available', async () => {
+  generateContentMock.mockResolvedValueOnce({
+    response: { text: () => 'Jane Doe' }
+  });
+  const name = await extractName('resume text');
+  expect(name).toBe('Jane Doe');
+  expect(generateContentMock).toHaveBeenCalledTimes(1);
+  expect(openaiExtractNameMock).not.toHaveBeenCalled();
+});
+
+test('falls back to OpenAI when Gemini fails', async () => {
+  generateContentMock.mockRejectedValueOnce(new Error('fail'));
+  openaiExtractNameMock.mockResolvedValueOnce('John Doe');
+  const name = await extractName('resume text');
+  expect(generateContentMock).toHaveBeenCalledTimes(1);
+  expect(openaiExtractNameMock).toHaveBeenCalledTimes(1);
+  expect(name).toBe('John Doe');
+});
+
+test('falls back to OpenAI when Gemini returns unknown', async () => {
+  generateContentMock.mockResolvedValueOnce({
+    response: { text: () => 'unknown' }
+  });
+  openaiExtractNameMock.mockResolvedValueOnce('John Doe');
+  const name = await extractName('resume text');
+  expect(generateContentMock).toHaveBeenCalledTimes(1);
+  expect(openaiExtractNameMock).toHaveBeenCalledTimes(1);
+  expect(name).toBe('John Doe');
+});


### PR DESCRIPTION
## Summary
- Enhance `extractName` to try Gemini first and fall back to OpenAI when Gemini fails or returns no name
- Expose new `extractName` helper in `openaiClient` for OpenAI name extraction
- Add tests verifying OpenAI fallback behavior

## Testing
- `npm test tests/extractName.test.js` *(fails: Cannot find package '@babel/preset-env')*
- `npm install` *(fails: 403 Forbidden retrieving @aws-sdk/s3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68bd538fb034832ba5acce5fdf880f12