### PR TITLE
Fix API root response and serverless socket compatibility

### DIFF
--- a/tests/rootRoute.test.js
+++ b/tests/rootRoute.test.js
@@ -1,0 +1,44 @@
+import request from 'supertest';
+import app from '../server.js';
+import { handler } from '../lambda.js';
+
+describe('serverless bootstrap', () => {
+  it('responds to GET / with status json', async () => {
+    const response = await request(app).get('/');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      status: 'ok',
+      message: 'ResumeForge API is running.'
+    });
+  });
+
+  it('handles API Gateway proxy events without socket errors', async () => {
+    const event = {
+      resource: '/{proxy+}',
+      path: '/',
+      httpMethod: 'GET',
+      headers: {},
+      multiValueHeaders: {},
+      queryStringParameters: null,
+      multiValueQueryStringParameters: null,
+      pathParameters: null,
+      stageVariables: null,
+      requestContext: {
+        accountId: '123456789012',
+        resourceId: '123456',
+        stage: 'prod',
+        requestId: 'id',
+        identity: {},
+        resourcePath: '/{proxy+}',
+        httpMethod: 'GET',
+        apiId: 'id'
+      },
+      body: null,
+      isBase64Encoded: false
+    };
+    const context = {};
+    const result = await handler(event, context);
+    expect(result.statusCode).toBe(200);
+    expect(result.body).toContain('ResumeForge API is running.');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure serverless-express requests always expose event-emitter socket interfaces to avoid ee-first errors
- add a root endpoint that responds with API status for CloudFront health checks
- cover the new behavior with a regression test hitting both express and the Lambda handler

## Testing
- npm test -- --runTestsByPath tests/rootRoute.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d7a41489e0832b881d7a93129118aa