### PR TITLE
Add job-based download route and update enhance response

### DIFF
--- a/services/dynamo.js
+++ b/services/dynamo.js
@@ -128,6 +128,9 @@ export async function logSession(
     coverLetterKey = '',
     atsScore = 0,
     improvement = 0,
+    sanitizedName = '',
+    date = '',
+    sessionId = '',
   },
   { signal } = {}
 ) {
@@ -168,6 +171,9 @@ export async function logSession(
   addString('credlyProfileUrl', credlyProfileUrl);
   addString('cvKey', cvKey);
   addString('coverLetterKey', coverLetterKey);
+  addString('sanitizedName', sanitizedName);
+  addString('date', date);
+  addString('sessionId', sessionId);
 
   await client.send(
     new PutItemCommand({ TableName: tableName, Item: item }),


### PR DESCRIPTION
## Summary
- replace query parameter download endpoint with `/api/download/:jobId/:file`
- store job metadata in DynamoDB and use it to build S3 keys
- return `jobId`, `variantFiles`, and `coverFiles` from `/api/enhance`

## Testing
- `node --check routes/processCv.js`
- `node --check services/dynamo.js`
- `npm test` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bf228a9dac832b87ce5a00a5920ab4