### PR TITLE
feat: add structured logging and detailed API errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-dynamodb": "^3.432.0",
         "@aws-sdk/client-s3": "^3.432.0",
         "@aws-sdk/client-secrets-manager": "^3.432.0",
+        "@aws-sdk/s3-request-presigner": "^3.432.0",
         "@google/generative-ai": "^0.11.3",
         "@sparticuz/chromium": "^123.0.0",
         "@vendia/serverless-express": "^4.10.3",
@@ -1382,6 +1383,130 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.896.0.tgz",
+      "integrity": "sha512-pAlxvB1UmbgyfW8JyJy30FXfsfcWAbtR5gCO25mR5PPwuBQgzQR6lf/L4zbp+ZsSNhlKsvroe537oW5EXYk6Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.896.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-format-url": "3.893.0",
+        "@smithy/middleware-endpoint": "^4.2.4",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.4",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/core": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.896.0.tgz",
+      "integrity": "sha512-uJaoyWKeGNyCyeI+cIJrD7LEB4iF/W8/x2ij7zg32OFpAAJx96N34/e+XSKp/xkJpO5FKiBOskKLnHeUsJsAPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/xml-builder": "3.894.0",
+        "@smithy/core": "^3.12.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/property-provider": "^4.1.1",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/signature-v4": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.4",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-base64": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.896.0.tgz",
+      "integrity": "sha512-hlPu/AZ5Afa4ZafP+aXIjRtKm7BX57lurA+TJ+7nXm1Az8Du3Sg2tZXP2/GfqTztLIFQYj/Jy5smkJ0+1HNAPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.896.0",
+        "@aws-sdk/types": "3.893.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/core": "^3.12.0",
+        "@smithy/node-config-provider": "^4.2.2",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/signature-v4": "^5.2.1",
+        "@smithy/smithy-client": "^4.6.4",
+        "@smithy/types": "^4.5.0",
+        "@smithy/util-config-provider": "^4.1.0",
+        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/util-stream": "^4.3.2",
+        "@smithy/util-utf8": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.896.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.896.0.tgz",
+      "integrity": "sha512-txiQDEZXL9tlNP8mbnNaDtuHBYc/FCqaZ8Y76qnfM3o6CTIn0t0tTAlnx1CyFe4EaikVBgQuZvj5KfNA8PmlzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.896.0",
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/protocol-http": "^5.2.1",
+        "@smithy/signature-v4": "^5.2.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/types": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.893.0.tgz",
+      "integrity": "sha512-Aht1nn5SnA0N+Tjv0dzhAY7CQbxVtmq1bBR6xI0MhG7p2XYVh1wXuKTzrldEvQWwA3odOYunAfT9aBiKZx9qIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
+      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.894.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.894.0.tgz",
+      "integrity": "sha512-E6EAMc9dT1a2DOdo4zyOf3fp5+NJ2wI+mcm7RaW1baFIWDwcb99PpvWoV7YEiK7oaBDshuOEGWKUSYXdW+JYgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.891.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.891.0.tgz",
@@ -1452,6 +1577,34 @@
         "@smithy/types": "^4.5.0",
         "@smithy/url-parser": "^4.1.1",
         "@smithy/util-endpoints": "^3.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.893.0.tgz",
+      "integrity": "sha512-VmAvcedZfQlekiSFJ9y/+YjuCFT3b/vXImbkqjYoD4gbsDjmKm5lxo/w1p9ch0s602obRPLMkh9H20YgXnmwEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.893.0",
+        "@smithy/querystring-builder": "^4.1.1",
+        "@smithy/types": "^4.5.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.893.0.tgz",
+      "integrity": "sha512-Aht1nn5SnA0N+Tjv0dzhAY7CQbxVtmq1bBR6xI0MhG7p2XYVh1wXuKTzrldEvQWwA3odOYunAfT9aBiKZx9qIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@aws-sdk/client-cloudformation": "^3.432.0",
     "@aws-sdk/client-dynamodb": "^3.432.0",
     "@aws-sdk/client-s3": "^3.432.0",
+    "@aws-sdk/s3-request-presigner": "^3.432.0",
     "@aws-sdk/client-secrets-manager": "^3.432.0",
     "@google/generative-ai": "^0.11.3",
     "@sparticuz/chromium": "^123.0.0",


### PR DESCRIPTION
## Summary
- add structured JSON logging, presigned URL expiry, and structured error handling to the API
- document the new response schema updates in the README
- update dependencies and integration tests for presigned URLs and response assertions

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d807029eb4832b857784158efcdf82