### PR TITLE
Standardize S3 key structure

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -315,7 +315,7 @@ export default function registerProcessCv(app, generativeModel) {
         const s3 = new S3Client({ region });
         const ext = path.extname(req.file.originalname).toLowerCase();
         const date = new Date().toISOString().split('T')[0];
-        const prefix = `${sanitized}/cv/${date}/`;
+        const prefix = `${sanitized}/${date}/cv/`;
         cvKey = `${prefix}${sanitized}${ext}`;
         try {
           await s3.send(
@@ -1315,6 +1315,7 @@ export default function registerProcessCv(app, generativeModel) {
         sanitizedName,
         'enhanced',
         date,
+        'cv',
         `${ts}-improved.pdf`
       );
       await s3.send(
@@ -1329,6 +1330,7 @@ export default function registerProcessCv(app, generativeModel) {
         sanitizedName,
         'enhanced',
         date,
+        'cv',
         `${ts}-improved.txt`
       );
       await s3.send(
@@ -1519,6 +1521,7 @@ export default function registerProcessCv(app, generativeModel) {
         sanitizedName,
         'enhanced',
         date,
+        'cover_letter',
         `${Date.now()}-cover_letter.pdf`
       );
       await s3.send(
@@ -1655,8 +1658,8 @@ export default function registerProcessCv(app, generativeModel) {
         existingCvKey = path.join(
           sanitizedName,
           'enhanced',
-          'cv',
           date,
+          'cv',
           `${Date.now()}-final_cv.pdf`
         );
         await s3.send(
@@ -1673,8 +1676,8 @@ export default function registerProcessCv(app, generativeModel) {
         existingCvTextKey = path.join(
           sanitizedName,
           'enhanced',
-          'cv',
           date,
+          'cv',
           `${Date.now()}-final_cv.txt`
         );
         await s3.send(

--- a/tests/evaluateS3Upload.test.js
+++ b/tests/evaluateS3Upload.test.js
@@ -59,6 +59,6 @@ describe('/api/evaluate S3 upload', () => {
     expect(res.status).toBe(200);
     expect(PutObjectCommand).toHaveBeenCalled();
     const key = PutObjectCommand.mock.calls[0][0].Key;
-    expect(key).toMatch(/^john_doe\/cv\/\d{4}-\d{2}-\d{2}\/john_doe\.pdf$/);
+    expect(key).toMatch(/^john_doe\/\d{4}-\d{2}-\d{2}\/cv\/john_doe\.pdf$/);
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -376,7 +376,7 @@ describe('/api/process-cv', () => {
         expect(url).toContain(`/${sanitized}/enhanced/${date}/cover_letter/`);
         expect(url).toContain('cover_letter');
       } else {
-        expect(url).toContain(`/${sanitized}/enhanced/cv/${date}/`);
+        expect(url).toContain(`/${sanitized}/enhanced/${date}/cv/`);
       }
     });
 
@@ -384,8 +384,8 @@ describe('/api/process-cv', () => {
       .map((c) => c[0]?.input?.Key)
       .filter((k) => k && k.endsWith('.pdf'));
     expect(pdfKeys).toHaveLength(5);
-    const cvPrefix = `${sanitized}/cv/${date}/`;
-    const enhancedCvPrefix = `${sanitized}/enhanced/cv/${date}/`;
+    const cvPrefix = `${sanitized}/${date}/cv/`;
+    const enhancedCvPrefix = `${sanitized}/enhanced/${date}/cv/`;
     const coverLetterPrefix = `${sanitized}/enhanced/${date}/cover_letter/`;
     const enhancedPrefix = `${sanitized}/enhanced/${date}/`;
     pdfKeys.forEach((k) => {


### PR DESCRIPTION
## Summary
- store evaluation uploads at `<name>/<date>/cv/`
- organize generated resumes and cover letters under `<name>/enhanced/<date>/cv|cover_letter/`
- update tests for new S3 key format

## Testing
- `npm test tests/evaluateS3Upload.test.js tests/server.test.js` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68bd6ab47cf8832ba9fedda66b5a1c0c