### PR TITLE
Disable Accept-Encoding flags for no-cache CloudFront policy

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -124,8 +124,8 @@ Resources:
         ParametersInCacheKeyAndForwardedToOrigin:
           CookiesConfig:
             CookieBehavior: none
-          EnableAcceptEncodingBrotli: true
-          EnableAcceptEncodingGzip: true
+          EnableAcceptEncodingBrotli: false
+          EnableAcceptEncodingGzip: false
           HeadersConfig:
             HeaderBehavior: none
           QueryStringsConfig:


### PR DESCRIPTION
## Summary
- disable Brotli and gzip Accept-Encoding flags on the custom CloudFront cache policy used for the API distribution
- align the cache policy settings with the zero-TTL configuration to avoid CloudFront validation errors during deployment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7c516a298832b8c3f009e58cb1cd4