### PR TITLE
Add fail-fast settings to server Jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "@aws-sdk/client-cloudformation": "^3.432.0",
     "@aws-sdk/client-dynamodb": "^3.432.0",
     "@aws-sdk/client-s3": "^3.432.0",
-    "@aws-sdk/s3-request-presigner": "^3.432.0",
     "@aws-sdk/client-secrets-manager": "^3.432.0",
+    "@aws-sdk/s3-request-presigner": "^3.432.0",
     "@google/generative-ai": "^0.11.3",
     "@sparticuz/chromium": "^123.0.0",
     "@vendia/serverless-express": "^4.10.3",
@@ -64,6 +64,8 @@
     "coverageReporters": [
       "text",
       "lcov"
-    ]
+    ],
+    "bail": true,
+    "forceExit": true
   }
 }


### PR DESCRIPTION
## Summary
- configure Jest to bail on first failure and force exit after the test run to prevent lengthy hangs

## Testing
- npm test -- server

------
https://chatgpt.com/codex/tasks/task_e_68d888aa4058832ba6e5914d83acfd67