### PR TITLE
Ensure cover letter S3 keys use forward slashes

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -120,6 +120,10 @@ export async function improveSections(sections, jobDescription) {
   return improvedSections;
 }
 
+export function buildS3Key(basePath, filename) {
+  return basePath.join('/') + '/' + filename;
+}
+
 function withTimeout(handler, timeoutMs = 10000) {
   return async (req, res, next) => {
     const start = Date.now();
@@ -1731,12 +1735,12 @@ export default function registerProcessCv(
         'enhanced',
         coverDate,
       ];
-      const coverKey = path.join(
-        ...coverBasePath,
+      const coverKey = buildS3Key(
+        coverBasePath,
         `${coverTimestamp}-cover_letter.pdf`,
       );
-      const coverTextKey = path.join(
-        ...coverBasePath,
+      const coverTextKey = buildS3Key(
+        coverBasePath,
         `${coverTimestamp}-cover_letter.txt`,
       );
       await s3.send(

--- a/tests/coverKeyPlatform.test.js
+++ b/tests/coverKeyPlatform.test.js
@@ -1,0 +1,17 @@
+import path from 'path';
+import { buildS3Key } from '../routes/processCv.js';
+
+describe('buildS3Key', () => {
+  test('produces forward-slash separated keys', () => {
+    const originalJoin = path.join;
+    path.join = path.win32.join;
+    const basePath = ['john_doe', 'enhanced', '2024-01-01'];
+    const pdfKey = buildS3Key(basePath, '123-cover_letter.pdf');
+    const textKey = buildS3Key(basePath, '123-cover_letter.txt');
+    expect(pdfKey).toBe('john_doe/enhanced/2024-01-01/123-cover_letter.pdf');
+    expect(textKey).toBe('john_doe/enhanced/2024-01-01/123-cover_letter.txt');
+    expect(pdfKey).not.toContain('\\');
+    expect(textKey).not.toContain('\\');
+    path.join = originalJoin;
+  });
+});


### PR DESCRIPTION
## Summary
- build S3 keys with forward slashes to avoid OS-specific separators
- verify cover letter keys remain platform-agnostic via unit test

## Testing
- `npm test tests/coverKeyPlatform.test.js` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68be385e5670832bb7b034abb7366f13