### PR TITLE
Reduce CloudFront origin request headers for SAM template

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -143,14 +143,12 @@ Resources:
           HeaderBehavior: whitelist
           Headers:
             - Accept
-            - Accept-Language
             - Access-Control-Request-Headers
             - Access-Control-Request-Method
             - Authorization
             - Content-Type
             - Origin
             - Referer
-            - User-Agent
             - X-Amz-Date
             - X-Amz-Security-Token
             - X-Requested-With


### PR DESCRIPTION
## Summary
- remove Accept-Language and User-Agent from the CloudFront origin request policy header allow list to comply with service limits and unblock stack updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7cb2cc920832ba69f624a0567cbe8