### PR TITLE
Centralize job fetch user agent

### DIFF
--- a/config/http.js
+++ b/config/http.js
@@ -1,0 +1,3 @@
+export const JOB_FETCH_USER_AGENT =
+  process.env.JOB_FETCH_USER_AGENT ||
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -19,6 +19,8 @@ import { logEvaluation, logSession } from '../services/dynamo.js';
 
 import { uploadResume, parseUserAgent, validateUrl } from '../lib/serverUtils.js';
 
+import { JOB_FETCH_USER_AGENT } from '../config/http.js';
+
 import {
   extractText,
   classifyDocument,
@@ -49,15 +51,12 @@ import {
   BLOCKED_PATTERNS
 } from '../server.js';
 
-const DEFAULT_USER_AGENT =
-  process.env.JOB_FETCH_USER_AGENT ||
-  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 const DEFAULT_FETCH_TIMEOUT_MS =
   parseInt(process.env.JOB_FETCH_TIMEOUT_MS || REQUEST_TIMEOUT_MS, 10);
 
 export async function fetchJobDescription(
   url,
-  { timeout = DEFAULT_FETCH_TIMEOUT_MS, userAgent = DEFAULT_USER_AGENT } = {},
+  { timeout = DEFAULT_FETCH_TIMEOUT_MS, userAgent = JOB_FETCH_USER_AGENT } = {},
 ) {
   const valid = await validateUrl(url);
   if (!valid) throw new Error('Invalid URL');
@@ -1047,7 +1046,7 @@ export default function registerProcessCv(app, generativeModel) {
         jobDescriptionUrl = await validateUrl(jobDescriptionUrl);
         if (!jobDescriptionUrl)
           return next(createError(400, 'invalid jobDescriptionUrl'));
-        const userAgent = req.headers['user-agent'] || DEFAULT_USER_AGENT;
+        const userAgent = req.headers['user-agent'] || JOB_FETCH_USER_AGENT;
         let jobDescription = '';
         try {
           jobDescription = await fetchJobDescription(jobDescriptionUrl, {
@@ -1095,7 +1094,7 @@ export default function registerProcessCv(app, generativeModel) {
           jobDescriptionUrl = await validateUrl(jobDescriptionUrl);
           if (!jobDescriptionUrl)
             return next(createError(400, 'invalid jobDescriptionUrl'));
-          const userAgent = req.headers['user-agent'] || DEFAULT_USER_AGENT;
+          const userAgent = req.headers['user-agent'] || JOB_FETCH_USER_AGENT;
           let jobDescriptionHtml = '';
           try {
             jobDescriptionHtml = await fetchJobDescription(jobDescriptionUrl, {
@@ -1120,7 +1119,7 @@ export default function registerProcessCv(app, generativeModel) {
         jobDescriptionUrl = await validateUrl(jobDescriptionUrl);
         if (!jobDescriptionUrl)
           return next(createError(400, 'invalid jobDescriptionUrl'));
-        const userAgent = req.headers['user-agent'] || DEFAULT_USER_AGENT;
+        const userAgent = req.headers['user-agent'] || JOB_FETCH_USER_AGENT;
         let jobDescriptionHtml = '';
         try {
           jobDescriptionHtml = await fetchJobDescription(jobDescriptionUrl, {
@@ -1694,7 +1693,7 @@ export default function registerProcessCv(app, generativeModel) {
       try {
         jobDescriptionHtml = await fetchJobDescription(jobDescriptionUrl, {
           timeout: REQUEST_TIMEOUT_MS,
-          userAgent: req.headers['user-agent'] || DEFAULT_USER_AGENT,
+          userAgent: req.headers['user-agent'] || JOB_FETCH_USER_AGENT,
         });
         ({ skills: jobSkills, text: jobDescription } = await analyzeJobDescription(
           jobDescriptionHtml,

--- a/server.js
+++ b/server.js
@@ -29,6 +29,7 @@ import { generativeModel } from './geminiClient.js';
 import registerProcessCv from './routes/processCv.js';
 import { generatePdf as _generatePdf } from './services/generatePdf.js';
 import { PUPPETEER_HEADLESS, PUPPETEER_ARGS } from './config/puppeteer.js';
+import { JOB_FETCH_USER_AGENT } from './config/http.js';
 import { uploadResume, parseUserAgent, validateUrl } from './lib/serverUtils.js';
 import {
   parseContent,
@@ -210,9 +211,6 @@ function selectTemplates({
 
 const region = process.env.AWS_REGION || 'ap-south-1';
 const REQUEST_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS, 10) || 5000;
-const JOB_FETCH_USER_AGENT =
-  process.env.JOB_FETCH_USER_AGENT ||
-  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 const BLOCKED_PATTERNS = [
   /captcha/i,
   /access denied/i,
@@ -1027,5 +1025,6 @@ export {
   rateLimiter,
   PUPPETEER_HEADLESS,
   PUPPETEER_ARGS,
-  BLOCKED_PATTERNS
+  BLOCKED_PATTERNS,
+  JOB_FETCH_USER_AGENT
 };

--- a/tests/configConsistency.test.js
+++ b/tests/configConsistency.test.js
@@ -10,6 +10,7 @@ jest.unstable_mockModule('axios', () => ({ default: { get: mockAxiosGet } }));
 jest.unstable_mockModule('puppeteer', () => ({ default: { launch: mockLaunch } }));
 
 const { PUPPETEER_HEADLESS } = await import('../config/puppeteer.js');
+const { JOB_FETCH_USER_AGENT } = await import('../config/http.js');
 const serverModule = await import('../server.js');
 const { BLOCKED_PATTERNS } = serverModule;
 const { fetchJobDescription } = await import('../routes/processCv.js');
@@ -42,6 +43,12 @@ describe('shared configuration values', () => {
     expect(mockLaunch).toHaveBeenCalledWith(
       expect.objectContaining({ headless: PUPPETEER_HEADLESS })
     );
+  });
+
+  test('fetchJobDescription uses exported JOB_FETCH_USER_AGENT', async () => {
+    mockAxiosGet.mockResolvedValueOnce({ data: '' });
+    await fetchJobDescription('http://example.com');
+    expect(mockPage.setUserAgent).toHaveBeenCalledWith(JOB_FETCH_USER_AGENT);
   });
 
   test('fetchJobDescription honors shared BLOCKED_PATTERNS', async () => {


### PR DESCRIPTION
## Summary
- add shared JOB_FETCH_USER_AGENT constant
- use shared constant in server and processCv
- check fetchJobDescription sets JOB_FETCH_USER_AGENT

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68bd88cc632c832bb4b7f69ba9fa14cc