### PR TITLE
Handle LinkedIn auth errors

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -197,6 +197,24 @@ function App() {
         }
         return
       }
+      if (response.status === 403) {
+        let data
+        let text
+        try {
+          data = await response.json()
+        } catch {
+          text = await response.text()
+        }
+        if (data?.code === 'LINKEDIN_AUTH_REQUIRED') {
+          setShowJdBanner(true)
+          setShowJobDescription(true)
+          setJobUrl('')
+          return
+        }
+        const errText = data?.error || text || 'Request failed'
+        setError(errText)
+        return
+      }
       if (!response.ok) {
         const text = await response.text()
         throw new Error(text || 'Request failed')


### PR DESCRIPTION
## Summary
- Detect LinkedIn auth requirement (403 with `LINKEDIN_AUTH_REQUIRED`) during evaluation
- Prompt user to manually enter job description and clear stored job URL

## Testing
- `npm test` *(fails: 11 failed, 41 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c056cf9f28832bb4ed712e6aaca98b