### PR TITLE
Show job description input by default

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,8 +1,8 @@
 import { useState, useRef, useEffect } from 'react'
-import skillResources from './skillResources'
-import certResources from './certResources'
-import languageResources from './languageResources'
-import { getScoreStatus } from './scoreStatus'
+import skillResources from './skillResources.js'
+import certResources from './certResources.js'
+import languageResources from './languageResources.js'
+import { getScoreStatus } from './scoreStatus.js'
 import { getSkillIcon } from '../../skillIcons.js'
 
 const metricTips = {
@@ -48,7 +48,6 @@ const otherQualityMetricCategories = {
 function App() {
   const [jobUrl, setJobUrl] = useState('')
   const [jobDescriptionText, setJobDescriptionText] = useState('')
-  const [showJobDescription, setShowJobDescription] = useState(false)
   const [showJdBanner, setShowJdBanner] = useState(false)
   const [cvFile, setCvFile] = useState(null)
   const [result, setResult] = useState(null)
@@ -120,7 +119,6 @@ function App() {
   }
 
   const handleJobUrlBlur = () => {
-    if (showJobDescription) return
     if (jobUrl && !isValidUrl(jobUrl)) {
       setJobUrlError('Please enter a valid URL.')
     } else {
@@ -138,9 +136,7 @@ function App() {
 
   useEffect(() => {
     if (jobUrl && isValidUrl(jobUrl)) {
-      setShowJobDescription(false)
       setShowJdBanner(false)
-      setJobDescriptionText('')
     }
   }, [jobUrl])
 
@@ -191,7 +187,6 @@ function App() {
         const errText = data?.error || text || 'Request failed'
         if (errText.includes('Job URL not readable')) {
           setShowJdBanner(true)
-          setShowJobDescription(true)
           setJobUrl('')
           setJobUrlError('')
         }
@@ -208,7 +203,6 @@ function App() {
         }
         if (data?.code === 'LINKEDIN_AUTH_REQUIRED') {
           setShowJdBanner(true)
-          setShowJobDescription(true)
           setJobUrl('')
           setJobUrlError('')
           return
@@ -507,33 +501,29 @@ function App() {
         <p className="text-red-600 text-sm mb-4">Resume file is required.</p>
       )}
 
-      {!showJobDescription && (
-        <input
-          type="url"
-          placeholder="Job Description URL"
-          value={jobUrl}
-          onChange={(e) => setJobUrl(e.target.value)}
-          onBlur={handleJobUrlBlur}
-          className={`w-full max-w-md p-2 border rounded ${
-            (disabled && !jobUrl && !jobDescriptionText) || jobUrlError
-              ? 'border-red-500'
-              : 'border-purple-300'
-          } mb-1`}
-        />
-      )}
+      <input
+        type="url"
+        placeholder="Job Description URL"
+        value={jobUrl}
+        onChange={(e) => setJobUrl(e.target.value)}
+        onBlur={handleJobUrlBlur}
+        className={`w-full max-w-md p-2 border rounded ${
+          (disabled && !jobUrl && !jobDescriptionText) || jobUrlError
+            ? 'border-red-500'
+            : 'border-purple-300'
+        } mb-1`}
+      />
       {showJdBanner && (
         <div className="text-red-600 text-sm mb-4">
           Job URL not readable. Please paste the job description text.
         </div>
       )}
-      {showJobDescription && (
-        <textarea
-          placeholder="Job Description Text"
-          value={jobDescriptionText}
-          onChange={(e) => setJobDescriptionText(e.target.value)}
-          className="w-full max-w-md p-2 border rounded border-purple-300 mb-1"
-        />
-      )}
+      <textarea
+        placeholder="Job Description Text"
+        value={jobDescriptionText}
+        onChange={(e) => setJobDescriptionText(e.target.value)}
+        className="w-full max-w-md p-2 border rounded border-purple-300 mb-1"
+      />
 
       {disabled && !jobUrl && !jobDescriptionText && (
         <p className="text-red-600 text-sm mb-4">

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -32,6 +32,40 @@ beforeEach(() => {
   fetch.mockReset()
 })
 
+test('renders job URL and description inputs; one is required', () => {
+  render(<App />)
+  // both inputs present
+  expect(screen.getByPlaceholderText('Job Description URL')).toBeInTheDocument()
+  expect(screen.getByPlaceholderText('Job Description Text')).toBeInTheDocument()
+
+  const submit = screen.getByText('Evaluate me against the JD')
+  // add CV file to enable validation on job fields
+  const file = new File(['dummy'], 'resume.pdf', { type: 'application/pdf' })
+  fireEvent.change(
+    screen.getByLabelText('Choose File', { selector: 'input', hidden: true }),
+    { target: { files: [file] } }
+  )
+
+  // Initially disabled since no JD fields filled
+  expect(submit).toBeDisabled()
+
+  // Filling job description text enables submission
+  fireEvent.change(screen.getByPlaceholderText('Job Description Text'), {
+    target: { value: 'Some description' },
+  })
+  expect(submit).not.toBeDisabled()
+
+  // Clearing text and entering URL also enables submission
+  fireEvent.change(screen.getByPlaceholderText('Job Description Text'), {
+    target: { value: '' },
+  })
+  expect(submit).toBeDisabled()
+  fireEvent.change(screen.getByPlaceholderText('Job Description URL'), {
+    target: { value: 'https://example.com/job' },
+  })
+  expect(submit).not.toBeDisabled()
+})
+
 test('evaluates CV and displays results', async () => {
   fetch.mockResolvedValueOnce({
     ok: true,


### PR DESCRIPTION
## Summary
- Always display both job URL and job description fields
- Keep validation requiring at least one of the fields to submit
- Add tests ensuring both inputs exist and only one is required

## Testing
- `npm test` *(fails: Must use import to load ES Module: client/src/skillResources.js)*
- `npm test client/src/App.test.jsx` *(fails: Must use import to load ES Module: client/src/skillResources.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c12c549340832b9b44a319e04edbfd