### PR TITLE
Refactor evaluation API and client

### DIFF
--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -4,21 +4,23 @@ import { render, screen, fireEvent, waitFor, within } from '@testing-library/rea
 import App from './App.jsx'
 
 const mockResponse = {
-  atsScore: 70,
-  jobTitle: 'Senior Developer',
-  originalTitle: 'Developer',
-  designationMatch: false,
-  missingSkills: ['aws'],
-  atsMetrics: {
-    layoutSearchability: 50,
-    atsReadability: 60,
-    impact: 80,
-    crispness: 90,
-    keywordDensity: 40,
-    sectionHeadingClarity: 100,
-    contactInfoCompleteness: 30,
-    grammar: 70
-  }
+  jobId: '1',
+  scores: {
+    ats: 70,
+    metrics: {
+      layoutSearchability: 50,
+      atsReadability: 60,
+      impact: 80,
+      crispness: 90,
+      keywordDensity: 40,
+      sectionHeadingClarity: 100,
+      contactInfoCompleteness: 30,
+      grammar: 70
+    }
+  },
+  keywords: ['aws'],
+  selectionProbability: 70,
+  issues: {}
 }
 
 global.fetch = jest.fn()
@@ -55,13 +57,6 @@ test('evaluates CV and displays results', async () => {
   ).toBeInTheDocument()
   expect(
     await screen.findByText('Include email, phone, and LinkedIn.')
-  ).toBeInTheDocument()
-  expect(
-    await screen.findByText(/Designation: Developer vs Senior Developer/)
-  ).toBeInTheDocument()
-  expect(await screen.findByText(/Designation mismatch/)).toBeInTheDocument()
-  expect(
-    await screen.findByPlaceholderText('Revised Designation')
   ).toBeInTheDocument()
   expect(await screen.findByDisplayValue('aws')).toBeInTheDocument()
   fireEvent.click(await screen.findByText('Add Skill'))

--- a/lib/serverUtils.js
+++ b/lib/serverUtils.js
@@ -23,7 +23,9 @@ const upload = multer({
   }
 });
 
