### PR TITLE
docs: document new S3 folder hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # ResumeForge
 
 ## Overview
-ResumeForge generates tailored cover letters and enhanced CV versions by combining a candidate's résumé with a scraped job description. The service uses Google's Gemini generative AI for text generation and stores files in Amazon S3 under a candidate-based hierarchy: the uploaded résumé lives at `<candidate>/cv/<date>/`, while generated cover letters and CVs are placed in `<candidate>/enhanced/<date>/`.
+ResumeForge generates tailored cover letters and enhanced CV versions by combining a candidate's résumé with a scraped job description. The service uses Google's Gemini generative AI for text generation. All files are now organized in Amazon S3 under a candidate-specific root with two clear subfolders:
+
+- `<candidate>/cv/<date>/` – the original résumé upload.
+- `<candidate>/enhanced/<date>/` – generated cover letters and improved CVs.
+
+This hierarchy replaces older examples that stored documents directly under the candidate's name, and it clarifies the separation between uploaded and generated files.
 
 Job descriptions are fetched with an initial Axios request and fall back to a Puppeteer-rendered page when direct access fails or requires client-side rendering. This approach cannot bypass authentication or strict anti-bot measures, so some postings may still be unreachable.
 


### PR DESCRIPTION
## Summary
- document candidate-based `cv` and `enhanced` directories in S3 storage
- note that the new layout replaces older examples

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68be805503e0832bbb7612a9ad0f2068