### PR TITLE
Install libatk-bridge for Puppeteer in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:18
+
+# Install libatk-bridge2.0-0 for Puppeteer
+RUN apt-get update && apt-get install -y libatk-bridge2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create app directory
+WORKDIR /app
+
+# Install app dependencies
+COPY package*.json ./
+RUN npm install --production
+
+# Bundle app source
+COPY . .
+
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add Dockerfile installing `libatk-bridge2.0-0` so Puppeteer has required shared library

## Testing
- `apt-get update && apt-get install -y libatk-bridge2.0-0`
- `npm test` *(fails: 13 failed, 44 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68beb1cfd58c832b95a0c328acecc93e