### PR TITLE
Fix SecretIsArn condition syntax

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -79,7 +79,7 @@ Conditions:
   AttachWebAcl: !Not [!Equals [!Ref WebAclArn, '']]
   UseSecretName: !Not [!Equals [!Ref SecretName, '']]
   SecretIsArn: !And
-    - UseSecretName
+    - !Condition UseSecretName
     - !Equals [!Select [0, !Split [":", !Ref SecretName]], 'arn']
 
 Rules:


### PR DESCRIPTION
## Summary
- ensure the SecretIsArn condition uses !Condition when referenced in the Fn::And list to satisfy CloudFormation requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d974edd6ac832b8e6d6973ac290f0b