### PR TITLE
feat: block restricted job pages

### DIFF
--- a/tests/configConsistency.test.js
+++ b/tests/configConsistency.test.js
@@ -53,8 +53,10 @@ describe('shared configuration values', () => {
 
   test('fetchJobDescription honors shared BLOCKED_PATTERNS', async () => {
     mockAxiosGet.mockResolvedValueOnce({ data: 'Access Denied' });
-    await fetchJobDescription('http://example.com');
-    expect(mockLaunch).toHaveBeenCalled();
+    await expect(fetchJobDescription('http://example.com')).rejects.toThrow(
+      'Blocked content'
+    );
+    expect(mockLaunch).not.toHaveBeenCalled();
     expect(BLOCKED_PATTERNS.some((re) => re.test('Access Denied'))).toBe(true);
   });
 });

--- a/tests/fetchJobDescription.test.js
+++ b/tests/fetchJobDescription.test.js
@@ -55,14 +55,27 @@ describe('fetchJobDescription', () => {
     });
   });
 
-  test('falls back to puppeteer on blocked axios content', async () => {
+  test('throws on blocked axios content', async () => {
     mockAxiosGet.mockResolvedValueOnce({ data: 'Access Denied' });
-    const html = await fetchJobDescription('http://example.com', {
-      timeout: 1000,
-      userAgent: 'agent',
-    });
+    await expect(
+      fetchJobDescription('http://example.com', {
+        timeout: 1000,
+        userAgent: 'agent',
+      })
+    ).rejects.toThrow('Blocked content');
+    expect(mockLaunch).not.toHaveBeenCalled();
+  });
+
+  test('throws on blocked puppeteer content', async () => {
+    mockAxiosGet.mockResolvedValueOnce({ data: '' });
+    mockPage.content.mockResolvedValueOnce('Access Denied');
+    await expect(
+      fetchJobDescription('http://example.com', {
+        timeout: 1000,
+        userAgent: 'agent',
+      })
+    ).rejects.toThrow('Blocked content');
     expect(mockLaunch).toHaveBeenCalled();
-    expect(html).toBe('<html>dynamic</html>');
   });
 
   test('rejects invalid URL', async () => {


### PR DESCRIPTION
## Summary
- detect blocked job pages by matching fetched HTML against BLOCKED_PATTERNS
- add tests for blocked content in both axios and puppeteer branches
- ensure configuration tests verify BLOCKED_PATTERNS handling

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68bd8a629288832ba645c0383f747d3f