### PR TITLE
Fix indentation in CI workflow summary script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,7 +336,7 @@ jobs:
 
           with Path(os.environ['GITHUB_STEP_SUMMARY']).open('a', encoding='utf-8') as fh:
               fh.write(''.join(summary_lines))
-PY
+          PY
 
           rm -f describe.json
 


### PR DESCRIPTION
## Summary
- correct the indentation of the heredoc terminator in the CI workflow so the YAML parses correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8381527e0832bb5c8ffaa951c67cf