### PR TITLE
feat: fallback to local secrets when AWS unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The server relies on the following environment variables:
 ```json
 {
   "AWS_REGION": "ap-south-1",
-  "SECRET_ID": "your-secret-id",
   "PORT": "3000",
   "GEMINI_API_KEY": "<api-key>",
   "OPENAI_API_KEY": "<api-key>",
@@ -25,7 +24,8 @@ The server relies on the following environment variables:
 
 `SECRET_ID` is required in production and must reference an AWS Secrets Manager secret containing the values shown below. During
 local development you may omit `SECRET_ID` and instead provide a `local-secrets.json` file at the project root with the same
-JSON structure. If neither `SECRET_ID` nor `local-secrets.json` is present, the server will fail to start.
+JSON structure. If both are absent, the server falls back to empty credentials so it can operate offline, though features
+requiring external services will be disabled.
 
 `S3_BUCKET` defines where uploads and logs are stored. If it is not set in the environment or secret, the server falls back to
 `resume-forge-data`, which is suitable for local development.


### PR DESCRIPTION
## Summary
- remove default `SECRET_ID` reference in docs
- load credentials from `local-secrets.json` when `SECRET_ID` missing or AWS lookup fails
- return empty secrets instead of throwing when no credentials available

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68be7997f1a4832b8b4eff898064e5ca