### PR TITLE
Log axios fallback errors in job fetch and test propagation

### DIFF
--- a/services/jobFetch.js
+++ b/services/jobFetch.js
@@ -19,13 +19,16 @@ export async function fetchJobDescription(
     !content || !content.trim() || BLOCKED_PATTERNS.some((re) => re.test(content));
 
   let html = '';
+  let axiosErrorMessage;
   try {
     const { data } = await axios.get(valid, {
       timeout,
       headers: { 'User-Agent': userAgent },
     });
     html = data;
-  } catch {
+  } catch (err) {
+    axiosErrorMessage = err.message;
+    console.error('Axios job fetch error:', axiosErrorMessage);
     // Ignore axios errors and fall back to puppeteer
     html = '';
   }
@@ -71,7 +74,10 @@ export async function fetchJobDescription(
   }
 
   if (isBlocked(html)) {
-    throw new Error('Blocked content');
+    const errorMessage = axiosErrorMessage
+      ? `Blocked content. Axios error: ${axiosErrorMessage}`
+      : 'Blocked content';
+    throw new Error(errorMessage);
   }
   return html;
 }

--- a/tests/fetchJobDescription.test.js
+++ b/tests/fetchJobDescription.test.js
@@ -77,6 +77,21 @@ describe('fetchJobDescription', () => {
     expect(mockLaunch).toHaveBeenCalled();
   });
 
+  test('includes axios error message when all retrieval methods fail', async () => {
+    const axiosError = new Error('network down');
+    mockAxiosGet.mockRejectedValueOnce(axiosError);
+    mockPage.content.mockResolvedValueOnce('Access Denied');
+    await expect(
+      fetchJobDescription('http://example.com', {
+        timeout: 1000,
+        userAgent: 'agent',
+      }),
+    ).rejects.toThrow(
+      `Blocked content. Axios error: ${axiosError.message}`,
+    );
+    expect(mockLaunch).toHaveBeenCalled();
+  });
+
   test('rejects invalid URL', async () => {
     await expect(fetchJobDescription('http://')).rejects.toThrow('Invalid URL');
     expect(mockAxiosGet).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Log axios request failures in jobFetch while allowing Puppeteer fallback
- Include original axios error message in final 'Blocked content' error when both retrieval methods fail
- Test that axios error is propagated when all retrieval methods fail

## Testing
- `npm test 2>&1 | tail -n 20` *(fails: Test Suites: 13 failed, 43 passed)*
- `npm test tests/fetchJobDescription.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68be8b5eb310832b8f45f3bb440df090