### PR TITLE
Fix YAML indentation in deployment context step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,12 +190,12 @@ jobs:
             exit 1
           fi
 
-          cat <<OUT >>"$GITHUB_OUTPUT"
-stack_name=$STACK_NAME
-bucket_name=$DATA_BUCKET
-resume_table=$TABLE_NAME
-secret_name=$SECRET_NAME
-OUT
+          {
+            printf 'stack_name=%s\n' "$STACK_NAME"
+            printf 'bucket_name=%s\n' "$DATA_BUCKET"
+            printf 'resume_table=%s\n' "$TABLE_NAME"
+            printf 'secret_name=%s\n' "$SECRET_NAME"
+          } >>"$GITHUB_OUTPUT"
 
       - name: Deploy stack
         shell: bash


### PR DESCRIPTION
## Summary
- indent the here-document output in the deploy job using printf so the workflow YAML remains valid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d82dc69ae4832b9639c0d887df329f