### PR TITLE
Add runtime config file fallback for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ResumeForge generates tailored cover letters and enhanced CV versions by combining a candidate's résumé with a scraped job description. The Express API is wrapped with `@vendia/serverless-express` and deployed to AWS Lambda behind API Gateway so the entire stack runs on demand. Persistent artifacts are stored in Amazon S3 while DynamoDB (on-demand billing) retains processing metadata, keeping the monthly infrastructure cost negligible for small user counts.
 
 ## Environment configuration
-ResumeForge now relies exclusively on environment variables for sensitive and deployment-specific configuration. The Express server validates the presence of required values at startup and fails fast if any are missing, ensuring secrets are not shipped inline with the source code.
+ResumeForge now relies exclusively on environment variables for sensitive and deployment-specific configuration. The Express server validates the presence of required values at startup and fails fast if any are missing, ensuring secrets are not shipped inline with the source code. For local development you can alternatively provide a `runtime-config.json`/`runtime-config.json5` file (or set `RUNTIME_CONFIG_PATH` to point at one) in the project root or inside the `config/` directory. The loader understands JSON5, so comments and trailing commas are allowed. An example file lives at `config/runtime-config.example.json5`—copy it to `config/runtime-config.json5`, fill in the secrets, and the server will load them automatically.
 
 The runtime looks for the following keys:
 

--- a/config/runtime-config.example.json5
+++ b/config/runtime-config.example.json5
@@ -1,0 +1,18 @@
+// Example runtime configuration for local development.
+// Copy this file to `config/runtime-config.json5` and fill in the values
+// to run ResumeForge without exporting environment variables.
+{
+  // AWS region used by the SDK clients.
+  AWS_REGION: 'us-east-1',
+  // Name of the S3 bucket that stores uploads and generated artefacts.
+  S3_BUCKET: 'resume-forge-local',
+  // Gemini API key used to generate enhanced content.
+  GEMINI_API_KEY: 'replace-me',
+  // Optional: allow requests from these origins when running locally.
+  CLOUDFRONT_ORIGINS: [
+    'http://localhost:3000',
+    'http://localhost:5173'
+  ],
+  // Optional: salt used when hashing PII before persisting to DynamoDB.
+  PII_HASH_SECRET: 'local-dev-secret'
+}


### PR DESCRIPTION
## Summary
- allow the runtime configuration to fall back to JSON/JSON5 files when required environment variables are missing
- normalise origin lists from both environment variables and config files and hydrate optional PII hash secret
- document the new workflow and add an example config file for local development

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d95c40fc8c832b9a99565cc979c25f