### PR TITLE
Fix CloudFront origin request policy header configuration

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -141,6 +141,8 @@ Resources:
           CookieBehavior: all
         HeadersConfig:
           HeaderBehavior: allViewerAndWhitelistCloudFront
+          Headers:
+            - CloudFront-Forwarded-Proto
         QueryStringsConfig:
           QueryStringBehavior: all
 


### PR DESCRIPTION
## Summary
- update the custom CloudFront origin request policy to explicitly whitelist the CloudFront-Forwarded-Proto header when forwarding all viewer headers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e123c4d4832bb8e2947000119a47