### PR TITLE
Fix secret validation messaging in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,13 +79,12 @@ jobs:
 
           if [ "${#missing[@]}" -ne 0 ]; then
             printf '::error::Missing required secrets: %s\n' "${missing[*]}"
-            cat <<'EOM'
-            To resolve this failure, open your repository in GitHub and navigate to:
-              Settings → Secrets and variables → Actions → New repository secret
-            Add each missing secret listed above with the correct value. The AWS access key ID and
-            secret access key can be copied from the AWS IAM console under the associated user or
-            deployment role. After saving the secrets, re-run this workflow.
-            EOM
+            printf '%s\n' \
+              "To resolve this failure, open your repository in GitHub and navigate to:" \
+              "  Settings → Secrets and variables → Actions → New repository secret" \
+              "Add each missing secret listed above with the correct value. The AWS access key ID and" \
+              "secret access key can be copied from the AWS IAM console under the associated user or" \
+              "deployment role. After saving the secrets, re-run this workflow."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- replace the heredoc in the secret validation step with printf commands
- ensure the workflow clearly reports missing secrets and remediation steps without syntax errors

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d79bd780bc832b8d36258ad58c9c32