### PR TITLE
use buildS3Key for cover letter S3 key

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -1486,10 +1486,8 @@ export default function registerProcessCv(
         defaultHeading: '',
       }, generativeModel);
       const date = new Date().toISOString().split('T')[0];
-      const key = path.join(
-        sanitizedName,
-        'enhanced',
-        date,
+      const key = buildS3Key(
+        [sanitizedName, 'enhanced', date],
         `${Date.now()}-cover_letter.pdf`
       );
       await s3.send(


### PR DESCRIPTION
## Summary
- build cover letter PDF S3 key with `buildS3Key` to ensure forward slashes across OSes

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aws-sdk%2fs3-request-presigner)*

------
https://chatgpt.com/codex/tasks/task_e_68be467c65b0832b961495a04efdb804