### PR TITLE
Document serverless deployment secrets and guard Lambda bootstrap

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import multer from 'multer';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import axios from 'axios';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
@@ -2648,7 +2649,14 @@ app.post('/api/process-cv', (req, res, next) => {
 });
 
 const port = process.env.PORT || 3000;
-if (process.env.NODE_ENV !== 'test') {
+const isLambda = Boolean(process.env.AWS_LAMBDA_FUNCTION_NAME);
+const isTestEnv = process.env.NODE_ENV === 'test';
+const currentFilePath = fileURLToPath(import.meta.url);
+const isDirectRun =
+  typeof process.argv[1] === 'string' &&
+  path.resolve(process.argv[1]) === currentFilePath;
+
+if (!isLambda && !isTestEnv && isDirectRun) {
   app.listen(port, () => {
     console.log(`Server running on port ${port}`);
   });


### PR DESCRIPTION
## Summary
- avoid starting the Express listener when the app is executed inside AWS Lambda and only listen when run directly for local development
- expand the README to highlight the serverless Lambda/API Gateway deployment model, detail the required AWS Secrets Manager payload, and document post-deployment verification steps

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc20b369cc832b93917671a234c349