### PR TITLE
Expose lightweight upload portal at CloudFront root

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ https://<api-id>.execute-api.<region>.amazonaws.com/<stage>
 
 ### Accessing the ResumeForge portal
 
-The SAM template deploys the API and a CloudFront distribution that forwards requests straight to API Gateway. The distribution’s default root object is `/healthz`, so opening the raw CloudFront domain or the API Gateway invoke URL in a browser returns a JSON health payload. CloudFront is configured to let AWS supply the `Host` header expected by API Gateway; forwarding the viewer’s `Host` would cause API Gateway to reject the request with a 403 because the CloudFront hostname is not mapped to the stage. If you omit the stage segment (for example, visiting `https://<api-id>.execute-api.<region>.amazonaws.com/`), API Gateway responds with `{"message":"Forbidden"}` because no resource matches that path. The React “portal” UI is not published automatically.
+The SAM template deploys the API and a CloudFront distribution that forwards requests straight to API Gateway. Visiting the raw CloudFront domain now renders a lightweight HTML portal served directly by the API’s root route, so candidates can upload their CV, provide the job description, and receive enhanced documents without any additional hosting. The `/healthz` endpoint is still available if you need a JSON health payload. CloudFront is configured to let AWS supply the `Host` header expected by API Gateway; forwarding the viewer’s `Host` would cause API Gateway to reject the request with a 403 because the CloudFront hostname is not mapped to the stage. If you omit the stage segment (for example, visiting `https://<api-id>.execute-api.<region>.amazonaws.com/`), API Gateway responds with `{"message":"Forbidden"}` because no resource matches that path.
 
-To use the portal you have two options:
+If you prefer the full React application you can continue to host it separately:
 
 1. **Run it locally**
    ```bash
@@ -112,6 +112,7 @@ To use the portal you have two options:
    VITE_API_BASE_URL="https://<api-id>.execute-api.<region>.amazonaws.com/<stage>" \
      npm run dev --prefix client
    ```
+
    This starts the Vite dev server on <http://localhost:5173>. The client proxies `/api` requests to `VITE_API_BASE_URL`, so set that variable to the deployed API (or leave it unset to target a locally running Express server).
 
 2. **Host the built assets yourself**
