### PR TITLE
Fix __dirname handling in Lambda bundle and enhance processing logs

### DIFF
--- a/scripts/build-lambda.mjs
+++ b/scripts/build-lambda.mjs
@@ -75,7 +75,13 @@ async function runEsbuild() {
     banner: {
       js: [
         "import { createRequire as __createRequire } from 'module';",
+        "import { fileURLToPath as __fileURLToPath } from 'url';",
+        "import path from 'path';",
         "const require = __createRequire(import.meta.url);",
+        "const __filename = __fileURLToPath(import.meta.url);",
+        "const __dirname = path.dirname(__filename);",
+        "globalThis.__filename = globalThis.__filename || __filename;",
+        "globalThis.__dirname = globalThis.__dirname || __dirname;",
       ].join('\n'),
     },
   })


### PR DESCRIPTION
## Summary
- ensure the Lambda bundle defines `__filename`/`__dirname` by injecting helpers that derive the values from `import.meta.url`
- add structured logging for each major CV processing stage, including resume ingestion, third-party fetches, AI rewrites, and output generation, so failures surface precise context
- wrap PDF generation in stage-aware logging and rethrow errors with additional detail to make downstream failures easier to diagnose

## Testing
- npm test >/tmp/test.log && tail -n 20 /tmp/test.log
- node scripts/build-lambda.mjs --outdir dist/lambda >/tmp/build.log && tail -n 5 /tmp/build.log

------
https://chatgpt.com/codex/tasks/task_e_68da029bcbc8832bb36c87d17da1a26b