### PR TITLE
feat: add document classifier fallbacks

### DIFF
--- a/services/documentClassifier.js
+++ b/services/documentClassifier.js
@@ -3,10 +3,36 @@ import { generativeModel } from '../geminiClient.js';
 const prompt =
   'Classify the following document. Respond with a short phrase such as "resume", "cover letter", "essay", etc.';
 
+function keywordHeuristic(text = '') {
+  const lower = text.toLowerCase();
+  if (
+    lower.includes('resume') ||
+    lower.includes('curriculum vitae') ||
+    lower.includes('cv')
+  )
+    return 'resume';
+  if (lower.includes('cover letter')) return 'cover letter';
+  if (lower.includes('essay')) return 'essay';
+  return null;
+}
+
 export async function describeDocument(text) {
   if (!generativeModel?.generateContent) {
-    console.warn('Gemini model not initialized');
-    return 'unknown';
+    console.warn('Gemini model not initialized; using OpenAI fallback');
+    try {
+      const { classifyDocument } = await import('../openaiClient.js');
+      const classification = await classifyDocument(text);
+      console.info('Document classification used OpenAI fallback');
+      return classification || 'unknown';
+    } catch (err) {
+      console.warn('OpenAI fallback failed, using keyword heuristic', err);
+      const heuristic = keywordHeuristic(text);
+      if (heuristic) {
+        console.info('Document classification used keyword heuristic');
+        return heuristic;
+      }
+      return 'unknown';
+    }
   }
   try {
     const result = await generativeModel.generateContent(


### PR DESCRIPTION
## Summary
- add OpenAI and heuristic fallbacks when Gemini classifier unavailable
- log which fallback was used for better debugging
- cover fallback scenarios in new tests

## Testing
- `npm test` *(fails: tests/templates/compileTemplates.test.js, client/src/App.test.jsx, selectTemplatesGroup.test.js, openaiClientGeminiFallback.test.js, improveSections.test.js, fixButton.test.jsx, geminiSections.test.js, extractName.test.js, evaluateS3Upload.test.js, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f5af38b4832bb01f1de34313d2bb