### PR TITLE
Adjust CloudFront origin request policy headers

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -140,15 +140,7 @@ Resources:
         CookiesConfig:
           CookieBehavior: all
         HeadersConfig:
-          HeaderBehavior: whitelist
-          Headers:
-            - CloudFront-Forwarded-Proto
-            - Origin
-            - Authorization
-            - Content-Type
-            - X-Amz-Date
-            - X-Api-Key
-            - X-Amz-Security-Token
+          HeaderBehavior: allViewer
         QueryStringsConfig:
           QueryStringBehavior: all
 


### PR DESCRIPTION
## Summary
- relax the CloudFront origin request policy to forward all viewer headers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7ea932e8c832bb581b477ffc64dfe