### PR TITLE
Align evaluation CV upload path with compile-time structure

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -315,7 +315,7 @@ export default function registerProcessCv(app, generativeModel) {
         const s3 = new S3Client({ region });
         const ext = path.extname(req.file.originalname).toLowerCase();
         const date = new Date().toISOString().split('T')[0];
-        const prefix = `${sanitized}/${date}/cv/`;
+        const prefix = `${sanitized}/cv/${date}/`;
         cvKey = `${prefix}${sanitized}${ext}`;
         try {
           await s3.send(

--- a/tests/evaluateS3Upload.test.js
+++ b/tests/evaluateS3Upload.test.js
@@ -59,6 +59,6 @@ describe('/api/evaluate S3 upload', () => {
     expect(res.status).toBe(200);
     expect(PutObjectCommand).toHaveBeenCalled();
     const key = PutObjectCommand.mock.calls[0][0].Key;
-    expect(key).toMatch(/^john_doe\/\d{4}-\d{2}-\d{2}\/cv\/john_doe\.pdf$/);
+    expect(key).toMatch(/^john_doe\/cv\/\d{4}-\d{2}-\d{2}\/john_doe\.pdf$/);
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -384,7 +384,7 @@ describe('/api/process-cv', () => {
       .map((c) => c[0]?.input?.Key)
       .filter((k) => k && k.endsWith('.pdf'));
     expect(pdfKeys).toHaveLength(5);
-    const cvPrefix = `${sanitized}/${date}/cv/`;
+    const cvPrefix = `${sanitized}/cv/${date}/`;
     const enhancedCvPrefix = `${sanitized}/enhanced/${date}/cv/`;
     const coverLetterPrefix = `${sanitized}/enhanced/${date}/cover_letter/`;
     const enhancedPrefix = `${sanitized}/enhanced/${date}/`;


### PR DESCRIPTION
## Summary
- Store evaluation uploads in `sanitized/cv/{date}` to match compile-time layout
- Adjust tests for new evaluation CV prefix

## Testing
- `npm test` *(fails: jest-environment-jsdom and @babel/preset-env missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd756df0e0832b9846097dcaa3872d