### PR TITLE
Ensure SAM uploads artifacts on every deploy attempt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,7 @@ jobs:
               --capabilities CAPABILITY_IAM \
               --no-confirm-changeset \
               --no-fail-on-empty-changeset \
+              --force-upload \
               --parameter-overrides \
                 StageName="$STAGE_NAME" \
                 PrimaryRegion="$PRIMARY_REGION" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -247,6 +247,7 @@ jobs:
                 --capabilities CAPABILITY_IAM \
                 --no-confirm-changeset \
                 --no-fail-on-empty-changeset \
+                --force-upload \
                 --parameter-overrides \
                   StageName="$STAGE_NAME" \
                   DataBucketName="$DATA_BUCKET" \


### PR DESCRIPTION
## Summary
- update the CI and deployment workflows to pass `--force-upload` to `sam deploy`
- guarantee that templates and artifacts are re-uploaded even when unchanged so CloudFormation can build change sets successfully

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d976144b88832b9ac19b8e54cfb3f7