### PR TITLE
Integrate evaluation LLM and expose improvement tips

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -773,6 +773,32 @@ function App() {
               )}
             </div>
           )}
+          {result?.tips && Object.keys(result.tips).length > 0 && (
+            <div className="text-purple-800 mb-2">
+              <p className="mb-2">Tips:</p>
+              <ul>
+                {Object.entries(result.tips).map(([category, tip]) => (
+                  <li key={category} className="mb-1" id={category}>
+                    <span>
+                      {formatMetricName(category)}: {tip}
+                    </span>
+                    <a
+                      href="#"
+                      className="ml-2 text-blue-600 underline"
+                      onClick={() => handleFix(category)}
+                    >
+                      Click to FIX
+                    </a>
+                    {metricSuggestions[category] && (
+                      <div className="mt-1 text-sm text-purple-700">
+                        {metricSuggestions[category]}
+                      </div>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
           {result.issues?.jdMismatches?.length > 0 && (
             <div className="text-purple-800 mb-2">
               <p className="mb-2">JD responsibility gaps:</p>

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -19,7 +19,9 @@ const mockResponse = {
       grammar: 70
     }
   },
+  seniority: 'mid',
   keywords: { mustHave: ['aws'], niceToHave: [] },
+  tips: {},
   selectionProbability: 70,
   issues: {}
 }

--- a/services/dynamo.js
+++ b/services/dynamo.js
@@ -69,6 +69,7 @@ export async function logEvaluation(
     cvKey = '',
     s3Prefix = '',
     docType = '',
+    seniority = '',
     scores = null,
     selectionProbability = null,
     status = '',
@@ -128,6 +129,7 @@ export async function logEvaluation(
   addString('cvKey', cvKey);
   addString('s3Prefix', s3Prefix);
   addString('docType', docType);
+  addString('seniority', seniority);
   addObject('scores', scores);
   addNumber('selectionProbability', selectionProbability);
   addString('status', status);

--- a/tests/evaluateLinkedInDiff.test.js
+++ b/tests/evaluateLinkedInDiff.test.js
@@ -18,7 +18,8 @@ jest.unstable_mockModule('mammoth', () => ({
 }));
 
 jest.unstable_mockModule('../services/dynamo.js', () => ({
-  logEvaluation: jest.fn().mockResolvedValue()
+  logEvaluation: jest.fn().mockResolvedValue(),
+  logSession: jest.fn().mockResolvedValue(),
 }));
 
 const mockS3Send = jest.fn().mockResolvedValue({});
@@ -35,6 +36,9 @@ jest.unstable_mockModule('../config/secrets.js', () => ({
 jest.unstable_mockModule('../openaiClient.js', () => ({
   classifyDocument: jest.fn().mockResolvedValue('resume'),
   requestAtsAnalysis: jest.fn().mockRejectedValue(new Error('no ai')),
+  requestEvaluation: jest
+    .fn()
+    .mockResolvedValue({ seniority: 'mid', keywords: { must_have: [], nice_to_have: [] }, tips: {} }),
 }));
 
 const serverModule = await import('../server.js');

--- a/tests/evaluateMetrics.test.js
+++ b/tests/evaluateMetrics.test.js
@@ -6,6 +6,8 @@ const pdfBuffer = Buffer.from('%PDF-1.4');
 const mockFetchJobDescription = jest.fn().mockResolvedValue('<html></html>');
 jest.unstable_mockModule('../services/jobFetch.js', () => ({
   fetchJobDescription: mockFetchJobDescription,
+  JD_UNREADABLE: 'JD_UNREADABLE',
+  LINKEDIN_AUTH_REQUIRED: 'LINKEDIN_AUTH_REQUIRED',
 }));
 
 jest.unstable_mockModule('axios', () => ({
@@ -21,7 +23,8 @@ jest.unstable_mockModule('mammoth', () => ({
 }));
 
 jest.unstable_mockModule('../services/dynamo.js', () => ({
-  logEvaluation: jest.fn().mockResolvedValue()
+  logEvaluation: jest.fn().mockResolvedValue(),
+  logSession: jest.fn().mockResolvedValue(),
 }));
 
 const mockS3Send = jest.fn().mockResolvedValue({});
@@ -38,6 +41,9 @@ jest.unstable_mockModule('../config/secrets.js', () => ({
 jest.unstable_mockModule('../openaiClient.js', () => ({
   classifyDocument: jest.fn().mockResolvedValue('resume'),
   requestAtsAnalysis: jest.fn().mockRejectedValue(new Error('no ai')),
+  requestEvaluation: jest
+    .fn()
+    .mockResolvedValue({ seniority: 'mid', keywords: { must_have: [], nice_to_have: [] }, tips: {} }),
 }));
 
 const { JOB_FETCH_USER_AGENT } = await import('../config/http.js');

--- a/tests/evaluateRejectNonResume.test.js
+++ b/tests/evaluateRejectNonResume.test.js
@@ -37,6 +37,9 @@ jest.unstable_mockModule('../openaiClient.js', () => ({
   requestEnhancedCV: jest.fn(),
   requestCoverLetter: jest.fn(),
   requestAtsAnalysis: jest.fn(),
+  requestEvaluation: jest
+    .fn()
+    .mockResolvedValue({ seniority: 'mid', keywords: { must_have: [], nice_to_have: [] }, tips: {} }),
   extractName: jest.fn(),
   classifyDocument: jest.fn(),
 }));

--- a/tests/evaluateS3Upload.test.js
+++ b/tests/evaluateS3Upload.test.js
@@ -27,6 +27,7 @@ jest.unstable_mockModule('mammoth', () => ({
 
 jest.unstable_mockModule('../services/dynamo.js', () => ({
   logEvaluation: jest.fn().mockResolvedValue(),
+  logSession: jest.fn().mockResolvedValue(),
 }));
 
 jest.unstable_mockModule('../config/secrets.js', () => ({
@@ -36,6 +37,9 @@ jest.unstable_mockModule('../config/secrets.js', () => ({
 jest.unstable_mockModule('../openaiClient.js', () => ({
   classifyDocument: jest.fn().mockResolvedValue('resume'),
   requestAtsAnalysis: jest.fn().mockRejectedValue(new Error('no ai')),
+  requestEvaluation: jest
+    .fn()
+    .mockResolvedValue({ seniority: 'mid', keywords: { must_have: [], nice_to_have: [] }, tips: {} }),
 }));
 
 const serverModule = await import('../server.js');

--- a/tests/extractName.test.js
+++ b/tests/extractName.test.js
@@ -11,7 +11,10 @@ jest.unstable_mockModule('../openaiClient.js', () => ({
   uploadFile: jest.fn(),
   requestEnhancedCV: jest.fn(),
   classifyDocument: jest.fn(),
-  extractName: openaiExtractNameMock
+  extractName: openaiExtractNameMock,
+  requestEvaluation: jest
+    .fn()
+    .mockResolvedValue({ seniority: 'mid', keywords: { must_have: [], nice_to_have: [] }, tips: {} })
 }));
 
 const { extractName } = await import('../server.js');

--- a/tests/fixButton.test.jsx
+++ b/tests/fixButton.test.jsx
@@ -7,7 +7,9 @@ test('Fix buttons work in each metric category', async () => {
   const evaluationResponse = {
     jobId: '1',
     scores: { ats: 50, metrics: { impact: 60, keywordDensity: 40 } },
-    keywords: [],
+    seniority: 'mid',
+    keywords: { mustHave: [], niceToHave: [] },
+    tips: {},
     selectionProbability: 50,
     issues: {}
   }

--- a/tests/improveSections.test.js
+++ b/tests/improveSections.test.js
@@ -7,6 +7,9 @@ jest.unstable_mockModule('../openaiClient.js', () => ({
   requestSectionImprovement,
   uploadFile,
   requestEnhancedCV,
+  requestEvaluation: jest
+    .fn()
+    .mockResolvedValue({ seniority: 'mid', keywords: { must_have: [], nice_to_have: [] }, tips: {} }),
 }));
 
 const { improveSections } = await import('../routes/processCv.js');

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -59,6 +59,9 @@ jest.unstable_mockModule('../openaiClient.js', () => ({
   requestEnhancedCV,
   requestSectionImprovement: jest.fn(async ({ sectionText }) => sectionText),
   requestCoverLetter,
+  requestEvaluation: jest
+    .fn()
+    .mockResolvedValue({ seniority: 'mid', keywords: { must_have: [], nice_to_have: [] }, tips: {} }),
 }));
 
 generateContentMock


### PR DESCRIPTION
## Summary
- call new evaluation LLM to retrieve seniority, keyword groups, and improvement tips
- log candidate seniority and expose grouped keywords and tips in API response
- surface tips in client with "Click to FIX" links

## Testing
- `npm test` *(fails: missing exports & ESM issues)*

------
https://chatgpt.com/codex/tasks/task_e_68c001a597cc832bb8da8e6c692fa240