### PR TITLE
Fix CloudFront header forwarding for API Gateway

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -135,14 +135,20 @@ Resources:
     Type: AWS::CloudFront::OriginRequestPolicy
     Properties:
       OriginRequestPolicyConfig:
-        Comment: Forward the full viewer header context along with CloudFront-managed headers required for API Gateway.
+        Comment: Forward required headers while letting CloudFront supply the Host header expected by API Gateway.
         Name: !Sub ResumeForgeOriginRequestPolicy-${AWS::StackName}
         CookiesConfig:
           CookieBehavior: all
         HeadersConfig:
-          HeaderBehavior: allViewerAndWhitelistCloudFront
+          HeaderBehavior: whitelist
           Headers:
             - CloudFront-Forwarded-Proto
+            - Origin
+            - Authorization
+            - Content-Type
+            - X-Amz-Date
+            - X-Api-Key
+            - X-Amz-Security-Token
         QueryStringsConfig:
           QueryStringBehavior: all
 


### PR DESCRIPTION
## Summary
- update the CloudFront origin request policy to stop forwarding the viewer Host header to API Gateway
- whitelist only the headers the API requires so CloudFront can present its managed Host header and avoid 403 responses

## Testing
- `npm test` *(fails: Cannot find module '@vendia/serverless-express' from 'lambda.js')*

------
https://chatgpt.com/codex/tasks/task_e_68d7e699b8a0832b9f514f4b8945905d