### PR TITLE
Fix CloudFront cache policy for disabled caching

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -116,20 +116,33 @@ Resources:
     Type: AWS::CloudFront::CachePolicy
     Properties:
       CachePolicyConfig:
-        Comment: Disable caching while forwarding all viewer context to the API origin.
+        Comment: Disable caching; viewer context is forwarded via a dedicated origin request policy.
         DefaultTTL: 0
         MaxTTL: 0
         MinTTL: 0
         Name: !Sub ResumeForgeCachePolicy-${AWS::StackName}
         ParametersInCacheKeyAndForwardedToOrigin:
           CookiesConfig:
-            CookieBehavior: all
+            CookieBehavior: none
           EnableAcceptEncodingBrotli: true
           EnableAcceptEncodingGzip: true
           HeadersConfig:
             HeaderBehavior: none
           QueryStringsConfig:
-            QueryStringBehavior: all
+            QueryStringBehavior: none
+
+  ResumeForgeOriginRequestPolicy:
+    Type: AWS::CloudFront::OriginRequestPolicy
+    Properties:
+      OriginRequestPolicyConfig:
+        Comment: Forward all viewer headers, cookies, and query strings to the API origin.
+        Name: !Sub ResumeForgeOriginRequestPolicy-${AWS::StackName}
+        CookiesConfig:
+          CookieBehavior: all
+        HeadersConfig:
+          HeaderBehavior: allViewer
+        QueryStringsConfig:
+          QueryStringBehavior: all
 
   ResumeForgeDistribution:
     Type: AWS::CloudFront::Distribution
@@ -163,6 +176,7 @@ Resources:
             - OPTIONS
           Compress: true
           CachePolicyId: !GetAtt ResumeForgeCachePolicy.Id
+          OriginRequestPolicyId: !GetAtt ResumeForgeOriginRequestPolicy.Id
 
 Outputs:
   ApiBaseUrl:


### PR DESCRIPTION
## Summary
- adjust the CloudFront cache policy to use no cookies/query strings in the cache key when caching is disabled
- add an origin request policy that forwards all viewer headers, cookies, and query parameters to API Gateway
- attach the new origin request policy to the distribution's default behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7c273cd04832b9e57408ba52128ff