### PR TITLE
Flatten cover letter storage path

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -1487,7 +1487,6 @@ export default function registerProcessCv(
         sanitizedName,
         'enhanced',
         date,
-        'cover_letter',
         `${Date.now()}-cover_letter.pdf`
       );
       await s3.send(
@@ -1732,7 +1731,6 @@ export default function registerProcessCv(
         sanitizedName,
         'enhanced',
         coverDate,
-        'cover_letter',
       ];
       const coverKey = path.join(
         ...coverBasePath,

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -372,12 +372,12 @@ describe('/api/process-cv', () => {
     const date = new Date().toISOString().split('T')[0];
 
     res2.body.urls.forEach(({ type, url }) => {
+      expect(url).toContain(`/${sanitized}/enhanced/${date}/`);
+      expect(url).not.toContain('/cover_letter/');
       if (type.startsWith('cover_letter')) {
-        expect(url).toContain(`/${sanitized}/enhanced/${date}/cover_letter/`);
         expect(url).toContain('cover_letter');
       } else {
-        expect(url).toContain(`/${sanitized}/enhanced/${date}/`);
-        expect(url).not.toContain('/cover_letter/');
+        expect(url).not.toContain('cover_letter');
       }
     });
 
@@ -386,12 +386,10 @@ describe('/api/process-cv', () => {
       .filter((k) => k && k.endsWith('.pdf'));
     expect(pdfKeys).toHaveLength(5);
     const cvPrefix = `${sanitized}/cv/${date}/`;
-    const coverLetterPrefix = `${sanitized}/enhanced/${date}/cover_letter/`;
     const enhancedPrefix = `${sanitized}/enhanced/${date}/`;
     pdfKeys.forEach((k) => {
       expect(
         k.startsWith(cvPrefix) ||
-          k.startsWith(coverLetterPrefix) ||
           k.startsWith(enhancedPrefix)
       ).toBe(true);
     });


### PR DESCRIPTION
## Summary
- flatten cover letter storage paths under `<candidate>/enhanced/<date>/`
- adjust server tests for new cover letter locations

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env' and missing jest-environment-jsdom)*


------
https://chatgpt.com/codex/tasks/task_e_68bda68ec78c832bab66b9c811d76304