### PR TITLE
Add Jest mock for AWS S3 presigner module

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "moduleNameMapper": {
       "^@google/generative-ai$": "<rootDir>/tests/mocks/google-generative-ai.js",
       "^@aws-sdk/client-dynamodb$": "<rootDir>/tests/mocks/aws-sdk-client-dynamodb.js",
+      "^@aws-sdk/s3-request-presigner$": "<rootDir>/tests/mocks/aws-sdk-s3-request-presigner.js",
       "^@vendia/serverless-express$": "<rootDir>/tests/mocks/serverless-express.js",
       "^puppeteer$": "<rootDir>/tests/mocks/puppeteer.js"
     },

--- a/tests/mocks/aws-sdk-s3-request-presigner.js
+++ b/tests/mocks/aws-sdk-s3-request-presigner.js
@@ -1,0 +1,10 @@
+import { jest } from '@jest/globals';
+
+export const getSignedUrl = jest
+  .fn((client, command = {}, options = {}) => {
+    const key = command?.input?.Key ?? 'mock-key';
+    const expiresIn = options?.expiresIn ?? 0;
+    return Promise.resolve(`https://example.com/${key}?expires=${expiresIn}`);
+  });
+
+export default { getSignedUrl };


### PR DESCRIPTION
## Summary
- map the AWS S3 request presigner module to a local Jest mock
- implement a shared mock that returns deterministic signed URLs for tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d92836c814832b9cf5ef8980f45f7e