### PR TITLE
Allow .doc uploads with macro warning

### DIFF
--- a/lib/serverUtils.js
+++ b/lib/serverUtils.js
@@ -3,21 +3,14 @@ import path from 'path';
 import net from 'net';
 import dns from 'dns';
 
-// Multer configuration for resume uploads. Accepts PDFs and DOCX.
+// Multer configuration for resume uploads. Accepts PDFs, DOC, and DOCX.
 const upload = multer({
   limits: { fileSize: 5 * 1024 * 1024 },
   fileFilter: (req, file, cb) => {
     const ext = path.extname(file.originalname).toLowerCase();
-    if (ext === '.doc') {
-      return cb(
-        new Error(
-          'Legacy .doc files are not supported. Please upload a .pdf or .docx file.'
-        )
-      );
-    }
-    const allowed = ['.pdf', '.docx'];
+    const allowed = ['.pdf', '.doc', '.docx'];
     if (!allowed.includes(ext)) {
-      return cb(new Error('Only .pdf and .docx files are allowed'));
+      return cb(new Error('Only .pdf, .doc, and .docx files are allowed'));
     }
     cb(null, true);
   }
@@ -28,16 +21,23 @@ function createUploadMiddleware(field = 'resume') {
 }
 
 function detectMime(buffer) {
-  if (!buffer || buffer.length < 4) return null;
-  const header = buffer.slice(0, 4).toString('binary');
-  if (header === '%PDF') return 'application/pdf';
-  if (header === 'PK\u0003\u0004') {
+  if (!buffer || buffer.length < 8) return null;
+  const header4 = buffer.slice(0, 4).toString('binary');
+  if (header4 === '%PDF') return 'application/pdf';
+  if (header4 === 'PK\u0003\u0004') {
     const ascii = buffer.toString('ascii');
     if (ascii.includes('[Content_Types].xml') && ascii.includes('word/')) {
       return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
     }
   }
+  const ole = Buffer.from([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+  if (buffer.slice(0, 8).equals(ole)) return 'application/msword';
   return null;
+}
+
+function detectMacros(buffer = Buffer.from([])) {
+  const ascii = buffer.toString('ascii').toLowerCase();
+  return ascii.includes('vbaproject') || ascii.includes('macros');
 }
 
 function uploadResume(req, res, cb, field = 'resume') {
@@ -48,12 +48,14 @@ function uploadResume(req, res, cb, field = 'resume') {
     const detected = detectMime(req.file.buffer);
     const allowed = [
       'application/pdf',
+      'application/msword',
       'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
     ];
     if (!detected || !allowed.includes(detected)) {
-      return cb(new Error('Invalid file type. Only .pdf and .docx files are allowed'));
+      return cb(new Error('Invalid file type. Only .pdf, .doc, and .docx files are allowed'));
     }
     req.file.mimetype = detected;
+    req.file.macroWarning = detectMacros(req.file.buffer);
     cb(null);
   });
 }
@@ -92,4 +94,4 @@ async function validateUrl(input) {
   }
 }
 
-export { uploadResume, parseUserAgent, validateUrl };
+export { uploadResume, parseUserAgent, validateUrl, detectMacros };

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -1889,7 +1889,7 @@ export default function registerProcessCv(
         console.error('failed to log session', err);
       }
 
-      res.json({ jobId, urls, insights });
+      res.json({ jobId, urls, insights, macroWarning: !!req.file?.macroWarning });
     } catch (err) {
       console.error('improve failed', err);
       try {

--- a/tests/detectMacros.test.js
+++ b/tests/detectMacros.test.js
@@ -1,0 +1,13 @@
+import { detectMacros } from '../lib/serverUtils.js';
+
+describe('detectMacros', () => {
+  test('flags buffers containing macro indicators', () => {
+    const buf = Buffer.from('hello vbaproject.bin world');
+    expect(detectMacros(buf)).toBe(true);
+  });
+
+  test('returns false for clean buffers', () => {
+    const buf = Buffer.from('plain text content');
+    expect(detectMacros(buf)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- permit `.doc` resumes in upload filter
- detect basic VBA/OLE macro markers and flag suspicious files
- expose macro warning flag from `/api/evaluate`
- add unit test for macro detection

## Testing
- `npm test` *(fails: Chromium dependencies missing, module import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bfde939368832b84e8a204ed508bcd