### PR TITLE
Handle unreadable job URLs

### DIFF
--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -18,7 +18,11 @@ import { logEvaluation, logSession } from '../services/dynamo.js';
 
 import { uploadResume, validateUrl } from '../lib/serverUtils.js';
 import userAgentMiddleware from '../middlewares/userAgent.js';
-import { fetchJobDescription, LINKEDIN_AUTH_REQUIRED } from '../services/jobFetch.js';
+import {
+  fetchJobDescription,
+  LINKEDIN_AUTH_REQUIRED,
+  JD_UNREADABLE,
+} from '../services/jobFetch.js';
 import { REGION } from '../config/aws.js';
 
 import { extractText } from '../lib/extractText.js';
@@ -554,6 +558,11 @@ export default function registerProcessCv(
                 error:
                   'LinkedIn job descriptions require authentication. Please paste the job description text directly.',
                 code: LINKEDIN_AUTH_REQUIRED,
+              });
+            } else if (err.code === JD_UNREADABLE) {
+              return res.status(400).json({
+                error:
+                  'Job URL not readable. Please paste the job description text directly.',
               });
             } else {
               throw err;
@@ -1132,6 +1141,11 @@ export default function registerProcessCv(
                 'LinkedIn job descriptions require authentication. Please paste the job description text directly.',
               code: LINKEDIN_AUTH_REQUIRED,
             });
+          } else if (err.code === JD_UNREADABLE) {
+            return res.status(400).json({
+              error:
+                'Job URL not readable. Please paste the job description text directly.',
+            });
           } else {
             console.error('Job description fetch failed', err);
             return next(createError(500, 'Job description fetch failed'));
@@ -1513,6 +1527,12 @@ export default function registerProcessCv(
               jobId: req.jobId,
             });
           } catch (err) {
+            if (err.code === JD_UNREADABLE) {
+              return res.status(400).json({
+                error:
+                  'Job URL not readable. Please paste the job description text directly.',
+              });
+            }
             if (!(err.code === LINKEDIN_AUTH_REQUIRED && jobDescriptionText)) {
               return next(createError(400, 'invalid jobDescriptionUrl'));
             }
@@ -1579,6 +1599,12 @@ export default function registerProcessCv(
                 jobId: req.jobId,
               });
             } catch (err) {
+              if (err.code === JD_UNREADABLE) {
+                return res.status(400).json({
+                  error:
+                    'Job URL not readable. Please paste the job description text directly.',
+                });
+              }
               if (!(err.code === LINKEDIN_AUTH_REQUIRED && jobDescriptionText)) {
                 return next(createError(400, 'invalid jobDescriptionUrl'));
               }
@@ -1619,6 +1645,12 @@ export default function registerProcessCv(
               jobId: req.jobId,
             });
           } catch (err) {
+            if (err.code === JD_UNREADABLE) {
+              return res.status(400).json({
+                error:
+                  'Job URL not readable. Please paste the job description text directly.',
+              });
+            }
             if (!(err.code === LINKEDIN_AUTH_REQUIRED && jobDescriptionText)) {
               return next(createError(400, 'invalid jobDescriptionUrl'));
             }
@@ -1758,6 +1790,11 @@ export default function registerProcessCv(
             ({ jobDescription, jobTitle } = await analyzeJobDescription(
               jobDescriptionText,
             ));
+          } else if (err.code === JD_UNREADABLE) {
+            return res.status(400).json({
+              error:
+                'Job URL not readable. Please paste the job description text directly.',
+            });
           } else {
             return next(createError(400, 'invalid jobDescriptionUrl'));
           }
@@ -2058,6 +2095,11 @@ export default function registerProcessCv(
           await endJd3(err.code || err.message);
           if (err.code === LINKEDIN_AUTH_REQUIRED && jobDescriptionText) {
             ({ jobDescription } = await analyzeJobDescription(jobDescriptionText));
+          } else if (err.code === JD_UNREADABLE) {
+            return res.status(400).json({
+              error:
+                'Job URL not readable. Please paste the job description text directly.',
+            });
           } else {
             return next(createError(400, 'invalid jobDescriptionUrl'));
           }
@@ -2360,6 +2402,11 @@ export default function registerProcessCv(
             ({ skills: jobSkills, text: jobDescription } = await analyzeJobDescription(
               jobDescriptionText,
             ));
+          } else if (err.code === JD_UNREADABLE) {
+            return res.status(400).json({
+              error:
+                'Job URL not readable. Please paste the job description text directly.',
+            });
           } else if (jobDescriptionText) {
             ({ skills: jobSkills, text: jobDescription } = await analyzeJobDescription(
               jobDescriptionText,

--- a/services/jobFetch.js
+++ b/services/jobFetch.js
@@ -6,6 +6,7 @@ import { PUPPETEER_HEADLESS, PUPPETEER_ARGS } from '../config/puppeteer.js';
 import { BLOCKED_PATTERNS, REQUEST_TIMEOUT_MS } from '../config/jobFetch.js';
 
 export const LINKEDIN_AUTH_REQUIRED = 'LINKEDIN_AUTH_REQUIRED';
+export const JD_UNREADABLE = 'JD_UNREADABLE';
 
 // Default timeout comes from config and can be overridden via environment
 // variables as defined in config/jobFetch.js
@@ -191,7 +192,9 @@ export async function fetchJobDescription(
       ? `Blocked content. Axios error: ${axiosErrorMessage}`
       : 'Blocked content';
     log(`job_fetch_blocked host=${host} error=${errorMessage}`);
-    throw new Error(errorMessage);
+    const err = new Error(errorMessage);
+    if (!isLinkedInHost) err.code = JD_UNREADABLE;
+    throw err;
   }
   log(`job_fetch_success host=${host}`);
   return html;


### PR DESCRIPTION
## Summary
- surface JD_UNREADABLE when job description HTML is blank or blocked
- return clear error when JD_UNREADABLE is raised

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env' imported from /workspace/ResumeForge/babel-virtual-resolve-base.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bf83d3ba08832b9df8e64903685f41