### PR TITLE
Stream job progress via SSE

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -303,17 +303,19 @@ function App() {
   }
 
   const pollProgress = (jobId) => {
-    const interval = setInterval(async () => {
+    const source = new EventSource(`${API_BASE_URL}/api/progress/${jobId}`)
+    const handleMessage = (event) => {
       try {
-        const resp = await fetch(`${API_BASE_URL}/api/progress/${jobId}`)
-        const data = await resp.json()
+        const data = JSON.parse(event.data)
         if (data && Object.values(data).every((v) => v === 'completed')) {
-          clearInterval(interval)
+          source.close()
         }
       } catch {
-        clearInterval(interval)
+        source.close()
       }
-    }, 1000)
+    }
+    source.addEventListener('step', handleMessage)
+    source.onerror = () => source.close()
   }
 
   const getDownloadUrl = async (jobId, file) => {


### PR DESCRIPTION
## Summary
- convert `/api/progress/:jobId` to a Server-Sent Events endpoint streaming step updates
- subscribe to job progress on the client using EventSource for real-time updates

## Testing
- `npm test` *(fails: Cannot find package '@babel/preset-env' imported from /workspace/ResumeForge/babel-virtual-resolve-base.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc1b1a6e8832b92523fd68c7e9335