### PR TITLE
feat: add certification and language prep resources

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,7 @@
 import { useState, useRef } from 'react'
 import skillResources from './skillResources'
+import certResources from './certResources'
+import languageResources from './languageResources'
 import { getScoreStatus } from './scoreStatus'
 import { getSkillIcon } from '../../skillIcons.js'
 
@@ -828,7 +830,8 @@ function App() {
               <h3 className="font-semibold mb-2">New Additions for Interview Prep</h3>
               <ul className="list-disc list-inside">
                 {newAdditions.map((item, idx) => {
-                  const resources = skillResources[item.toLowerCase().trim()]
+                  const key = item.toLowerCase().trim()
+                  const resources = skillResources[key] || certResources[key] || languageResources[key]
                   return (
                     <li key={idx}>
                       {item}{' '}

--- a/client/src/certResources.js
+++ b/client/src/certResources.js
@@ -1,0 +1,24 @@
+const certResources = {
+  'aws certified cloud practitioner': [
+    {
+      label: 'AWS Cloud Practitioner Essentials',
+      url: 'https://aws.amazon.com/training/course-descriptions/cloud-practitioner-essentials/'
+    },
+    {
+      label: 'AWS Certification: CCP',
+      url: 'https://aws.amazon.com/certification/certified-cloud-practitioner/'
+    }
+  ],
+  'project management professional': [
+    {
+      label: 'PMI PMP Certification',
+      url: 'https://www.pmi.org/certifications/project-management-pmp'
+    },
+    {
+      label: 'PMP Exam Prep',
+      url: 'https://www.project-management-prepcast.com/'
+    }
+  ]
+}
+
+export default certResources

--- a/client/src/languageResources.js
+++ b/client/src/languageResources.js
@@ -1,0 +1,24 @@
+const languageResources = {
+  spanish: [
+    {
+      label: 'Duolingo Spanish Course',
+      url: 'https://www.duolingo.com/course/es/en/Learn-Spanish'
+    },
+    {
+      label: 'BBC Languages - Spanish',
+      url: 'http://www.bbc.co.uk/languages/spanish/'
+    }
+  ],
+  french: [
+    {
+      label: 'Duolingo French Course',
+      url: 'https://www.duolingo.com/course/fr/en/Learn-French'
+    },
+    {
+      label: 'TV5MONDE French',
+      url: 'https://apprendre.tv5monde.com/en'
+    }
+  ]
+}
+
+export default languageResources


### PR DESCRIPTION
## Summary
- add certification and language resource maps
- surface certification and language recommendations in prep section

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bd5e4cc5ec832b8193d7246a3f8cca