### PR TITLE
Allow internal URLs

### DIFF
--- a/lib/serverUtils.js
+++ b/lib/serverUtils.js
@@ -76,36 +76,12 @@ async function validateUrl(input) {
     const url = new URL(String(input));
     if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
     const host = url.hostname.toLowerCase();
-    if (host === 'localhost') return null;
-    let ip = host;
-    let ipVersion = net.isIP(host);
-    if (!ipVersion) {
+    if (!net.isIP(host)) {
       try {
-        const { address, family } = await dns.promises.lookup(host);
-        ip = address;
-        ipVersion = family;
+        await dns.promises.lookup(host);
       } catch {
         return null;
       }
-    }
-    if (ipVersion === 4) {
-      if (
-        /^0\./.test(ip) ||
-        /^10\./.test(ip) ||
-        /^127\./.test(ip) ||
-        /^169\.254\./.test(ip) ||
-        /^192\.168\./.test(ip) ||
-        /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(ip)
-      )
-        return null;
-    } else if (ipVersion === 6) {
-      if (
-        /^fc00:/i.test(ip) ||
-        /^fd00:/i.test(ip) ||
-        /^fe80:/i.test(ip) ||
-        ip === '::1'
-      )
-        return null;
     }
     return url.toString();
   } catch {


### PR DESCRIPTION
## Summary
- relax `validateUrl` to accept localhost and private IP addresses
- test that internal network URLs pass validation

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config '{"testEnvironment":"node","transform":{}}' tests/validateUrl.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68be49e7d0d4832ba785f81faa708275