### PR TITLE
Add deployment URL reporting to GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -192,3 +192,72 @@ jobs:
               SecretName="$SECRET_NAME" \
               CreateDataBucket="$create_data_bucket" \
               CreateResumeTable="$create_resume_table"
+
+      - name: Publish deployment URLs
+        id: deployment_urls
+        shell: bash
+        env:
+          STACK_NAME: ${{ env.STACK_NAME }}
+        run: |
+          set -euo pipefail
+
+          aws cloudformation describe-stacks --stack-name "$STACK_NAME" --output json > describe.json
+
+          python <<'PY'
+import json
+import os
+from pathlib import Path
+
+with Path('describe.json').open() as fh:
+    data = json.load(fh)
+
+stacks = data.get('Stacks', [])
+if not stacks:
+    raise SystemExit('Unable to find stack description for deployment outputs.')
+
+outputs = {item['OutputKey']: item['OutputValue'] for item in stacks[0].get('Outputs', [])}
+app_url = outputs.get('AppBaseUrl') or outputs.get('CloudFrontUrl', '')
+api_url = outputs.get('ApiBaseUrl', '')
+
+summary_path = Path(os.environ['GITHUB_STEP_SUMMARY'])
+summary_lines = ['\n## Deployment URLs\n']
+if app_url:
+    summary_lines.append(f"- **App URL:** {app_url}\n")
+if api_url:
+    summary_lines.append(f"- **API base URL:** {api_url}\n")
+if len(summary_lines) == 1:
+    summary_lines.append('- No deployment URLs were returned by the stack outputs.\n')
+
+with summary_path.open('a', encoding='utf-8') as fh:
+    fh.write(''.join(summary_lines))
+
+output_path = Path(os.environ['GITHUB_OUTPUT'])
+with output_path.open('a', encoding='utf-8') as fh:
+    fh.write(f"app_url={app_url}\n")
+    fh.write(f"api_url={api_url}\n")
+
+notice_parts = []
+if app_url:
+    notice_parts.append(f"App URL: {app_url}")
+if api_url:
+    notice_parts.append(f"API URL: {api_url}")
+
+if notice_parts:
+    print(f"::notice title=Deployment URLs::{ ' | '.join(notice_parts) }")
+else:
+    print('::warning::Deployment succeeded but no URLs were returned in the stack outputs.')
+PY
+
+          rm -f describe.json
+
+      - name: Verify health endpoint availability
+        if: steps.deployment_urls.outputs.api_url != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          base_url='${{ steps.deployment_urls.outputs.api_url }}'
+          health_url="$base_url/healthz"
+          echo "Checking API health endpoint at $health_url"
+          response=$(curl --retry 5 --retry-delay 10 --fail --silent --show-error "$health_url")
+          echo "Health check response: $response"


### PR DESCRIPTION
## Summary
- extend the deploy workflow to capture CloudFormation outputs after `sam deploy`
- publish the application and API URLs to the job summary and as step outputs
- verify the deployed `/healthz` endpoint to ensure the stack is reachable

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d7a7db35fc832bba3848bccd571182