### PR TITLE
Add development logging for server startup and request handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ resource "aws_lambda_permission" "allow_events" {
 5. Visit `http://localhost:5173` in the browser. If the backend runs elsewhere (e.g., in
    production), set `VITE_API_BASE_URL` to the server's base URL before starting the client.
 
+### Viewing logs during development
+
+Run the backend with `npm run dev` and watch the terminal output:
+
+- If the server fails to bind to the port, an error like `Server failed to start: ...` is printed.
+- Successful startup logs `Server running on port <port>`.
+- Each request to `/api/evaluate` logs `Received /api/evaluate request`, confirming the backend saw the request.
+
+These messages appear in the same terminal where `npm run dev` was executed.
+
 ## Upload Restrictions
 - Maximum file size: 5&nbsp;MB
 - Allowed file types: `.pdf`, `.docx`

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -82,7 +82,7 @@ function extractResponsibilitiesFromJd(html = '', jobSkills = []) {
       if (!verbs.some((v) => lower.includes(v))) return false;
       const words = lower.split(/[^a-z0-9+]+/);
       return !words.some((w) => skillSet.has(w));
-    });
+      });
 }
 
 function computeJdMismatches(resumeText = '', jobHtml = '', jobSkills = []) {
@@ -115,7 +115,7 @@ export async function improveSections(sections, jobDescription) {
       sectionName: key,
       sectionText: text,
       jobDescription,
-    });
+      });
   }
   return improvedSections;
 }
@@ -183,6 +183,7 @@ export default function registerProcessCv(
       });
     },
     withTimeout(async (req, res, next) => {
+      console.log('Received /api/evaluate request');
       const jobId = crypto.randomUUID();
       const ipAddress =
         (req.headers['x-forwarded-for'] || '')
@@ -998,9 +999,9 @@ export default function registerProcessCv(
           createError(504, 'The AI service took too long to respond. Please try again later.')
         );
       }
-      return next(createError(500, 'processing failed'));
-    }
-  });
+        return next(createError(500, 'processing failed'));
+      }
+    }));
 
   app.post(
     '/api/fix-metric',
@@ -1833,7 +1834,6 @@ export default function registerProcessCv(
         addedLanguages: selectedLanguagesArr,
         designation: designation || '',
       });
-    })
-  );
-}
+    });
+  }
 

--- a/server.js
+++ b/server.js
@@ -982,9 +982,12 @@ app.use((err, req, res, next) => {
 
 const port = process.env.PORT || 3000;
 if (process.env.NODE_ENV !== 'test') {
-  app.listen(port, () => {
+  const server = app.listen(port, () => {
     console.log(`Server running on port ${port}`);
   });
+  server.on('error', (err) =>
+    console.error('Server failed to start:', err)
+  );
 }
 
 export default app;


### PR DESCRIPTION
## Summary
- capture server.listen errors and keep reference to listener
- log incoming `/api/evaluate` requests
- document how to view backend logs during development

## Testing
- `npm test` *(fails: Snapshot Summary; Test Suites: 16 failed, 39 passed, 55 total)*

------
https://chatgpt.com/codex/tasks/task_e_68be60cc0494832ba419f48cef7232f9