### PR TITLE
Allow DOC uploads and warn on macro detection

### DIFF
--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -104,6 +104,30 @@ test('allows file to be dropped in drop zone', async () => {
   await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
 })
 
+test('shows macro warning when macroWarning flag is true', async () => {
+  fetch.mockResolvedValueOnce({
+    ok: true,
+    headers: { get: () => 'application/json' },
+    json: () => Promise.resolve({ ...mockResponse, macroWarning: true })
+  })
+  render(<App />)
+  const file = new File(['dummy'], 'resume.pdf', { type: 'application/pdf' })
+  fireEvent.change(
+    screen.getByLabelText('Choose File', { selector: 'input', hidden: true }),
+    {
+      target: { files: [file] }
+    }
+  )
+  fireEvent.change(screen.getByPlaceholderText('Job Description URL'), {
+    target: { value: 'https://indeed.com/job' }
+  })
+  fireEvent.click(screen.getByText('Evaluate me against the JD'))
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1))
+  expect(
+    await screen.findByText('Warning: macros detected in your document.')
+  ).toBeInTheDocument()
+})
+
 test('shows category tip and fetches category fix suggestion', async () => {
   fetch
     .mockResolvedValueOnce({

--- a/routes/processCv.js
+++ b/routes/processCv.js
@@ -779,21 +779,22 @@ export default function registerProcessCv(
             status: 'success',
           }, { signal: req.signal });
 
-          res.json({
-            jobId,
-            scores: {
-              ats: atsScore,
-              keywordMatch,
-              metrics: atsMetrics,
-              cardScores,
-              overallScore,
-            },
-            seniority,
-            keywords: { mustHave, niceToHave },
-            tips,
-            selectionProbability,
-            issues: { jdMismatches, certifications: missingCertifications },
-          });
+        res.json({
+          jobId,
+          scores: {
+            ats: atsScore,
+            keywordMatch,
+            metrics: atsMetrics,
+            cardScores,
+            overallScore,
+          },
+          seniority,
+          keywords: { mustHave, niceToHave },
+          tips,
+          selectionProbability,
+          macroWarning: !!req.file?.macroWarning,
+          issues: { jdMismatches, certifications: missingCertifications },
+        });
       } catch (err) {
         console.error('evaluation failed', err);
         try {

--- a/tests/evaluateMacroWarning.test.js
+++ b/tests/evaluateMacroWarning.test.js
@@ -1,0 +1,67 @@
+import { jest } from '@jest/globals';
+import request from 'supertest';
+
+const pdfBuffer = Buffer.from('%PDF-1.4vbaproject');
+
+const mockFetchJobDescription = jest.fn().mockResolvedValue('<html></html>');
+jest.unstable_mockModule('../services/jobFetch.js', () => ({
+  fetchJobDescription: mockFetchJobDescription,
+  JD_UNREADABLE: 'JD_UNREADABLE',
+  LINKEDIN_AUTH_REQUIRED: 'LINKEDIN_AUTH_REQUIRED',
+}));
+
+jest.unstable_mockModule('axios', () => ({
+  default: { get: jest.fn().mockResolvedValue({ data: '' }) },
+}));
+
+jest.unstable_mockModule('pdf-parse/lib/pdf-parse.js', () => ({
+  default: jest.fn().mockResolvedValue({ text: 'Experience\n- Engineer\nEducation\n- Uni' }),
+}));
+
+jest.unstable_mockModule('mammoth', () => ({
+  default: { extractRawText: jest.fn().mockResolvedValue({ value: '' }) },
+}));
+
+jest.unstable_mockModule('../services/dynamo.js', () => ({
+  logEvaluation: jest.fn().mockResolvedValue(),
+  logSession: jest.fn().mockResolvedValue(),
+}));
+
+const mockS3Send = jest.fn().mockResolvedValue({});
+jest.unstable_mockModule('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(() => ({ send: mockS3Send })),
+  PutObjectCommand: jest.fn((input) => ({ input })),
+  GetObjectCommand: jest.fn((input) => ({ input })),
+}));
+
+jest.unstable_mockModule('../config/secrets.js', () => ({
+  getSecrets: jest.fn().mockResolvedValue({}),
+}));
+
+jest.unstable_mockModule('../openaiClient.js', () => ({
+  classifyDocument: jest.fn().mockResolvedValue('resume'),
+  requestAtsAnalysis: jest.fn().mockRejectedValue(new Error('no ai')),
+  requestEvaluation: jest
+    .fn()
+    .mockResolvedValue({ seniority: 'mid', keywords: { must_have: [], nice_to_have: [] }, tips: {} }),
+  uploadFile: jest.fn(),
+  requestSectionImprovement: jest.fn(),
+  requestEnhancedCV: jest.fn(),
+  requestCoverLetter: jest.fn(),
+  extractName: jest.fn(),
+}));
+
+const app = (await import('../server.js')).default;
+
+describe('/api/evaluate macro warning', () => {
+  test('includes macroWarning flag when macros detected', async () => {
+    const res = await request(app)
+      .post('/api/evaluate')
+      .unset('User-Agent')
+      .field('jobUrl', 'https://indeed.com/job')
+      .attach('file', pdfBuffer, 'resume.pdf');
+    expect(res.status).toBe(200);
+    expect(res.body.macroWarning).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Accept `.doc` resumes and validate selection on the client
- Warn users when uploaded files contain macros
- Expose macro detection flag from `/api/evaluate` and cover with tests

## Testing
- `npm test tests/evaluateMacroWarning.test.js`
- `npm test` *(fails: Must use import to load ES Module: client/src/skillResources.js, other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c01c68e610832bbb53085bba8e4349