### PR TITLE
Use placeholder name when applicant name missing

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -261,13 +261,12 @@ export default function registerProcessCv(
                 "The document type couldn't be recognized; please upload a CV.",
             });
         }
-        const applicantName =
+        let applicantName =
           req.body.applicantName || (await extractName(resumeText));
-        const sanitized = sanitizeName(applicantName);
+        let sanitized = sanitizeName(applicantName);
         if (!sanitized) {
-          return res
-            .status(400)
-            .json({ error: 'name required', nameRequired: true });
+          sanitized = 'candidate';
+          applicantName = 'Candidate';
         }
         let bucket;
         try {
@@ -590,10 +589,10 @@ export default function registerProcessCv(
         req.body.applicantName || (await extractName(originalText));
       originalTitle = lines[1] || '';
       sanitizedName = sanitizeName(applicantName);
-      if (!sanitizedName)
-        return res
-          .status(400)
-          .json({ error: 'name required', nameRequired: true });
+      if (!sanitizedName) {
+        sanitizedName = 'candidate';
+        applicantName = 'Candidate';
+      }
       ext = path.extname(req.file.originalname).toLowerCase();
       const date = new Date().toISOString().split('T')[0];
       prefix = `${sanitizedName}/cv/${date}/`;
@@ -1198,13 +1197,13 @@ export default function registerProcessCv(
           buffer: existingCvBuffer,
         });
       }
-      const applicantName =
+      let applicantName =
         req.body.applicantName || (await extractName(originalText));
       let sanitizedName = sanitizeName(applicantName);
-      if (!sanitizedName)
-        return res
-          .status(400)
-          .json({ error: 'name required', nameRequired: true });
+      if (!sanitizedName) {
+        sanitizedName = 'candidate';
+        applicantName = 'Candidate';
+      }
 
       let jobDescription = '';
       let jobTitle = '';
@@ -1415,13 +1414,13 @@ export default function registerProcessCv(
         return next(createError(500, 'failed to process cv'));
       }
 
-      const applicantName =
+      let applicantName =
         req.body.applicantName || (await extractName(originalText));
       let sanitizedName = sanitizeName(applicantName);
-      if (!sanitizedName)
-        return res
-          .status(400)
-          .json({ error: 'name required', nameRequired: true });
+      if (!sanitizedName) {
+        sanitizedName = 'candidate';
+        applicantName = 'Candidate';
+      }
 
       let jobDescription = '';
       try {
@@ -1610,13 +1609,13 @@ export default function registerProcessCv(
         return next(createError(500, 'failed to load cv'));
       }
 
-      const applicantName =
+      let applicantName =
         req.body.applicantName || (await extractName(cvText));
       let sanitizedName = sanitizeName(applicantName);
-      if (!sanitizedName)
-        return res
-          .status(400)
-          .json({ error: 'name required', nameRequired: true });
+      if (!sanitizedName) {
+        sanitizedName = 'candidate';
+        applicantName = 'Candidate';
+      }
       const date = new Date().toISOString().split('T')[0];
 
       if (!existingCvKey) {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -258,7 +258,7 @@ describe('/api/process-cv', () => {
     expect(res.body.addedCertifications).toEqual(['AWS Cert - Amazon']);
   });
 
-  test('prompts for name when model uncertain', async () => {
+  test('uses placeholder name when model uncertain', async () => {
     generateContentMock.mockReset();
     generateContentMock.mockResolvedValue({
       response: { text: () => 'unknown' }
@@ -268,8 +268,9 @@ describe('/api/process-cv', () => {
       .field('jobDescriptionUrl', 'https://indeed.com/job')
       .field('linkedinProfileUrl', 'https://linkedin.com/in/example')
       .attach('resume', pdfBuffer, 'resume.pdf');
-    expect(res.status).toBe(400);
-    expect(res.body.nameRequired).toBe(true);
+    expect(res.status).toBe(200);
+    expect(res.body.applicantName).toBe('Candidate');
+    expect(res.body.bestCvKey.startsWith('candidate/')).toBe(true);
   });
   test('handles DynamoDB table lifecycle', async () => {
     mockDynamoSend


### PR DESCRIPTION
## Summary
- Default to a placeholder name when `sanitizeName` yields no result to keep processing going and ensure S3 keys/logs are valid
- Update server test to expect placeholder behavior instead of a 400

## Testing
- `npm test` *(fails: jest-environment-jsdom not found; missing @babel/preset-env)*

------
https://chatgpt.com/codex/tasks/task_e_68be3640c594832b81ebfba72b0a3642