### PR TITLE
Add configurable process timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The server relies on the following environment variables:
   "S3_BUCKET": "resume-forge-data",
   "DYNAMO_TABLE": "ResumeForgeLogs",
   "REQUEST_TIMEOUT_MS": "5000",
+  "PROCESS_TIMEOUT_MS": "300000",
   "TRUST_PROXY": "1",
   "ENFORCE_HTTPS": "true"
 }
@@ -39,6 +40,8 @@ requiring external services will be disabled.
 `ResumeForgeLogs`.
 
 `REQUEST_TIMEOUT_MS` sets the timeout in milliseconds for outbound HTTP requests when fetching external profiles and job descriptions. It defaults to `5000`.
+
+`PROCESS_TIMEOUT_MS` defines the maximum time in milliseconds allowed for processing `/api/evaluate` and `/api/process-cv` requests. It defaults to `300000` (5 minutes).
 
 When deploying behind a reverse proxy or load balancer, set `TRUST_PROXY` to the number of trusted hops (typically `1`) so Express honors `X-Forwarded-*` headers. Combine this with `ENFORCE_HTTPS=true` to redirect all HTTP requests to `https://`.
 

--- a/config/process.js
+++ b/config/process.js
@@ -1,0 +1,1 @@
+export const PROCESS_TIMEOUT_MS = parseInt(process.env.PROCESS_TIMEOUT_MS, 10) || 300000;

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -30,6 +30,7 @@ import {
   extractLanguages,
 } from '../services/parseContent.js';
 import { REQUEST_TIMEOUT_MS } from '../config/jobFetch.js';
+import { PROCESS_TIMEOUT_MS } from '../config/process.js';
 
 const createError = (status, message) => {
   const err = new Error(message);
@@ -426,9 +427,9 @@ export default function registerProcessCv(
         console.error('evaluation failed', err);
         next(createError(500, 'evaluation failed'));
       }
-    })
-  );
-  app.post(
+      }, PROCESS_TIMEOUT_MS)
+    );
+    app.post(
     '/api/process-cv',
     (req, res, next) => {
       uploadResume(req, res, (err) => {
@@ -990,7 +991,7 @@ export default function registerProcessCv(
       }
         return next(createError(500, 'processing failed'));
       }
-    }));
+      }, PROCESS_TIMEOUT_MS));
 
   app.post(
     '/api/fix-metric',


### PR DESCRIPTION
## Summary
- add `PROCESS_TIMEOUT_MS` environment variable with 5-minute default
- apply timeout when processing `/api/evaluate` and `/api/process-cv` routes
- document new timeout variable in README

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68beb6ba40dc832ba29c39c2f5ac68b1