### PR TITLE
Use makefile bundling to shrink Lambda package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 client/node_modules
 client/dist
+dist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build-ResumeForgeFunction:
+	node scripts/build-lambda.mjs --outdir $(ARTIFACTS_DIR)
+
+clean-ResumeForgeFunction:
+	rm -rf $(ARTIFACTS_DIR)

--- a/template.yaml
+++ b/template.yaml
@@ -99,6 +99,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: ResumeForgeHandler
+      CodeUri: .
       Handler: lambda.handler
       Runtime: nodejs18.x
       MemorySize: 2048
@@ -147,6 +148,8 @@ Resources:
         - DynamoDBCrudPolicy:
             TableName: !Ref ResumeTableName
       Layers: []
+    Metadata:
+      BuildMethod: makefile
 
   ResumeForgeCachePolicy:
     Type: AWS::CloudFront::CachePolicy


### PR DESCRIPTION
## Summary
- add a Makefile so SAM builds the Lambda bundle with the existing esbuild script
- allow the Lambda build script to target an arbitrary artifacts directory and skip source maps by default
- point the SAM template at the makefile build output and ignore generated dist folders in git

## Testing
- npm test -- --runInBand
- npm run build:lambda

------
https://chatgpt.com/codex/tasks/task_e_68d8f8974928832ba5c617e9b4cfcdbc