@@ -121,8 +122,6 @@ To use the portal you have two options:
      npm run build --prefix client
    ```
    Upload the generated `client/dist` directory to an S3 static website bucket or another hosting service, and (optionally) front it with CloudFront. If the portal runs on a different origin than the API, ensure the API’s CORS configuration allows that origin.
-
-Until the static assets are hosted, the CloudFront URL printed by the deployment will only expose the health check and JSON API responses—not the ResumeForge portal.
 
 Using the default stage (`prod`), the `/api/process-cv` endpoint is reachable either directly through API Gateway or via the CloudFront distribution:
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "moduleNameMapper": {
       "^@google/generative-ai$": "<rootDir>/tests/mocks/google-generative-ai.js",
       "^@aws-sdk/client-dynamodb$": "<rootDir>/tests/mocks/aws-sdk-client-dynamodb.js",
+      "^@vendia/serverless-express$": "<rootDir>/tests/mocks/serverless-express.js",
       "^puppeteer$": "<rootDir>/tests/mocks/puppeteer.js"
     }
   }

--- a/templates/portal.html
+++ b/templates/portal.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ResumeForge Portal</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: linear-gradient(135deg, #101828, #1d2939);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        color: #f8fafc;
+      }
+      .card {
+        width: min(960px, 100%);
+        background: rgba(15, 23, 42, 0.88);
+        border-radius: 20px;
+        box-shadow: 0 24px 80px rgba(15, 23, 42, 0.45);
+        padding: 40px clamp(24px, 5vw, 48px);
+        backdrop-filter: blur(12px);
+      }
+      h1 {
+        margin: 0 0 12px;
+        font-size: clamp(2rem, 3.5vw, 2.6rem);
+        font-weight: 700;
+        letter-spacing: -0.02em;
+      }
+      p.lead {
+        margin: 0 0 32px;
+        font-size: clamp(1.05rem, 2.5vw, 1.2rem);
+        color: rgba(226, 232, 240, 0.85);
+      }
+      form {
+        display: grid;
+        gap: 20px;
+      }
+      label {
+        font-size: 0.95rem;
+        font-weight: 600;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      input[type="text"],
+      input[type="url"],
+      input[type="file"],
+      select,
+      textarea {
+        font: inherit;
+        padding: 12px 14px;
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        background: rgba(15, 23, 42, 0.75);
+        color: inherit;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      }
+      input[type="file"] {
+        padding: 10px 14px;
+        background: rgba(15, 23, 42, 0.6);
+      }
+      input:focus,
+      textarea:focus,
+      select:focus {
+        outline: none;
+        border-color: #38bdf8;
+        box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.25);
+      }
+      button[type="submit"] {
+        border: none;
+        border-radius: 999px;
+        padding: 14px 28px;
+        font-size: 1rem;
+        font-weight: 600;
+        background: linear-gradient(135deg, #38bdf8, #14b8a6);
+        color: #0f172a;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+      button[type="submit"]:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 12px 40px rgba(20, 184, 166, 0.35);
+      }
+      .hint {
+        font-size: 0.85rem;
+        color: rgba(226, 232, 240, 0.7);
+      }
+      .results {
+        margin-top: 32px;
+        padding-top: 32px;
+        border-top: 1px solid rgba(148, 163, 184, 0.2);
+        display: none;
+      }
+      .results.active {
+        display: grid;
+        gap: 18px;
+      }
+      .links {
+        display: grid;
+        gap: 12px;
+      }
+      .link-card {
+        background: rgba(30, 41, 59, 0.9);
+        border-radius: 14px;
+        padding: 16px 18px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+      }
+      .link-card a {
+        color: #38bdf8;
+        text-decoration: none;
+        font-weight: 600;
+      }
+      .metrics {
+        display: grid;
+        gap: 8px;
+        font-size: 0.95rem;
+      }
+      .error {
+        border-radius: 12px;
+        padding: 14px 16px;
+        background: rgba(248, 113, 113, 0.16);
+        border: 1px solid rgba(248, 113, 113, 0.5);
+        color: #fecaca;
+        display: none;
+      }
+      .error.active {
+        display: block;
+      }
+      @media (max-width: 640px) {
+        .card {
+          padding: 32px 20px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <h1>ResumeForge</h1>
+      <p class="lead">
+        Upload your CV, provide the job posting and LinkedIn profile, and we will craft
+        AI-enhanced resumes and tailored cover letters for you.
+      </p>
+      <form id="portal-form">
+        <label>
+          Resume (PDF or DOCX)
+          <input type="file" name="resume" accept=".pdf,.doc,.docx" required />
+          <span class="hint">Maximum size: 5 MB.</span>
+        </label>
+        <label>
+          Job description URL
+          <input
+            type="url"
+            name="jobDescriptionUrl"
+            placeholder="https://company.com/careers/role"
+            required
+          />
+        </label>
+        <label>
+          LinkedIn profile URL
+          <input
+            type="url"
+            name="linkedinProfileUrl"
+            placeholder="https://www.linkedin.com/in/your-profile"
+            required
+          />
+        </label>
+        <label>
+          Credly profile URL (optional)
+          <input
+            type="url"
+            name="credlyProfileUrl"
+            placeholder="https://www.credly.com/users/your-profile"
+          />
+        </label>
+        <label>
+          Preferred CV template (optional)
+          <select name="template">
+            <option value="">Let ResumeForge decide</option>
+            <option value="modern">Modern</option>
+            <option value="ucmo">Classic</option>
+            <option value="professional">Professional</option>
+            <option value="vibrant">Vibrant</option>
+            <option value="2025">Futuristic</option>
+          </select>
+        </label>
+        <label>
+          Preferred cover letter template (optional)
+          <select name="coverTemplate">
+            <option value="">Let ResumeForge decide</option>
+            <option value="cover_modern">Modern</option>
+            <option value="cover_classic">Classic</option>
+          </select>
+        </label>
+        <button type="submit">Generate my enhanced CV</button>
+      </form>
+      <div id="error" class="error"></div>
+      <section id="results" class="results" aria-live="polite">
+        <div class="metrics" id="metrics"></div>
+        <div class="links" id="links"></div>
+      </section>
+    </main>
+    <script>
+      const form = document.getElementById('portal-form');
+      const errorBox = document.getElementById('error');
+      const results = document.getElementById('results');
+      const links = document.getElementById('links');
+      const metrics = document.getElementById('metrics');
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        errorBox.classList.remove('active');
+        errorBox.textContent = '';
+        results.classList.remove('active');
+        links.innerHTML = '';
+        metrics.innerHTML = '';
+
+        const formData = new FormData(form);
+        const submitButton = form.querySelector('button[type="submit"]');
+        const originalText = submitButton.textContent;
+        submitButton.disabled = true;
+        submitButton.textContent = 'Generating...';
+
+        try {
+          const response = await fetch('/api/process-cv', {
+            method: 'POST',
+            body: formData
+          });
+          const data = await response.json();
+          if (!response.ok) {
+            throw new Error(data.error || 'Processing failed');
+          }
+
+          if (Array.isArray(data.urls) && data.urls.length) {
+            data.urls.forEach((item) => {
+              if (!item || !item.url) return;
+              const div = document.createElement('div');
+              div.className = 'link-card';
+              const label = item.type.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+              div.innerHTML = `<span>${label}</span><a href="${item.url}" target="_blank" rel="noopener">Download</a>`;
+              links.appendChild(div);
+            });
+          }
+
+          const scoreParts = [];
+          if (typeof data.originalScore === 'number') {
+            scoreParts.push(`Original match score: ${Math.round(data.originalScore * 100)}%`);
+          }
+          if (typeof data.enhancedScore === 'number') {
+            scoreParts.push(`Enhanced match score: ${Math.round(data.enhancedScore * 100)}%`);
+          }
+          if (data.addedSkills && data.addedSkills.length) {
+            scoreParts.push(`Newly highlighted skills: ${data.addedSkills.join(', ')}`);
+          }
+          if (scoreParts.length) {
+            metrics.innerHTML = scoreParts.map((text) => `<div>${text}</div>`).join('');
+          }
+
+          if (!links.childElementCount && !metrics.childElementCount) {
+            metrics.innerHTML = '<div>Your enhanced documents are ready.</div>';
+          }
+
+          results.classList.add('active');
+        } catch (err) {
+          errorBox.textContent = err.message;
+          errorBox.classList.add('active');
+        } finally {
+          submitButton.disabled = false;
+          submitButton.textContent = originalText;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/tests/mocks/serverless-express.js
+++ b/tests/mocks/serverless-express.js
@@ -1,0 +1,26 @@
+import request from 'supertest';
+
+export const configure = ({ app }) => {
+  return async (event) => {
+    const method = (event.httpMethod || 'GET').toLowerCase();
+    const path = event.path || '/';
+    let req = request(app)[method](path);
+    if (event.headers) {
+      for (const [key, value] of Object.entries(event.headers)) {
+        if (value !== undefined) req = req.set(key, value);
+      }
+    }
+    if (event.body) {
+      const payload = event.isBase64Encoded
+        ? Buffer.from(event.body, 'base64').toString()
+        : event.body;
+      req = req.send(payload);
+    }
+    const response = await req;
+    return {
+      statusCode: response.status,
+      body: response.text,
+      headers: response.headers
+    };
+  };
+};

--- a/tests/rootRoute.test.js
+++ b/tests/rootRoute.test.js
@@ -3,13 +3,12 @@ import app from '../server.js';
 import { handler } from '../lambda.js';
 
 describe('serverless bootstrap', () => {
-  it('responds to GET / with status json', async () => {
+  it('responds to GET / with the hosted portal', async () => {
     const response = await request(app).get('/');
     expect(response.status).toBe(200);
-    expect(response.body).toEqual({
-      status: 'ok',
-      message: 'ResumeForge API is running.'
-    });
+    expect(response.type).toMatch(/html/);
+    expect(response.text).toContain('<title>ResumeForge Portal</title>');
+    expect(response.text).toContain('id="portal-form"');
   });
 
   it('handles API Gateway proxy events without socket errors', async () => {
@@ -39,6 +38,6 @@ describe('serverless bootstrap', () => {
     const context = {};
     const result = await handler(event, context);
     expect(result.statusCode).toBe(200);
-    expect(result.body).toContain('ResumeForge API is running.');
+    expect(result.body).toContain('<title>ResumeForge Portal</title>');
   });
 });


### PR DESCRIPTION
## Summary
- serve a cached HTML portal from the root route so CloudFront users can upload resumes immediately
- document the new hosted portal option in the deployment guide
- add a Jest mock for @vendia/serverless-express and update root route coverage for the HTML response

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7f56e1334832bba7c847e71192b39