### PR TITLE
feat: use local Font Awesome for 2025 template

### DIFF
--- a/assets/fontawesome/README.md
+++ b/assets/fontawesome/README.md
@@ -1,0 +1,6 @@
+# Font Awesome Assets
+
+This directory should contain local copies of Font Awesome 6.5.0 files.
+Download `css/all.min.css`, `js/all.min.js`, and the contents of the `webfonts/` directory from the official Font Awesome distribution or CDN and place them here.
+
+Placeholders are included because network access was unavailable during setup.

--- a/assets/fontawesome/css/all.min.css
+++ b/assets/fontawesome/css/all.min.css
@@ -1,0 +1,1 @@
+/* Placeholder for Font Awesome CSS. Replace with actual all.min.css */

--- a/assets/fontawesome/js/all.min.js
+++ b/assets/fontawesome/js/all.min.js
@@ -1,0 +1,1 @@
+// Placeholder for Font Awesome JS. Replace with actual all.min.js

--- a/templates/2025.html
+++ b/templates/2025.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Resume</title>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+  <link rel="stylesheet" href="../assets/fontawesome/css/all.min.css">
+  <script defer src="../assets/fontawesome/js/all.min.js"></script>
   <!-- 2025 template ensures whitespace and tab rendering -->
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add local placeholders for Font Awesome assets
- update 2025 template to load Font Awesome from local assets

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68bd5f515cf8832bb417244688c40e6e