### PR TITLE
Add fallback-driven skill icon mapping

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from 'react'
 import skillResources from './skillResources'
 import { getScoreStatus } from './scoreStatus'
-import { DEFAULT_SKILL_ICONS } from '../../skillIcons.js'
+import { getSkillIcon } from '../../skillIcons.js'
 
 const metricTips = {
   layoutSearchability: 'Use bullet points for better scanning.',
@@ -174,7 +174,7 @@ function App() {
       setSkills(
         (data.missingSkills || []).map((s) => ({
           name: s,
-          icon: DEFAULT_SKILL_ICONS[s.toLowerCase()] || '',
+          icon: getSkillIcon(s),
           level: 70
         }))
       )
@@ -208,8 +208,7 @@ function App() {
         if (i !== idx) return s
         const updated = { ...s, [field]: value }
         if (field === 'name') {
-          const icon = DEFAULT_SKILL_ICONS[value.toLowerCase()]
-          if (icon) updated.icon = icon
+          updated.icon = getSkillIcon(value)
           if (!updated.level) updated.level = 70
         }
         return updated

--- a/services/generatePdf.js
+++ b/services/generatePdf.js
@@ -8,7 +8,7 @@ import {
   mergeDuplicateSections,
   normalizeHeading
 } from './parseContent.js';
-import { DEFAULT_SKILL_ICONS } from '../skillIcons.js';
+import { getSkillIcon } from '../skillIcons.js';
 
 const ALL_TEMPLATES = [
   'modern',
@@ -212,7 +212,7 @@ export async function generatePdf(
             if (level > 100) level = 100;
           }
           if (!icon) {
-            icon = DEFAULT_SKILL_ICONS[name.toLowerCase()] || null;
+            icon = getSkillIcon(name);
           }
           let iconHtml = '';
           if (icon) {

--- a/skillIcons.js
+++ b/skillIcons.js
@@ -1,12 +1,47 @@
 export const DEFAULT_SKILL_ICONS = {
   javascript: 'fa-brands fa-js',
+  typescript: 'fa-solid fa-code',
   python: 'fa-brands fa-python',
+  java: 'fa-brands fa-java',
+  ruby: 'fa-regular fa-gem',
+  php: 'fa-brands fa-php',
   html: 'fa-brands fa-html5',
   css: 'fa-brands fa-css3-alt',
   node: 'fa-brands fa-node-js',
   react: 'fa-brands fa-react',
+  angular: 'fa-brands fa-angular',
+  vue: 'fa-brands fa-vuejs',
   docker: 'fa-brands fa-docker',
-  aws: 'fa-brands fa-aws'
+  kubernetes: 'fa-solid fa-gears',
+  aws: 'fa-brands fa-aws',
+  git: 'fa-brands fa-git-alt',
+  github: 'fa-brands fa-github',
+  gitlab: 'fa-brands fa-gitlab',
+  mysql: 'fa-solid fa-database',
+  postgres: 'fa-solid fa-database',
+  postgresql: 'fa-solid fa-database',
+  mongodb: 'fa-solid fa-database',
+  sql: 'fa-solid fa-database',
+  linux: 'fa-brands fa-linux',
+  c: 'fa-solid fa-code',
+  'c++': 'fa-solid fa-code',
+  cpp: 'fa-solid fa-code',
+  'c#': 'fa-solid fa-code',
+  csharp: 'fa-solid fa-code',
+  go: 'fa-solid fa-code',
+  golang: 'fa-solid fa-code',
+  swift: 'fa-brands fa-swift',
+  kotlin: 'fa-solid fa-code',
+  android: 'fa-brands fa-android',
+  ios: 'fa-brands fa-apple',
+  wordpress: 'fa-brands fa-wordpress',
+  bootstrap: 'fa-brands fa-bootstrap',
+  graphql: 'fa-solid fa-share-nodes'
 }
+
+export const FALLBACK_SKILL_ICON = 'fa-solid fa-circle-question'
+
+export const getSkillIcon = (skill = '') =>
+  DEFAULT_SKILL_ICONS[skill.toLowerCase()] || FALLBACK_SKILL_ICON
 
 export default DEFAULT_SKILL_ICONS

--- a/tests/skillIcons.test.js
+++ b/tests/skillIcons.test.js
@@ -1,0 +1,12 @@
+import { getSkillIcon, FALLBACK_SKILL_ICON, DEFAULT_SKILL_ICONS } from '../skillIcons.js'
+
+describe('getSkillIcon', () => {
+  test('returns icon for known skill', () => {
+    expect(getSkillIcon('javascript')).toBe(DEFAULT_SKILL_ICONS.javascript)
+  })
+
+  test('returns fallback for unknown skill', () => {
+    expect(getSkillIcon('unknown-skill')).toBe(FALLBACK_SKILL_ICON)
+  })
+})
+


### PR DESCRIPTION
## Summary
- extend built-in skill icons with additional common technologies
- add `getSkillIcon` helper and fallback icon for unmapped skills
- update client and PDF generation to always show an icon
- cover icon helper with unit tests

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bd5b8efa44832bb0455131abe1e0a1