### PR TITLE
Hide job URL when using manual JD

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -120,6 +120,7 @@ function App() {
   }
 
   const handleJobUrlBlur = () => {
+    if (showJobDescription) return
     if (jobUrl && !isValidUrl(jobUrl)) {
       setJobUrlError('Please enter a valid URL.')
     } else {
@@ -191,6 +192,8 @@ function App() {
         if (errText.includes('Job URL not readable')) {
           setShowJdBanner(true)
           setShowJobDescription(true)
+          setJobUrl('')
+          setJobUrlError('')
           setError('')
         } else {
           setError(errText)
@@ -209,6 +212,7 @@ function App() {
           setShowJdBanner(true)
           setShowJobDescription(true)
           setJobUrl('')
+          setJobUrlError('')
           return
         }
         const errText = data?.error || text || 'Request failed'
@@ -505,18 +509,20 @@ function App() {
         <p className="text-red-600 text-sm mb-4">Resume file is required.</p>
       )}
 
-      <input
-        type="url"
-        placeholder="Job Description URL"
-        value={jobUrl}
-        onChange={(e) => setJobUrl(e.target.value)}
-        onBlur={handleJobUrlBlur}
-        className={`w-full max-w-md p-2 border rounded ${
-          (disabled && !jobUrl && !jobDescriptionText) || jobUrlError
-            ? 'border-red-500'
-            : 'border-purple-300'
-        } mb-1`}
-      />
+      {!showJobDescription && (
+        <input
+          type="url"
+          placeholder="Job Description URL"
+          value={jobUrl}
+          onChange={(e) => setJobUrl(e.target.value)}
+          onBlur={handleJobUrlBlur}
+          className={`w-full max-w-md p-2 border rounded ${
+            (disabled && !jobUrl && !jobDescriptionText) || jobUrlError
+              ? 'border-red-500'
+              : 'border-purple-300'
+          } mb-1`}
+        />
+      )}
       {showJdBanner && (
         <div className="text-red-600 text-sm mb-4">
           Job URL not readable. Please paste the job description text.


### PR DESCRIPTION
## Summary
- Skip Job URL validation when manual JD text input is active
- Clear Job URL on manual-mode switches and hide its input

## Testing
- `npm test` *(fails: client tests require ESM modules and several integration tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68c057aeced4832bb0c838e38cbfe1bd