### PR TITLE
Handle missing Gemini model in document classifier

### DIFF
--- a/services/documentClassifier.js
+++ b/services/documentClassifier.js
@@ -5,7 +5,8 @@ const prompt =
 
 export async function describeDocument(text) {
   if (!generativeModel?.generateContent) {
-    throw new Error('Gemini model not initialized');
+    console.warn('Gemini model not initialized');
+    return 'unknown';
   }
   try {
     const result = await generativeModel.generateContent(

--- a/tests/documentClassifier.test.js
+++ b/tests/documentClassifier.test.js
@@ -1,0 +1,14 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../geminiClient.js', () => ({
+  generativeModel: {}
+}));
+
+const { describeDocument } = await import('../services/documentClassifier.js');
+
+describe('documentClassifier', () => {
+  test('returns unknown when generative model is unavailable', async () => {
+    const result = await describeDocument('sample text');
+    expect(result).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Summary
- Safely handle absent Gemini generative model in `describeDocument`, logging a warning and returning `unknown`
- Add unit test ensuring the classifier returns `unknown` when the model is unavailable

## Testing
- `npm test` *(fails: npm command not found)*
- `apt-get install -y nodejs npm` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c060e2b970832bb941747ec3eeca12