### PR TITLE
Handle DELETE_IN_PROGRESS errors during deployment retries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -260,13 +260,13 @@ jobs:
             fi
 
             deploy_err=$(cat "$tmp_deploy_err")
-            if echo "$deploy_err" | grep -qi "is in UPDATE_IN_PROGRESS state and can not be updated"; then
+            if echo "$deploy_err" | grep -Eqi "is in (UPDATE|DELETE)_IN_PROGRESS state and can not be updated"; then
               if [ "$deploy_attempt" -eq "$max_deploy_attempts" ]; then
-                echo "Stack remained in UPDATE_IN_PROGRESS after $max_deploy_attempts attempts. Aborting deployment." >&2
+                echo "Stack remained busy after $max_deploy_attempts attempts. Aborting deployment." >&2
                 exit 1
               fi
 
-              echo "Stack update currently in progress. Waiting for CloudFormation to finish before retrying..."
+              echo "Stack update or deletion currently in progress. Waiting for CloudFormation to finish before retrying..."
               : >"$tmp_err"
               if stack_status=$(aws cloudformation describe-stacks \
                   --stack-name "$STACK_NAME" \


### PR DESCRIPTION
## Summary
- allow the deploy workflow to treat DELETE_IN_PROGRESS like UPDATE_IN_PROGRESS when retrying sam deploy
- clarify the retry logging so it covers both update and delete activity

## Testing
- npm test -- --runInBand *(fails: Cannot find module 'handlebars' from 'lib/handlebars.js')*

------
https://chatgpt.com/codex/tasks/task_e_68d961764f3c832b9d33f527b4967af6