### PR TITLE
Add keyword match metric to ATS evaluation and client UI

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -33,7 +33,8 @@ const atsMetricCategories = {
   Readability: ['atsReadability'],
   Impact: ['impact'],
   Crispness: ['crispness'],
-  Grammar: ['grammar']
+  Grammar: ['grammar'],
+  'Keyword Match %': ['keywordMatch']
 }
 
 const allAtsMetrics = Object.values(atsMetricCategories).flat()

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -636,10 +636,8 @@ export default function registerProcessCv(
           console.error(`initial upload to bucket ${bucket} failed`, err);
         }
         const resumeSkills = extractResumeSkills(resumeText);
-        const { newSkills: missingSkills } = calculateMatchScore(
-          jobSkills,
-          resumeSkills
-        );
+        const { score: keywordMatch, newSkills: missingSkills } =
+          calculateMatchScore(jobSkills, resumeSkills);
         const jdMismatches = computeJdMismatches(
           resumeText,
           jobHtml,
@@ -659,6 +657,7 @@ export default function registerProcessCv(
           Object.values(atsMetrics).reduce((a, b) => a + b, 0) /
             Math.max(Object.keys(atsMetrics).length, 1)
         );
+        atsMetrics.keywordMatch = keywordMatch;
         const resumeExperience = extractExperience(resumeText);
         const resumeEducation = extractEducation(resumeText);
         const resumeCertifications = extractCertifications(resumeText);
@@ -768,6 +767,7 @@ export default function registerProcessCv(
           jobId,
           sessionId,
           atsScore,
+          keywordMatch,
           atsMetrics,
           jobTitle,
           originalTitle,


### PR DESCRIPTION
## Summary
- compute keyword match percentage during resume evaluation and expose in API response
- surface keyword match within ATS metrics and display a "Keyword Match %" card in client

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68bf79a82238832bb74bda3f648a4c12