### PR TITLE
Add helper to print CloudFront URL from CloudFormation outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,13 @@ The deployment creates:
 - Regional REST API Gateway with binary support for `multipart/form-data`
 - S3 bucket for uploads/logs and DynamoDB table with on-demand billing
 
-After `sam deploy` completes it prints the `AppBaseUrl`, `ApiBaseUrl`, and `CloudFrontUrl` outputs. `AppBaseUrl` is the primary CloudFront front page and the canonical entry point for the hosted application. The production endpoint for the application is:
+After `sam deploy` completes it prints the `AppBaseUrl`, `ApiBaseUrl`, and `CloudFrontUrl` outputs. `AppBaseUrl` is the primary CloudFront front page and the canonical entry point for the hosted application. If you ever need to retrieve the CloudFront URL again, run:
+
+```bash
+npm run print:cloudfront-url -- <stack-name>
+```
+
+The script uses your configured AWS credentials/region to read the `CloudFrontUrl` output from the specified stack and prints the full distribution URL (for example, `https://d123456abcdef8.cloudfront.net`). The production endpoint for the application is:
 
 ```
 https://<api-id>.execute-api.<region>.amazonaws.com/<stage>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "resumeforge",
       "version": "1.0.0",
       "dependencies": {
+        "@aws-sdk/client-cloudformation": "^3.432.0",
         "@aws-sdk/client-dynamodb": "^3.432.0",
         "@aws-sdk/client-s3": "^3.432.0",
         "@aws-sdk/client-secrets-manager": "^3.432.0",
@@ -231,6 +232,495 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.896.0.tgz",
+      "integrity": "sha512-jNt7SabJK94Y2HmUNrEK38OV67DGcU1Yx8suz5W/qmzU4760fPGlsizmZ9dWa3JDa3FpJS5fl6uo4sm1QUYlNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.896.0",
+        "@aws-sdk/credential-provider-node": "3.896.0",
+        "@aws-sdk/middleware-host-header": "3.893.0",
+        "@aws-sdk/middleware-logger": "3.893.0",
+        "@aws-sdk/middleware-recursion-detection": "3.893.0",
+        "@aws-sdk/middleware-user-agent": "3.896.0",
+        "@aws-sdk/region-config-resolver": "3.893.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@aws-sdk/util-user-agent-browser": "3.893.0",
+        "@aws-sdk/util-user-agent-node": "3.896.0",
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/core": "^3.12.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.4",
+        "@smithy/middleware-retry": "^4.3.0",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.4",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.4",
+        "@smithy/util-defaults-mode-node": "^4.1.4",
+        "@smithy/util-endpoints": "^3.1.2",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "@smithy/util-waiter": "^4.1.1",
+        "@smithy/uuid": "^1.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/client-sso": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.896.0.tgz",
+      "integrity": "sha512-mpE3mrNili1dcvEvxaYjyoib8HlRXkb2bY5a3WeK++KObFY+HUujKtgQmiNSRX5YwQszm//fTrmGMmv9zpMcKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.896.0",
+        "@aws-sdk/middleware-host-header": "3.893.0",
+        "@aws-sdk/middleware-logger": "3.893.0",
+        "@aws-sdk/middleware-recursion-detection": "3.893.0",
+        "@aws-sdk/middleware-user-agent": "3.896.0",
+        "@aws-sdk/region-config-resolver": "3.893.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@aws-sdk/util-user-agent-browser": "3.893.0",
+        "@aws-sdk/util-user-agent-node": "3.896.0",
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/core": "^3.12.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.4",
+        "@smithy/middleware-retry": "^4.3.0",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.4",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.4",
+        "@smithy/util-defaults-mode-node": "^4.1.4",
+        "@smithy/util-endpoints": "^3.1.2",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/core": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.896.0.tgz",
+      "integrity": "sha512-uJaoyWKeGNyCyeI+cIJrD7LEB4iF/W8/x2ij7zg32OFpAAJx96N34/e+XSKp/xkJpO5FKiBOskKLnHeUsJsAPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/xml-builder": "3.894.0",
+        "@smithy/core": "^3.12.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/signature-v4": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.4",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.896.0.tgz",
+      "integrity": "sha512-Cnqhupdkp825ICySrz4QTI64Nq3AmUAscPW8dueanni0avYBDp7RBppX4H0+6icqN569B983XNfQ0YSImQhfhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.896.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.896.0.tgz",
+      "integrity": "sha512-CN0fTCKCUA1OTSx1c76o8XyJCy2WoI/av3J8r8mL6GmxTerhLRyzDy/MwxzPjTYPoL+GLEg6V4a9fRkWj1hBUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.896.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.4",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-stream": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.896.0.tgz",
+      "integrity": "sha512-+rbYG98czzwZLTYHJasK+VBjnIeXk73mRpZXHvaa4kDNxBezdN2YsoGNpLlPSxPdbpq18LY3LRtkdFTaT6DIQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.896.0",
+        "@aws-sdk/credential-provider-env": "3.896.0",
+        "@aws-sdk/credential-provider-http": "3.896.0",
+        "@aws-sdk/credential-provider-process": "3.896.0",
+        "@aws-sdk/credential-provider-sso": "3.896.0",
+        "@aws-sdk/credential-provider-web-identity": "3.896.0",
+        "@aws-sdk/nested-clients": "3.896.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/credential-provider-imds": "^4.1.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.896.0.tgz",
+      "integrity": "sha512-J0Jm+56MNngk1PIyqoJFf5FC2fjA4CYXlqODqNRDtid7yk7HB9W3UTtvxofmii5KJOLcHGNPdGnHWKkUc+xYgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.896.0",
+        "@aws-sdk/credential-provider-http": "3.896.0",
+        "@aws-sdk/credential-provider-ini": "3.896.0",
+        "@aws-sdk/credential-provider-process": "3.896.0",
+        "@aws-sdk/credential-provider-sso": "3.896.0",
+        "@aws-sdk/credential-provider-web-identity": "3.896.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/credential-provider-imds": "^4.1.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.896.0.tgz",
+      "integrity": "sha512-UfWVMQPZy7dus40c4LWxh5vQ+I51z0q4vf09Eqas5848e9DrGRG46GYIuc/gy+4CqEypjbg/XNMjnZfGLHxVnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.896.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.896.0.tgz",
+      "integrity": "sha512-77Te8WrVdLABKlv7QyetXP6aYEX1UORiahLA1PXQb/p66aFBw18Xc6JiN/6zJ4RqdyV1Xr9rwYBwGYua93ANIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.896.0",
+        "@aws-sdk/core": "3.896.0",
+        "@aws-sdk/token-providers": "3.896.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.896.0.tgz",
+      "integrity": "sha512-gwMwZWumo+V0xJplO8j2HIb1TfPsF9fbcRGXS0CanEvjg4fF2Xs1pOQl2oCw3biPZpxHB0plNZjqSF2eneGg9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.896.0",
+        "@aws-sdk/nested-clients": "3.896.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.893.0.tgz",
+      "integrity": "sha512-qL5xYRt80ahDfj9nDYLhpCNkDinEXvjLe/Qen/Y/u12+djrR2MB4DRa6mzBCkLkdXDtf0WAoW2EZsNCfGrmOEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.893.0.tgz",
+      "integrity": "sha512-ZqzMecjju5zkBquSIfVfCORI/3Mge21nUY4nWaGQy+NUXehqCGG4W7AiVpiHGOcY2cGJa7xeEkYcr2E2U9U0AA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.893.0.tgz",
+      "integrity": "sha512-H7Zotd9zUHQAr/wr3bcWHULYhEeoQrF54artgsoUGIf/9emv6LzY89QUccKIxYd6oHKNTrTyXm9F0ZZrzXNxlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@aws/lambda-invoke-store": "^0.0.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.896.0.tgz",
+      "integrity": "sha512-so/3tZH34YIeqG/QJgn5ZinnmHRdXV1ehsj4wVUrezL/dVW86jfwIkQIwpw8roOC657UoUf91c9FDhCxs3J5aQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.896.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@smithy/core": "^3.12.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.896.0.tgz",
+      "integrity": "sha512-KaHALB6DIXScJL/ExmonADr3jtTV6dpOHoEeTRSskJ/aW+rhZo7kH8SLmrwOT/qX8d5tza17YyR/oRkIKY6Eaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.896.0",
+        "@aws-sdk/middleware-host-header": "3.893.0",
+        "@aws-sdk/middleware-logger": "3.893.0",
+        "@aws-sdk/middleware-recursion-detection": "3.893.0",
+        "@aws-sdk/middleware-user-agent": "3.896.0",
+        "@aws-sdk/region-config-resolver": "3.893.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-endpoints": "3.895.0",
+        "@aws-sdk/util-user-agent-browser": "3.893.0",
+        "@aws-sdk/util-user-agent-node": "3.896.0",
+        "@smithy/config-resolver": "^4.2.2",
+        "@smithy/core": "^3.12.0",
+        "@smithy/fetch-http-handler": "^5.2.1",
+        "@smithy/hash-node": "^4.1.1",
+        "@smithy/invalid-dependency": "^4.1.1",
+        "@smithy/middleware-content-length": "^4.1.1",
+        "@smithy/middleware-endpoint": "^4.2.4",
+        "@smithy/middleware-retry": "^4.3.0",
+        "@smithy/middleware-serde": "^4.1.1",
+        "@smithy/middleware-stack": "^4.1.1",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/node-http-handler": "^4.2.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.4",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-body-length-browser": "^4.1.0",
+        "@smithy/util-body-length-node": "^4.1.0",
+        "@smithy/util-defaults-mode-browser": "^4.1.4",
+        "@smithy/util-defaults-mode-node": "^4.1.4",
+        "@smithy/util-endpoints": "^3.1.2",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-retry": "^4.1.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.893.0.tgz",
+      "integrity": "sha512-/cJvh3Zsa+Of0Zbg7vl9wp/kZtdb40yk/2+XcroAMVPO9hPvmS9r/UOm6tO7FeX4TtkRFwWaQJiTZTgSdsPY+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/token-providers": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.896.0.tgz",
+      "integrity": "sha512-WBoD+RY7tUfW9M+wGrZ2vdveR+ziZOjGHWFY3lcGnDvI8KE+fcSccEOTxgJBNBS5Z8B+WHKU2sZjb+Z7QqGwjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.896.0",
+        "@aws-sdk/nested-clients": "3.896.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/shared-ini-file-loader": "^4.2.0",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/types": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.893.0.tgz",
+      "integrity": "sha512-Aht1nn5SnA0N+Tjv0dzhAY7CQbxVtmq1bBR6xI0MhG7p2XYVh1wXuKTzrldEvQWwA3odOYunAfT9aBiKZx9qIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.895.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.895.0.tgz",
+      "integrity": "sha512-MhxBvWbwxmKknuggO2NeMwOVkHOYL98pZ+1ZRI5YwckoCL3AvISMnPJgfN60ww6AIXHGpkp+HhpFdKOe8RHSEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "@smithy/url-parser": "^4.1.1",
+        "@smithy/util-endpoints": "^3.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.893.0.tgz",
+      "integrity": "sha512-PE9NtbDBW6Kgl1bG6A5fF3EPo168tnkj8TgMcT0sg4xYBWsBpq0bpJZRh+Jm5Bkwiw9IgTCLjEU7mR6xWaMB9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/types": "^4.5.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.896.0.tgz",
+      "integrity": "sha512-jegizucAwoxyBddKl0kRGNEgRHcfGuMeyhP1Nf+wIUmHz/9CxobIajqcVk/KRNLdZY5mSn7YG2VtP3z0BcBb0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.896.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.894.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.894.0.tgz",
+      "integrity": "sha512-E6EAMc9dT1a2DOdo4zyOf3fp5+NJ2wI+mcm7RaW1baFIWDwcb99PpvWoV7YEiK7oaBDshuOEGWKUSYXdW+JYgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
@@ -2131,9 +2621,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.11.1.tgz",
-      "integrity": "sha512-REH7crwORgdjSpYs15JBiIWOYjj0hJNC3aCecpJvAlMMaaqL5i2CLb1i6Hc4yevToTKSqslLMI9FKjhugEwALA==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.13.0.tgz",
+      "integrity": "sha512-BI6ALLPOKnPOU1Cjkc+1TPhOlP3JXSR/UH14JmnaLq41t3ma+IjuXrKfhycVjr5IQ0XxRh2NnQo3olp+eCVrGg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.1.1",
@@ -2144,9 +2634,8 @@
         "@smithy/util-middleware": "^4.1.1",
         "@smithy/util-stream": "^4.3.2",
         "@smithy/util-utf8": "^4.1.0",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@smithy/uuid": "^1.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -2352,12 +2841,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.2.3.tgz",
-      "integrity": "sha512-+1H5A28DeffRVrqmVmtqtRraEjoaC6JVap3xEQdVoBh2EagCVY7noPmcBcG4y7mnr9AJitR1ZAse2l+tEtK5vg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.2.5.tgz",
+      "integrity": "sha512-DdOIpssQ5LFev7hV6GX9TMBW5ChTsQBxqgNW1ZGtJNSAi5ksd5klwPwwMY0ejejfEzwXXGqxgVO3cpaod4veiA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.11.1",
+        "@smithy/core": "^3.13.0",
         "@smithy/middleware-serde": "^4.1.1",
         "@smithy/node-config-provider": "^4.2.2",
         "@smithy/shared-ini-file-loader": "^4.2.0",
@@ -2371,21 +2860,20 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.2.4.tgz",
-      "integrity": "sha512-amyqYQFewnAviX3yy/rI/n1HqAgfvUdkEhc04kDjxsngAUREKuOI24iwqQUirrj6GtodWmR4iO5Zeyl3/3BwWg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.3.1.tgz",
+      "integrity": "sha512-aH2bD1bzb6FB04XBhXA5mgedEZPKx3tD/qBuYCAKt5iieWvWO1Y2j++J9uLqOndXb9Pf/83Xka/YjSnMbcPchA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.2.2",
         "@smithy/protocol-http": "^5.2.1",
         "@smithy/service-error-classification": "^4.1.2",
-        "@smithy/smithy-client": "^4.6.3",
+        "@smithy/smithy-client": "^4.6.5",
         "@smithy/types": "^4.5.0",
         "@smithy/util-middleware": "^4.1.1",
         "@smithy/util-retry": "^4.1.2",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@smithy/uuid": "^1.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -2547,13 +3035,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.6.3.tgz",
-      "integrity": "sha512-K27LqywsaqKz4jusdUQYJh/YP2VbnbdskZ42zG8xfV+eovbTtMc2/ZatLWCfSkW0PDsTUXlpvlaMyu8925HsOw==",
+      "version": "4.6.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.6.5.tgz",
+      "integrity": "sha512-6J2hhuWu7EjnvLBIGltPCqzNswL1cW/AkaZx6i56qLsQ0ix17IAhmDD9aMmL+6CN9nCJODOXpBTCQS6iKAA7/g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.11.1",
-        "@smithy/middleware-endpoint": "^4.2.3",
+        "@smithy/core": "^3.13.0",
+        "@smithy/middleware-endpoint": "^4.2.5",
         "@smithy/middleware-stack": "^4.1.1",
         "@smithy/protocol-http": "^5.2.1",
         "@smithy/types": "^4.5.0",
@@ -2654,13 +3142,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.1.3.tgz",
-      "integrity": "sha512-5fm3i2laE95uhY6n6O6uGFxI5SVbqo3/RWEuS3YsT0LVmSZk+0eUqPhKd4qk0KxBRPaT5VNT/WEBUqdMyYoRgg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.1.5.tgz",
+      "integrity": "sha512-FGBhlmFZVSRto816l6IwrmDcQ9pUYX6ikdR1mmAhdtSS1m77FgADukbQg7F7gurXfAvloxE/pgsrb7SGja6FQA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.1.1",
-        "@smithy/smithy-client": "^4.6.3",
+        "@smithy/smithy-client": "^4.6.5",
         "@smithy/types": "^4.5.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -2670,16 +3158,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.1.3.tgz",
-      "integrity": "sha512-lwnMzlMslZ9GJNt+/wVjz6+fe9Wp5tqR1xAyQn+iywmP+Ymj0F6NhU/KfHM5jhGPQchRSCcau5weKhFdLIM4cA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.1.5.tgz",
+      "integrity": "sha512-Gwj8KLgJ/+MHYjVubJF0EELEh9/Ir7z7DFqyYlwgmp4J37KE+5vz6b3pWUnSt53tIe5FjDfVjDmHGYKjwIvW0Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.2.2",
         "@smithy/credential-provider-imds": "^4.1.2",
         "@smithy/node-config-provider": "^4.2.2",
         "@smithy/property-provider": "^4.1.1",
-        "@smithy/smithy-client": "^4.6.3",
+        "@smithy/smithy-client": "^4.6.5",
         "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
@@ -2792,6 +3280,18 @@
       "dependencies": {
         "@smithy/abort-controller": "^4.1.1",
         "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.0.0.tgz",
+      "integrity": "sha512-OlA/yZHh0ekYFnbUkmYBDQPE6fGfdrvgz39ktp8Xf+FA6BfxLejPTMDOG0Nfk5/rDySAz1dRbFf24zaAFYVXlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node server.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "dev": "node server.js",
-    "build": "echo 'No build step'"
+    "build": "echo 'No build step'",
+    "print:cloudfront-url": "node scripts/print-cloudfront-url.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.432.0",
@@ -26,7 +27,8 @@
     "pdfkit": "^0.13.0",
     "puppeteer-core": "^22.9.0",
     "json5": "^2.2.3",
-    "ua-parser-js": "^1.0.35"
+    "ua-parser-js": "^1.0.35",
+    "@aws-sdk/client-cloudformation": "^3.432.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/scripts/print-cloudfront-url.mjs
+++ b/scripts/print-cloudfront-url.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import { CloudFormationClient, DescribeStacksCommand } from "@aws-sdk/client-cloudformation";
+
+const [, , stackName] = process.argv;
+
+if (!stackName) {
+  console.error("Usage: npm run print:cloudfront-url -- <stack-name>");
+  process.exitCode = 1;
+  process.exit();
+}
+
+const client = new CloudFormationClient({});
+
+try {
+  const response = await client.send(new DescribeStacksCommand({ StackName: stackName }));
+  const stack = response.Stacks?.[0];
+
+  if (!stack) {
+    console.error(`Stack '${stackName}' not found.`);
+    process.exitCode = 1;
+    process.exit();
+  }
+
+  const outputs = stack.Outputs ?? [];
+  const cloudFrontOutput = outputs.find((output) => output.OutputKey === "CloudFrontUrl")
+    ?? outputs.find((output) => output.OutputKey === "AppBaseUrl");
+
+  if (!cloudFrontOutput?.OutputValue) {
+    console.error(
+      "The stack does not contain a CloudFrontUrl (or AppBaseUrl) output. Ensure the stack was deployed with the provided template."
+    );
+    process.exitCode = 1;
+    process.exit();
+  }
+
+  console.log(cloudFrontOutput.OutputValue);
+} catch (error) {
+  if (error?.name === "ValidationError") {
+    console.error(`Unable to describe stack '${stackName}'. Confirm the name and AWS credentials/region.`);
+  } else {
+    console.error(error instanceof Error ? error.message : error);
+  }
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add an npm script that queries CloudFormation for the CloudFrontUrl output and prints it
- document how to retrieve the CloudFront distribution URL in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d79d2562b4832bb29b4a2f083051b6