### PR TITLE
Grant Lambda access to Secrets Manager secret

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -78,6 +78,9 @@ Conditions:
   EnableProvisionedConcurrency: !Not [!Equals [!Ref ProvisionedConcurrency, 0]]
   AttachWebAcl: !Not [!Equals [!Ref WebAclArn, '']]
   UseSecretName: !Not [!Equals [!Ref SecretName, '']]
+  SecretIsArn: !And
+    - UseSecretName
+    - !Equals [!Select [0, !Split [":", !Ref SecretName]], 'arn']
 
 Rules:
   RequireGeminiConfiguration:
@@ -182,6 +185,18 @@ Resources:
               Resource: '*'
         - DynamoDBCrudPolicy:
             TableName: !Ref ResumeTableName
+        - !If
+          - UseSecretName
+          - Statement:
+              - Sid: AllowSecretAccess
+                Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: !If
+                  - SecretIsArn
+                  - !Ref SecretName
+                  - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${SecretName}*
+          - !Ref AWS::NoValue
       Layers: []
     Metadata:
       BuildMethod: makefile


### PR DESCRIPTION
## Summary
- allow the Lambda execution role to fetch the configured Gemini API key from Secrets Manager when a secret name is provided
- detect when the SecretName parameter is already an ARN so the IAM policy references it correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9726f1180832b986d67088c02493d