### PR TITLE
feat: improve document classification heuristics

### DIFF
--- a/services/documentClassifier.js
+++ b/services/documentClassifier.js
@@ -3,22 +3,78 @@ import { generativeModel } from '../geminiClient.js';
 const prompt =
   'Classify the following document. Respond with a short phrase such as "resume", "cover letter", "essay", etc.';
 
+function normalizeText(text = '') {
+  return text.toLowerCase().replace(/[^\w\s]/g, ' ');
+}
+
 function keywordHeuristic(text = '') {
-  const lower = text.toLowerCase();
+  const lower = normalizeText(text);
   if (
     lower.includes('resume') ||
     lower.includes('curriculum vitae') ||
+    lower.includes('curriculumvitae') ||
     lower.includes('cv')
   )
     return 'resume';
   if (lower.includes('cover letter')) return 'cover letter';
   if (lower.includes('essay')) return 'essay';
 
-  const sections = ['experience', 'education', 'skills', 'work history'];
+  const sections = [
+    'experience',
+    'work experience',
+    'professional experience',
+    'employment history',
+    'work history',
+    'education',
+    'skills',
+    'professional summary',
+    'summary',
+  ];
   const matches = sections.filter((section) => lower.includes(section));
   if (matches.length >= 2) return 'resume';
 
   return null;
+}
+
+function localClassifier(text = '') {
+  const lower = normalizeText(text);
+  const categories = {
+    resume: [
+      'work experience',
+      'experience',
+      'education',
+      'skills',
+      'professional summary',
+      'objective',
+    ],
+    'cover letter': [
+      'dear',
+      'hiring manager',
+      'sincerely',
+      'application',
+      'position',
+    ],
+    essay: ['introduction', 'conclusion', 'thesis'],
+  };
+  let bestScore = 0;
+  let bestLabel = null;
+  for (const [label, keywords] of Object.entries(categories)) {
+    let score = 0;
+    keywords.forEach((k) => {
+      if (lower.includes(k)) score++;
+    });
+    if (score > bestScore) {
+      bestScore = score;
+      bestLabel = label;
+    }
+  }
+  return bestScore > 0 ? bestLabel : null;
+}
+
+function classifyLocally(text = '') {
+  const heuristic = keywordHeuristic(text);
+  if (heuristic) return heuristic;
+  return localClassifier(text);
 }
 
 export async function describeDocument(text) {
@@ -28,15 +84,10 @@ export async function describeDocument(text) {
       const { classifyDocument } = await import('../openaiClient.js');
       const classification = await classifyDocument(text);
       console.info('Document classification used OpenAI fallback');
-      return classification || 'unknown';
+      return classification || classifyLocally(text) || 'unknown';
     } catch (err) {
-      console.warn('OpenAI fallback failed, using keyword heuristic', err);
-      const heuristic = keywordHeuristic(text);
-      if (heuristic) {
-        console.info('Document classification used keyword heuristic');
-        return heuristic;
-      }
-      return 'unknown';
+      console.warn('OpenAI fallback failed, using local classifiers', err);
+      return classifyLocally(text) || 'unknown';
     }
   }
   try {
@@ -44,10 +95,10 @@ export async function describeDocument(text) {
       `${prompt}\n\n${text.slice(0, 4000)}`
     );
     const classification = result?.response?.text?.().trim().toLowerCase();
-    return classification || 'unknown';
+    return classification || classifyLocally(text) || 'unknown';
   } catch (err) {
     console.error('describeDocument error', err);
-    return 'unknown';
+    return classifyLocally(text) || 'unknown';
   }
 }
 


### PR DESCRIPTION
## Summary
- expand keyword heuristics for resumes and normalize punctuation
- add local rule-based classifier fallback when external APIs fail
- cover PDF/DOCX resume detection and local classifier in unit tests

## Testing
- `npm test` *(fails: handlebars template compilation, evaluateRejectNonResume, evaluateMetrics, others)*
- `npm test tests/documentClassifier.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c107199358832b9b22d9510b25dbf3