### PR TITLE
refactor: reuse logKey variable in processCv

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -648,7 +648,6 @@ export default function registerProcessCv(
       sanitizedName,
       ext,
       prefix,
-      logKey,
       existingCvBuffer,
       originalText,
       originalTitle;


### PR DESCRIPTION
## Summary
- reuse initial logKey variable instead of redeclaring

## Testing
- `npm test` *(fails: 13 failed, 45 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bec62fa3ac832b974e963b7a626f40