### PR TITLE
Add abort handling across CV processing pipeline

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -20,6 +20,10 @@ export async function logEvent({
   logger = console,
   signal
 }) {
+  if (signal?.aborted) {
+    logger.warn('logEvent aborted: signal already triggered');
+    return;
+  }
   const entry = {
     timestamp: new Date().toISOString(),
     jobId,

--- a/server.js
+++ b/server.js
@@ -219,6 +219,7 @@ const isBlocked = (content) =>
 async function fetchLinkedInProfile(url, signal) {
   const valid = await validateUrl(url);
   if (!valid) throw new Error('Invalid LinkedIn URL');
+  if (signal?.aborted) throw new Error('Aborted');
   let html = '';
   let status;
   try {
@@ -368,6 +369,7 @@ async function fetchLinkedInProfile(url, signal) {
 async function fetchCredlyProfile(url, signal) {
   const valid = await validateUrl(url);
   if (!valid) throw new Error('Invalid Credly URL');
+  if (signal?.aborted) throw new Error('Aborted');
   let html = '';
   try {
     const { data } = await axios.get(valid, {

--- a/services/jobFetch.js
+++ b/services/jobFetch.js
@@ -37,6 +37,11 @@ export async function fetchJobDescription(
     console.log(`[${ts}]${idPart} [jobFetch] ${msg}`);
   };
 
+  if (signal?.aborted) {
+    log('aborted_before_start');
+    throw new Error('Aborted');
+  }
+
   const isBlocked = (content) =>
     !content || !content.trim() || BLOCKED_PATTERNS.some((re) => re.test(content));
 


### PR DESCRIPTION
## Summary
- propagate AbortController through CV processing and log abort events
- halt S3 uploads and helper requests when aborted
- update utility functions to respect abort signals

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68bed45087c4832bb938ac46f62cc903