### PR TITLE
Handle blocked job pages from Puppeteer

### DIFF
--- a/tests/fetchHtml.test.js
+++ b/tests/fetchHtml.test.js
@@ -1,0 +1,47 @@
+import { jest } from '@jest/globals';
+
+process.env.PUPPETEER_HEADLESS = 'false';
+
+const mockAxiosGet = jest.fn();
+const mockLaunch = jest.fn();
+
+jest.unstable_mockModule('axios', () => ({ default: { get: mockAxiosGet } }));
+jest.unstable_mockModule('puppeteer', () => ({ default: { launch: mockLaunch } }));
+
+const { analyzeJobDescription } = await import('../server.js');
+
+describe('fetchHtml blocked content detection', () => {
+  const mockPage = {
+    setUserAgent: jest.fn(),
+    goto: jest.fn(),
+    content: jest.fn().mockResolvedValue('<html>dynamic</html>')
+  };
+  const mockBrowser = {
+    newPage: jest.fn().mockResolvedValue(mockPage),
+    close: jest.fn()
+  };
+
+  beforeEach(() => {
+    mockAxiosGet.mockReset();
+    mockLaunch.mockReset();
+    mockPage.setUserAgent.mockReset();
+    mockPage.goto.mockReset();
+    mockPage.content.mockReset().mockResolvedValue('<html>dynamic</html>');
+    mockBrowser.newPage.mockReset().mockResolvedValue(mockPage);
+    mockBrowser.close.mockReset();
+    mockLaunch.mockResolvedValue(mockBrowser);
+  });
+
+  test('throws on blocked axios content', async () => {
+    mockAxiosGet.mockResolvedValueOnce({ data: 'Access Denied' });
+    await expect(analyzeJobDescription('http://example.com')).rejects.toThrow('Blocked content');
+    expect(mockLaunch).not.toHaveBeenCalled();
+  });
+
+  test('throws on blocked puppeteer content', async () => {
+    mockAxiosGet.mockResolvedValueOnce({ data: '' });
+    mockPage.content.mockResolvedValueOnce('Access Denied');
+    await expect(analyzeJobDescription('http://example.com')).rejects.toThrow('Blocked content');
+    expect(mockLaunch).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- check Puppeteer-fetched HTML against `BLOCKED_PATTERNS` in `fetchHtml`
- surface blocked content errors for both Axios and Puppeteer branches
- cover blocked page handling with new tests

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68bd8e7e33d8832b8f0b8e3d1bf83be5