### PR TITLE
Normalize API base URL handling in the client

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,7 +10,8 @@ function App() {
   const [outputFiles, setOutputFiles] = useState([])
   const [match, setMatch] = useState(null)
   const [error, setError] = useState('')
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || ''
+  const rawBaseUrl = (import.meta.env.VITE_API_BASE_URL || '').trim()
+  const API_BASE_URL = rawBaseUrl.replace(/\/+$/u, '')
 
   const handleDrop = useCallback((e) => {
     e.preventDefault()
@@ -43,7 +44,11 @@ function App() {
       formData.append('jobDescriptionUrl', jobUrl)
       if (credlyUrl) formData.append('credlyProfileUrl', credlyUrl)
 
-      const response = await fetch(`${API_BASE_URL}/api/process-cv`, {
+      const requestUrl = API_BASE_URL
+        ? `${API_BASE_URL}/api/process-cv`
+        : '/api/process-cv'
+
+      const response = await fetch(requestUrl, {
         method: 'POST',
         body: formData,
       })


### PR DESCRIPTION
## Summary
- trim whitespace and trailing slashes from `VITE_API_BASE_URL`
- build the request URL dynamically to avoid duplicated slashes when the base URL is absent

## Testing
- npm test *(fails: Cannot find module '@vendia/serverless-express' from 'lambda.js')*

------
https://chatgpt.com/codex/tasks/task_e_68d7e2dcf050832b89d4eca27a8f7eb6