### PR TITLE
refactor: extract shared utilities to modules

### DIFF
--- a/lib/extractText.js
+++ b/lib/extractText.js
@@ -1,0 +1,20 @@
+import path from 'path';
+import pdfParse from 'pdf-parse/lib/pdf-parse.js';
+import mammoth from 'mammoth';
+
+export async function extractText(file) {
+  const ext = path.extname(file.originalname).toLowerCase();
+  if (ext === '.pdf') {
+    try {
+      const data = await pdfParse(file.buffer);
+      return data.text;
+    } catch (err) {
+      throw new Error('Failed to parse PDF');
+    }
+  }
+  if (ext === '.docx') {
+    const { value } = await mammoth.extractRawText({ buffer: file.buffer });
+    return value;
+  }
+  return file.buffer.toString();
+}

--- a/lib/sanitizeName.js
+++ b/lib/sanitizeName.js
@@ -1,0 +1,3 @@
+export function sanitizeName(name) {
+  return name.trim().split(/\s+/).slice(0, 2).join('_').toLowerCase();
+}

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -20,32 +20,16 @@ import { uploadResume, parseUserAgent, validateUrl } from '../lib/serverUtils.js
 import { JOB_FETCH_USER_AGENT } from '../config/http.js';
 import { fetchJobDescription } from '../services/jobFetch.js';
 
+import { extractText } from '../lib/extractText.js';
+import { sanitizeName } from '../lib/sanitizeName.js';
 import {
-  extractText,
-  classifyDocument,
-  extractName,
-  sanitizeName,
-  CV_TEMPLATES,
-  CL_TEMPLATES,
-  selectTemplates,
-  analyzeJobDescription,
-  fetchLinkedInProfile,
-  fetchCredlyProfile,
+  parseContent,
   extractExperience,
   extractEducation,
   extractCertifications,
   extractLanguages,
-  parseContent,
-  collectSectionText,
-  extractResumeSkills,
-  generateProjectSummary,
-  calculateMatchScore,
-  region,
-  REQUEST_TIMEOUT_MS,
-  sanitizeGeneratedText,
-  parseAiJson,
-  generatePdf
-} from '../server.js';
+} from '../services/parseContent.js';
+import { REQUEST_TIMEOUT_MS } from '../config/jobFetch.js';
 
 const createError = (status, message) => {
   const err = new Error(message);
@@ -164,7 +148,28 @@ function withTimeout(handler, timeoutMs = 10000) {
   };
 }
 
-export default function registerProcessCv(app, generativeModel) {
+export default function registerProcessCv(
+  app,
+  {
+    generativeModel,
+    classifyDocument,
+    extractName,
+    CV_TEMPLATES,
+    CL_TEMPLATES,
+    selectTemplates,
+    analyzeJobDescription,
+    fetchLinkedInProfile,
+    fetchCredlyProfile,
+    collectSectionText,
+    extractResumeSkills,
+    generateProjectSummary,
+    calculateMatchScore,
+    sanitizeGeneratedText,
+    parseAiJson,
+    generatePdf,
+  }
+) {
+  const region = process.env.AWS_REGION || 'ap-south-1';
   app.post(
     '/api/evaluate',
     (req, res, next) => {


### PR DESCRIPTION
## Summary
- move extractText and sanitizeName into lib modules
- update processCv route to import utilities directly and accept dependencies
- load processCv route in server with passed helpers to avoid circular imports

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env'; jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd95d0f4e4832ba0687f6551467749