### PR TITLE
Centralize AWS region configuration

### DIFF
--- a/config/aws.js
+++ b/config/aws.js
@@ -1,0 +1,2 @@
+export const REGION = process.env.AWS_REGION || 'ap-south-1';
+process.env.AWS_REGION = REGION;

--- a/config/secrets.js
+++ b/config/secrets.js
@@ -1,13 +1,9 @@
 import path from 'path';
 import fs from 'fs/promises';
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+import { REGION } from './aws.js';
 
-const DEFAULT_AWS_REGION = 'ap-south-1';
-
-process.env.AWS_REGION = process.env.AWS_REGION || DEFAULT_AWS_REGION;
-
-const region = process.env.AWS_REGION || DEFAULT_AWS_REGION;
-const secretsClient = new SecretsManagerClient({ region });
+const secretsClient = new SecretsManagerClient({ region: REGION });
 
 let secretCache;
 export async function getSecrets() {

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -19,6 +19,7 @@ import { uploadResume, parseUserAgent, validateUrl } from '../lib/serverUtils.js
 
 import { JOB_FETCH_USER_AGENT } from '../config/http.js';
 import { fetchJobDescription } from '../services/jobFetch.js';
+import { REGION } from '../config/aws.js';
 
 import { extractText } from '../lib/extractText.js';
 import { sanitizeName } from '../lib/sanitizeName.js';
@@ -169,7 +170,6 @@ export default function registerProcessCv(
     generatePdf,
   }
 ) {
-  const region = process.env.AWS_REGION || 'ap-south-1';
   app.post(
     '/api/evaluate',
     (req, res, next) => {
@@ -278,7 +278,7 @@ export default function registerProcessCv(
           console.error('failed to load configuration', err);
           return next(createError(500, 'failed to load configuration'));
         }
-        const s3 = new S3Client({ region });
+        const s3 = new S3Client({ region: REGION });
         const ext = path.extname(req.file.originalname).toLowerCase();
         const date = new Date().toISOString().split('T')[0];
         const prefix = `${sanitized}/cv/${date}/`;
@@ -438,7 +438,7 @@ export default function registerProcessCv(
     },
     withTimeout(async (req, res, next) => {
     const jobId = crypto.randomUUID();
-    const s3 = new S3Client({ region });
+    const s3 = new S3Client({ region: REGION });
     let bucket;
     let secrets;
     try {
@@ -630,7 +630,7 @@ export default function registerProcessCv(
     }
 
     // Store raw file to configured bucket
-    const initialS3 = new S3Client({ region });
+    const initialS3 = new S3Client({ region: REGION });
     try {
       await initialS3.send(
         new PutObjectCommand({
@@ -1128,7 +1128,7 @@ export default function registerProcessCv(
 
   app.post('/api/improve-metric', async (req, res, next) => {
     const jobId = crypto.randomUUID();
-    const s3 = new S3Client({ region });
+    const s3 = new S3Client({ region: REGION });
     let bucket;
     let secrets;
     try {
@@ -1342,7 +1342,7 @@ export default function registerProcessCv(
       });
     },
     async (req, res, next) => {
-      const s3 = new S3Client({ region });
+      const s3 = new S3Client({ region: REGION });
       let bucket;
       let secrets;
       try {
@@ -1521,7 +1521,7 @@ export default function registerProcessCv(
     },
     async (req, res, next) => {
       const jobId = crypto.randomUUID();
-      const s3 = new S3Client({ region });
+      const s3 = new S3Client({ region: REGION });
       let bucket;
       let secrets;
       try {

--- a/server.js
+++ b/server.js
@@ -33,6 +33,7 @@ import { JOB_FETCH_USER_AGENT } from './config/http.js';
 import { uploadResume, parseUserAgent, validateUrl } from './lib/serverUtils.js';
 import { fetchJobDescription } from './services/jobFetch.js';
 import { BLOCKED_PATTERNS, REQUEST_TIMEOUT_MS } from './config/jobFetch.js';
+import { REGION } from './config/aws.js';
 import {
   parseContent,
   parseLine,
@@ -211,7 +212,6 @@ function selectTemplates({
   return { template1, template2, coverTemplate1, coverTemplate2 };
 }
 
-const region = process.env.AWS_REGION || 'ap-south-1';
 
 async function fetchLinkedInProfile(url) {
   const valid = await validateUrl(url);
@@ -1026,7 +1026,7 @@ export {
   validateUrl,
   extractName,
   sanitizeName,
-  region,
+  REGION as region,
   REQUEST_TIMEOUT_MS,
   rateLimiter,
   PUPPETEER_HEADLESS,

--- a/services/dynamo.js
+++ b/services/dynamo.js
@@ -7,7 +7,7 @@ import {
   DeleteItemCommand
 } from '@aws-sdk/client-dynamodb';
 import { getSecrets } from '../config/secrets.js';
-const region = process.env.AWS_REGION || 'ap-south-1';
+import { REGION } from '../config/aws.js';
 
 async function resolveLocation(ipAddress) {
   if (!ipAddress) return 'unknown';
@@ -62,7 +62,7 @@ export async function logEvaluation({
   cvKey = '',
   docType = '',
 }) {
-  const client = new DynamoDBClient({ region });
+  const client = new DynamoDBClient({ region: REGION });
   let tableName = process.env.DYNAMO_TABLE;
   if (!tableName) {
     try {
@@ -116,7 +116,7 @@ export async function logSession({
   atsScore = 0,
   improvement = 0,
 }) {
-  const client = new DynamoDBClient({ region });
+  const client = new DynamoDBClient({ region: REGION });
   let tableName = process.env.DYNAMO_TABLE;
   if (!tableName) {
     try {
@@ -158,7 +158,7 @@ export async function logSession({
 }
 
 export async function cleanupOldRecords({ retentionDays = 30 } = {}) {
-  const client = new DynamoDBClient({ region });
+  const client = new DynamoDBClient({ region: REGION });
   let tableName = process.env.DYNAMO_TABLE;
   if (!tableName) {
     try {

--- a/tests/awsRegion.test.js
+++ b/tests/awsRegion.test.js
@@ -1,0 +1,64 @@
+import { jest } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+
+describe('shared AWS region configuration', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.AWS_REGION = 'us-test-1';
+  });
+
+  test('server exports shared region', async () => {
+    const mockAxiosGet = jest.fn();
+    const mockLaunch = jest.fn();
+    jest.unstable_mockModule('axios', () => ({ default: { get: mockAxiosGet } }));
+    jest.unstable_mockModule('puppeteer', () => ({ default: { launch: mockLaunch } }));
+    const { REGION } = await import('../config/aws.js');
+    const serverModule = await import('../server.js');
+    expect(serverModule.region).toBe(REGION);
+  });
+
+  test('dynamo client uses shared region', async () => {
+    const ctor = jest.fn(() => ({ send: jest.fn().mockResolvedValue({}) }));
+    jest.unstable_mockModule('@aws-sdk/client-dynamodb', () => ({
+      DynamoDBClient: function (config) {
+        ctor(config);
+        return { send: jest.fn().mockResolvedValue({}) };
+      },
+      CreateTableCommand: class {},
+      DescribeTableCommand: class {},
+      PutItemCommand: class {},
+      ScanCommand: class {},
+      DeleteItemCommand: class {},
+    }));
+    process.env.DYNAMO_TABLE = 'test';
+    const { REGION } = await import('../config/aws.js');
+    const { logEvaluation } = await import('../services/dynamo.js');
+    global.fetch = jest.fn().mockResolvedValue({ json: jest.fn().mockResolvedValue({}) });
+    await logEvaluation({ jobId: '1' });
+    expect(ctor).toHaveBeenCalledWith(expect.objectContaining({ region: REGION }));
+    delete process.env.DYNAMO_TABLE;
+    delete global.fetch;
+  });
+
+  test('secrets client uses shared region', async () => {
+    const ctor = jest.fn(() => ({ send: jest.fn().mockResolvedValue({}) }));
+    jest.unstable_mockModule('@aws-sdk/client-secrets-manager', () => ({
+      SecretsManagerClient: function (config) {
+        ctor(config);
+        return { send: jest.fn().mockResolvedValue({}) };
+      },
+      GetSecretValueCommand: class {},
+    }));
+    const { REGION } = await import('../config/aws.js');
+    await import('../config/secrets.js');
+    expect(ctor).toHaveBeenCalledWith(expect.objectContaining({ region: REGION }));
+  });
+
+  test('processCv imports region config', () => {
+    const content = fs.readFileSync(path.resolve('routes/processCv.js'), 'utf8');
+    expect(content).toMatch(/from '\.\.\/config\/aws\.js'/);
+    expect(content).not.toMatch(/AWS_REGION/);
+    expect(content).not.toMatch(/ap-south-1/);
+  });
+});


### PR DESCRIPTION
## Summary
- Centralize AWS region in `config/aws.js`
- Replace hardcoded region values across server and services
- Add tests to ensure modules use shared region constant

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env'; missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9a843cd8832bbacbc1abdcae804e