### PR TITLE
Allow SAM template to resolve Gemini API key from Secrets Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,17 @@ Add the following secrets under **Settings → Secrets and variables → Actions
 | `AWS_REGION` | Region that hosts the ResumeForge stack (e.g., `ap-south-1`). |
 | `RESUMEFORGE_STACK_NAME` | CloudFormation stack name used by `sam deploy` (e.g., `ResumeForge`). |
 | `RESUMEFORGE_DATA_BUCKET` | Globally unique S3 bucket name passed to the `DataBucketName` parameter. |
-| `GEMINI_API_KEY` | Gemini API key provided to the runtime via environment variable overrides. |
+| `RESUMEFORGE_SECRET_NAME` | Name of the AWS Secrets Manager secret that stores runtime configuration. The secret must contain a `GEMINI_API_KEY` field. |
+
+The Secrets Manager entry referenced by `RESUMEFORGE_SECRET_NAME` should store a JSON object, for example:
+
+```json
+{
+  "GEMINI_API_KEY": "<api-key-value>"
+}
+```
+
+If you prefer to supply the Gemini API key directly (for local testing or bespoke deployments), pass a value to the `GeminiApiKey` parameter instead of configuring a secret. The CloudFormation template enforces that at least one of these sources is provided.
 
 Optional secrets:
 

--- a/template.yaml
+++ b/template.yaml
@@ -42,10 +42,19 @@ Parameters:
   GeminiApiKey:
     Type: String
     NoEcho: true
-    MinLength: 1
+    Default: ''
     Description: >-
       Gemini API key used by the Lambda function to generate enhanced resume
-      content. Provide the value securely when deploying the stack.
+      content. Provide the value securely when deploying the stack or supply a
+      Secrets Manager secret name instead.
+  SecretName:
+    Type: String
+    Default: ''
+    Description: >-
+      Optional AWS Secrets Manager secret (JSON) that contains a
+      GEMINI_API_KEY value. When provided, the Lambda environment resolves the
+      API key from the secret at runtime. Leave blank to pass GeminiApiKey
+      directly.
   ProvisionedConcurrency:
     Type: Number
     Default: 0
@@ -68,6 +77,18 @@ Conditions:
   CreateDataBucketCondition: !Equals [!Ref CreateDataBucket, 'true']
   EnableProvisionedConcurrency: !Not [!Equals [!Ref ProvisionedConcurrency, 0]]
   AttachWebAcl: !Not [!Equals [!Ref WebAclArn, '']]
+  UseSecretName: !Not [!Equals [!Ref SecretName, '']]
+
+Rules:
+  RequireGeminiConfiguration:
+    Assertions:
+      - Assert: !Or
+          - !Not [!Equals [!Ref SecretName, '']]
+          - !Not [!Equals [!Ref GeminiApiKey, '']]
+        AssertDescription: >-
+          Provide either SecretName (pointing to a Secrets Manager secret with
+          GEMINI_API_KEY) or GeminiApiKey so the Lambda function can access the
+          Gemini API.
 
 Resources:
   ResumeForgeApi:
@@ -137,7 +158,10 @@ Resources:
         Variables:
           S3_BUCKET: !Ref DataBucketName
           RESUME_TABLE_NAME: !Ref ResumeTableName
-          GEMINI_API_KEY: !Ref GeminiApiKey
+          GEMINI_API_KEY: !If
+            - UseSecretName
+            - !Sub '{{resolve:secretsmanager:${SecretName}:SecretString:GEMINI_API_KEY}}'
+            - !Ref GeminiApiKey
           PRIMARY_REGION: !Ref AWS::Region
           SECONDARY_REGION: !Ref SecondaryRegion
       Policies:


### PR DESCRIPTION
## Summary
- allow the SAM template to accept either a Secrets Manager secret or direct parameter value for the Gemini API key
- document the Secrets Manager usage in the deployment instructions and describe the expected JSON structure

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d96ee30df8832bb13166a786326eff