### PR TITLE
Improve resume detection via section heading heuristic

### DIFF
--- a/services/documentClassifier.js
+++ b/services/documentClassifier.js
@@ -13,6 +13,11 @@ function keywordHeuristic(text = '') {
     return 'resume';
   if (lower.includes('cover letter')) return 'cover letter';
   if (lower.includes('essay')) return 'essay';
+
+  const sections = ['experience', 'education', 'skills', 'work history'];
+  const matches = sections.filter((section) => lower.includes(section));
+  if (matches.length >= 2) return 'resume';
+
   return null;
 }
 

--- a/tests/documentClassifier.test.js
+++ b/tests/documentClassifier.test.js
@@ -25,6 +25,17 @@ describe('documentClassifier', () => {
     expect(result).toBe('resume');
   });
 
+  test('classifies resumes by common section headings', async () => {
+    jest.unstable_mockModule('../geminiClient.js', () => ({ generativeModel: null }));
+    jest.unstable_mockModule('../openaiClient.js', () => ({
+      classifyDocument: jest.fn().mockRejectedValue(new Error('openai down'))
+    }));
+    const { describeDocument } = await import('../services/documentClassifier.js');
+    const sample = `Experience:\nWorked as engineer.\nEducation:\nUniversity.\nSkills:\nJavaScript and Python.`;
+    const result = await describeDocument(sample);
+    expect(result).toBe('resume');
+  });
+
   test('returns unknown when no fallback succeeds', async () => {
     jest.unstable_mockModule('../geminiClient.js', () => ({ generativeModel: null }));
     jest.unstable_mockModule('../openaiClient.js', () => ({


### PR DESCRIPTION
## Summary
- broaden keyword heuristic to detect resumes using common section headings
- add tests for documents without "resume" or "cv" but with typical résumé sections

## Testing
- `npm test tests/documentClassifier.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0ffc986e8832b99328c356773b57f