### PR TITLE
Fix CloudFront header forwarding to avoid API 403s

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -140,7 +140,14 @@ Resources:
         CookiesConfig:
           CookieBehavior: all
         HeadersConfig:
-          HeaderBehavior: allViewer
+          HeaderBehavior: whitelist
+          Headers:
+            - Authorization
+            - Content-Type
+            - Origin
+            - Access-Control-Request-Method
+            - Access-Control-Request-Headers
+            - Accept
         QueryStringsConfig:
           QueryStringBehavior: all
 


### PR DESCRIPTION
## Summary
- update the CloudFront origin request policy to whitelist only the headers that API Gateway needs
- ensure the Host header is not forwarded so API Gateway accepts requests from the distribution domain

## Testing
- npm test *(fails: Cannot find module '@vendia/serverless-express' from 'lambda.js')*

------
https://chatgpt.com/codex/tasks/task_e_68d7eee80e18832b976f704120dba9cb