### PR TITLE
Log doc type for non-CV uploads

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -245,7 +245,7 @@ export default function registerProcessCv(
             error: `You have uploaded a ${docType}. Please upload a CV only.`,
           });
         }
-        if (docType === 'unknown') {
+        if (!docType || docType === 'unknown') {
           await logEvaluation({
             jobId,
             ipAddress,
@@ -577,7 +577,7 @@ export default function registerProcessCv(
           )
         );
       }
-      if (docType === 'unknown') {
+      if (!docType || docType === 'unknown') {
         return next(
           createError(
             400,


### PR DESCRIPTION
## Summary
- Interpolate the detected docType in non-CV upload errors
- Treat empty classifier results like unknown document types
- Update non-resume tests to cover empty and unknown doc types and mock new dependencies

## Testing
- `npm test tests/evaluateRejectNonResume.test.js` *(fails: Expected status 400 but received 500)*

------
https://chatgpt.com/codex/tasks/task_e_68be67d0b16c832b8e92df5b490d9693