### PR TITLE
feat: support configurable OpenAI model

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The server relies on the following environment variables:
   "PORT": "3000",
   "GEMINI_API_KEY": "<api-key>",
   "OPENAI_API_KEY": "<api-key>",
+  "MODEL_NAME": "gpt-5",
   "S3_BUCKET": "resume-forge-data",
   "DYNAMO_TABLE": "ResumeForgeLogs",
   "REQUEST_TIMEOUT_MS": "5000",
@@ -72,6 +73,8 @@ When deploying behind a reverse proxy or load balancer, set `TRUST_PROXY` to the
 
 
 `GEMINI_API_KEY` and `OPENAI_API_KEY` supply the Google Gemini and OpenAI API keys. Set them directly in your environment for development or include them in the secret.
+
+`MODEL_NAME` selects the OpenAI model used for résumé processing. It defaults to `gpt-5` and falls back to `gpt-4.1` or `gpt-4o` if the preferred model is unavailable.
 
 The AWS Secrets Manager secret referenced by `SECRET_ID` must contain:
 

--- a/openaiClient.js
+++ b/openaiClient.js
@@ -4,10 +4,12 @@ import path from 'path';
 import { getSecrets } from './config/secrets.js';
 import { generativeModel } from './geminiClient.js';
 
+const MODEL_NAME = process.env.MODEL_NAME || 'gpt-5';
+
 // Ordered list of supported models. Unavailable or experimental models should
 // be placed at the end or removed to avoid unnecessary `model_not_found`
 // warnings during résumé generation.
-const preferredModels = ['gpt-4.1', 'gpt-4o-mini'];
+const preferredModels = [MODEL_NAME, 'gpt-4.1', 'gpt-4o'];
 
 const AI_TIMEOUT_MS = parseInt(process.env.AI_TIMEOUT_MS || '10000', 10);
 

--- a/tests/openaiClientModels.test.js
+++ b/tests/openaiClientModels.test.js
@@ -23,7 +23,7 @@ test('uses supported model without model_not_found warnings', async () => {
 
   expect(createResponse).toHaveBeenCalledTimes(1);
   const options = createResponse.mock.calls[0][0];
-  expect(options.model).toBe('gpt-4.1');
+  expect(options.model).toBe('gpt-5');
   expect(options.text.format).toMatchObject({
     type: 'json_schema',
     name: 'EnhancedCV',


### PR DESCRIPTION
## Summary
- read MODEL_NAME env var to choose OpenAI model with default gpt-5 and fallbacks to gpt-4.1 and gpt-4o
- update preferred model ordering and tests
- document MODEL_NAME in README

## Testing
- `npm test` *(fails: 13 failed, 47 passed, 60 total)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe0039c30832b80a4a13326d0350e