### PR TITLE
feat: add puppeteer fallback for job description fetch

### DIFF
--- a/tests/analyzeJobDescription.test.js
+++ b/tests/analyzeJobDescription.test.js
@@ -1,15 +1,15 @@
 import { analyzeJobDescription } from '../server.js';
 
 describe('analyzeJobDescription', () => {
-  test('includes skills that appear once', () => {
+  test('includes skills that appear once', async () => {
     const html = '<p>Proficiency in JavaScript is required.</p>';
-    const { skills } = analyzeJobDescription(html);
+    const { skills } = await analyzeJobDescription(html);
     expect(skills).toContain('javascript');
   });
 
-  test('pads skills list to five items', () => {
+  test('pads skills list to five items', async () => {
     const html = '<p>JavaScript and Python are needed.</p>';
-    const { skills } = analyzeJobDescription(html);
+    const { skills } = await analyzeJobDescription(html);
     expect(skills.slice(0, 2)).toEqual(['javascript', 'python']);
     expect(skills).toHaveLength(5);
   });

--- a/tests/fetchJobDescription.test.js
+++ b/tests/fetchJobDescription.test.js
@@ -55,6 +55,16 @@ describe('fetchJobDescription', () => {
     });
   });
 
+  test('falls back to puppeteer on blocked axios content', async () => {
+    mockAxiosGet.mockResolvedValueOnce({ data: 'Access Denied' });
+    const html = await fetchJobDescription('http://example.com', {
+      timeout: 1000,
+      userAgent: 'agent',
+    });
+    expect(mockLaunch).toHaveBeenCalled();
+    expect(html).toBe('<html>dynamic</html>');
+  });
+
   test('rejects invalid URL', async () => {
     await expect(fetchJobDescription('http:/bad')).rejects.toThrow('Invalid URL');
     expect(mockAxiosGet).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- detect blocked or empty job listing responses and fall back to headless Chromium
- analyze job descriptions after dynamic render
- test puppeteer fallback for blocked pages

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bd784487a0832b862668c67e483425