### PR TITLE
Grant S3 list/delete permissions to ResumeForge Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,13 @@ Minimal permissions required by the server:
   "Statement": [
     {
       "Effect": "Allow",
-      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
       "Resource": "arn:aws:s3:::S3_BUCKET/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::S3_BUCKET"
     },
     {
       "Effect": "Allow",

--- a/template.yaml
+++ b/template.yaml
@@ -175,7 +175,11 @@ Resources:
               Action:
                 - s3:GetObject
                 - s3:PutObject
-              Resource: !Sub arn:aws:s3:::${DataBucketName}/*
+                - s3:DeleteObject
+                - s3:ListBucket
+              Resource:
+                - !Sub arn:aws:s3:::${DataBucketName}
+                - !Sub arn:aws:s3:::${DataBucketName}/*
             - Sid: AllowWafIntegration
               Effect: Allow
               Action:


### PR DESCRIPTION
## Summary
- extend the Lambda execution role policy to include S3 delete and list permissions needed by the retention job
- update the IAM guidance in the README so required S3 actions are documented for operators

## Testing
- npm test -- --runInBand *(fails: Cannot find module 'handlebars' from 'lib/handlebars.js')*


------
https://chatgpt.com/codex/tasks/task_e_68d9fa82acdc832ba3cf987e5a6d7c0b