### PR TITLE
Fix API base resolution for CloudFront paths

### DIFF
--- a/client/src/resolveApiBase.js
+++ b/client/src/resolveApiBase.js
@@ -33,8 +33,12 @@ export function resolveApiBase(rawBaseUrl) {
     const matchesHost = url.hostname === window.location.hostname
     const looksLikeCloudFront = CLOUD_FRONT_HOST.test(url.hostname)
 
-    if (atRoot && (looksLikeCloudFront || matchesHost)) {
+    if (atRoot && matchesHost && !normalizedPath) {
       return url.origin
+    }
+
+    if (looksLikeCloudFront && normalizedPath) {
+      return `${url.origin}/${normalizedPath}`
     }
 
     return `${url.origin}${normalizedPath ? `/${normalizedPath}` : ''}`


### PR DESCRIPTION
## Summary
- update resolveApiBase to retain CloudFront path segments when building the API URL
- ensure same-host URLs without extra paths still normalize to the origin

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d90c46eac0832bb6adb3fb5a1f74b0