### PR TITLE
refactor: use shared region constant

### DIFF
--- a/config/aws.js
+++ b/config/aws.js
@@ -1,2 +1,1 @@
 export const REGION = process.env.AWS_REGION || 'ap-south-1';
-process.env.AWS_REGION = REGION;

--- a/tests/awsRegion.test.js
+++ b/tests/awsRegion.test.js
@@ -60,5 +60,8 @@ describe('shared AWS region configuration', () => {
     expect(content).toMatch(/from '\.\.\/config\/aws\.js'/);
     expect(content).not.toMatch(/AWS_REGION/);
     expect(content).not.toMatch(/ap-south-1/);
+    const s3Clients = content.match(/new S3Client\(/g) || [];
+    const withRegion = content.match(/new S3Client\(\{ region: REGION \}\)/g) || [];
+    expect(s3Clients.length).toBe(withRegion.length);
   });
 });


### PR DESCRIPTION
## Summary
- export REGION without mutating `process.env.AWS_REGION`
- verify S3 clients in `processCv` use the shared region constant

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68be33546e8c832ba94a0cd484edda6e