### PR TITLE
refactor: centralize puppeteer configuration

### DIFF
--- a/config/puppeteer.js
+++ b/config/puppeteer.js
@@ -1,0 +1,4 @@
+export const PUPPETEER_HEADLESS =
+  process.env.PUPPETEER_HEADLESS === 'false' ? false : 'new';
+
+export const PUPPETEER_ARGS = ['--no-sandbox', '--disable-setuid-sandbox'];

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -46,6 +46,7 @@ import {
   parseAiJson,
   generatePdf,
   PUPPETEER_HEADLESS,
+  PUPPETEER_ARGS,
   BLOCKED_PATTERNS
 } from '../server.js';
 
@@ -73,7 +74,7 @@ export async function fetchJobDescription(
   }
   const browser = await puppeteer.launch({
     headless: PUPPETEER_HEADLESS,
-    args: ['--no-sandbox', '--disable-setuid-sandbox']
+    args: PUPPETEER_ARGS
   });
   try {
     const page = await browser.newPage();

--- a/server.js
+++ b/server.js
@@ -29,6 +29,7 @@ import JSON5 from 'json5';
 import { generativeModel } from './geminiClient.js';
 import registerProcessCv from './routes/processCv.js';
 import { generatePdf as _generatePdf } from './services/generatePdf.js';
+import { PUPPETEER_HEADLESS, PUPPETEER_ARGS } from './config/puppeteer.js';
 import {
   parseContent,
   parseLine,
@@ -320,8 +321,6 @@ const REQUEST_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS, 10) || 5000;
 const JOB_FETCH_USER_AGENT =
   process.env.JOB_FETCH_USER_AGENT ||
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
-const PUPPETEER_HEADLESS =
-  process.env.PUPPETEER_HEADLESS === 'false' ? false : 'new';
 const BLOCKED_PATTERNS = [
   /captcha/i,
   /access denied/i,
@@ -487,7 +486,7 @@ async function fetchHtml(url, { timeout = REQUEST_TIMEOUT_MS, userAgent = JOB_FE
   }
   const browser = await puppeteer.launch({
     headless: PUPPETEER_HEADLESS,
-    args: ['--no-sandbox', '--disable-setuid-sandbox']
+    args: PUPPETEER_ARGS
   });
   try {
     const page = await browser.newPage();
@@ -1135,5 +1134,6 @@ export {
   REQUEST_TIMEOUT_MS,
   rateLimiter,
   PUPPETEER_HEADLESS,
+  PUPPETEER_ARGS,
   BLOCKED_PATTERNS
 };

--- a/services/generatePdf.js
+++ b/services/generatePdf.js
@@ -9,6 +9,7 @@ import {
   normalizeHeading
 } from './parseContent.js';
 import { getSkillIcon } from '../skillIcons.js';
+import { PUPPETEER_HEADLESS, PUPPETEER_ARGS } from '../config/puppeteer.js';
 
 const ALL_TEMPLATES = [
   'modern',
@@ -21,9 +22,6 @@ const ALL_TEMPLATES = [
   'cover_classic',
   'cover_2025'
 ];
-
-const PUPPETEER_HEADLESS =
-  process.env.PUPPETEER_HEADLESS === 'false' ? false : 'new';
 
 function proficiencyToLevel(str = '') {
   const s = String(str).toLowerCase();
@@ -267,7 +265,7 @@ export async function generatePdf(
     // Launch using Chromium's default sandboxing.
     browser = await puppeteer.launch({
       headless: PUPPETEER_HEADLESS,
-      args: ['--no-sandbox', '--disable-setuid-sandbox']
+      args: PUPPETEER_ARGS
     });
     const page = await browser.newPage();
     // Ensure consistent layout width for templates that use multiple columns

--- a/tests/configConsistency.test.js
+++ b/tests/configConsistency.test.js
@@ -9,8 +9,9 @@ const mockLaunch = jest.fn();
 jest.unstable_mockModule('axios', () => ({ default: { get: mockAxiosGet } }));
 jest.unstable_mockModule('puppeteer', () => ({ default: { launch: mockLaunch } }));
 
+const { PUPPETEER_HEADLESS } = await import('../config/puppeteer.js');
 const serverModule = await import('../server.js');
-const { PUPPETEER_HEADLESS, BLOCKED_PATTERNS } = serverModule;
+const { BLOCKED_PATTERNS } = serverModule;
 const { fetchJobDescription } = await import('../routes/processCv.js');
 
 describe('shared configuration values', () => {


### PR DESCRIPTION
## Summary
- add shared config for Puppeteer headless mode and launch args
- refactor server, PDF generator, and CV route to use centralized Puppeteer config
- adjust tests to import Puppeteer config from shared module

## Testing
- ⚠️ `npm test` (command not found: npm)
- ⚠️ `apt-get install -y nodejs npm` (Unable to locate package nodejs/npm)

------
https://chatgpt.com/codex/tasks/task_e_68bd83c0f7f8832b99065a04632803f3