-const uploadMiddleware = upload.single('resume');
+function createUploadMiddleware(field = 'resume') {
+  return upload.single(field);
+}
 
 function detectMime(buffer) {
   if (!buffer || buffer.length < 4) return null;
@@ -38,8 +40,9 @@ function detectMime(buffer) {
   return null;
 }
 
-function uploadResume(req, res, cb) {
-  uploadMiddleware(req, res, (err) => {
+function uploadResume(req, res, cb, field = 'resume') {
+  const middleware = createUploadMiddleware(field);
+  middleware(req, res, (err) => {
     if (err) return cb(err);
     if (!req.file) return cb(null);
     const detected = detectMime(req.file.buffer);

--- a/tests/evaluateMetrics.test.js
+++ b/tests/evaluateMetrics.test.js
@@ -49,12 +49,11 @@ const app = serverModule.default;
       const res = await request(app)
         .post('/api/evaluate')
         .unset('User-Agent')
-        .field('jobDescriptionUrl', 'https://indeed.com/job')
-        .field('linkedinProfileUrl', 'https://linkedin.com/in/example')
-        .attach('resume', pdfBuffer, 'resume.pdf');
+        .field('jobUrl', 'https://indeed.com/job')
+        .attach('file', pdfBuffer, 'resume.pdf');
       expect(res.status).toBe(200);
-      expect(res.body.atsMetrics).toBeDefined();
-      expect(res.body.atsMetrics).toEqual(
+      expect(res.body.scores.metrics).toBeDefined();
+      expect(res.body.scores.metrics).toEqual(
         expect.objectContaining({
           layoutSearchability: expect.any(Number),
           atsReadability: expect.any(Number),

--- a/tests/evaluateRejectNonResume.test.js
+++ b/tests/evaluateRejectNonResume.test.js
@@ -55,9 +55,8 @@ describe('/api/evaluate non-resume', () => {
     const res = await request(app)
       .post('/api/evaluate')
       .unset('User-Agent')
-      .field('jobDescriptionUrl', 'https://example.com/job')
-      .field('linkedinProfileUrl', 'https://linkedin.com/in/example')
-      .attach('resume', pdfBuffer, 'file.pdf');
+      .field('jobUrl', 'https://example.com/job')
+      .attach('file', pdfBuffer, 'file.pdf');
     expect(res.status).toBe(400);
     expect(res.text).toBe(
       `You have uploaded a ${docType}. Please upload a CV only.`
@@ -66,7 +65,6 @@ describe('/api/evaluate non-resume', () => {
     expect(logEvaluation).toHaveBeenCalledWith(
       expect.objectContaining({
         docType,
-        linkedinProfileUrl: 'https://linkedin.com/in/example',
         cvKey: expect.any(String),
       })
     );
@@ -78,9 +76,8 @@ describe('/api/evaluate non-resume', () => {
     const res = await request(app)
       .post('/api/evaluate')
       .unset('User-Agent')
-      .field('jobDescriptionUrl', 'https://example.com/job')
-      .field('linkedinProfileUrl', 'https://linkedin.com/in/example')
-      .attach('resume', pdfBuffer, 'file.pdf');
+      .field('jobUrl', 'https://example.com/job')
+      .attach('file', pdfBuffer, 'file.pdf');
     expect(res.status).toBe(400);
     expect(res.text).toBe(
       'This document looks like a essay. Please upload a CV.'
@@ -89,7 +86,6 @@ describe('/api/evaluate non-resume', () => {
     expect(logEvaluation).toHaveBeenCalledWith(
       expect.objectContaining({
         docType,
-        linkedinProfileUrl: 'https://linkedin.com/in/example',
         cvKey: expect.any(String),
       })
     );

--- a/tests/evaluateS3Upload.test.js
+++ b/tests/evaluateS3Upload.test.js
@@ -40,26 +40,18 @@ jest.unstable_mockModule('../openaiClient.js', () => ({
 
 const serverModule = await import('../server.js');
 const app = serverModule.default;
-jest.spyOn(serverModule, 'fetchLinkedInProfile').mockResolvedValue({
-  experience: [],
-  education: [],
-  certifications: [],
-  languages: [],
-});
-
 describe('/api/evaluate S3 upload', () => {
   test('uploads resume to S3 with expected key', async () => {
     PutObjectCommand.mockClear();
     const res = await request(app)
       .post('/api/evaluate')
       .unset('User-Agent')
-      .field('jobDescriptionUrl', 'https://example.com/job')
-      .field('linkedinProfileUrl', 'https://linkedin.com/in/example')
+      .field('jobUrl', 'https://example.com/job')
       .field('applicantName', 'John Doe')
-      .attach('resume', pdfBuffer, 'resume.pdf');
+      .attach('file', pdfBuffer, 'resume.pdf');
     expect(res.status).toBe(200);
     expect(PutObjectCommand).toHaveBeenCalled();
     const key = PutObjectCommand.mock.calls[0][0].Key;
-    expect(key).toMatch(/^john_doe\/cv\/\d{4}-\d{2}-\d{2}\/john_doe\.pdf$/);
+    expect(key).toMatch(/^john_doe\/\d{4}-\d{2}-\d{2}\/[^/]+\/original\/\d+-john_doe\.pdf$/);
   });
 });

--- a/tests/fixButton.test.jsx
+++ b/tests/fixButton.test.jsx
@@ -5,16 +5,11 @@ import App from '../client/src/App.jsx'
 
 test('Fix buttons work in each metric category', async () => {
   const evaluationResponse = {
-    atsScore: 50,
-    atsMetrics: { impact: 60, keywordDensity: 40 },
-    jobTitle: 'Dev',
-    originalTitle: 'Dev',
-    designationMatch: true,
-    missingSkills: [],
-    missingExperience: [],
-    missingEducation: [],
-    missingCertifications: [],
-    missingLanguages: []
+    jobId: '1',
+    scores: { ats: 50, metrics: { impact: 60, keywordDensity: 40 } },
+    keywords: [],
+    selectionProbability: 50,
+    issues: {}
   }
   global.fetch = jest
     .fn()


### PR DESCRIPTION
## Summary
- Accept `file`, `jobUrl`, optional `jdText` and `credlyUrl` for evaluation
- Return job scores, keywords, selection probability and issues
- Update client to send new fields and consume new response

## Testing
- `npm test` *(fails: 13 failed, 46 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb7e3b0f0832b8da1bdbd82c520b1