### PR TITLE
Fix PDF link annotations and expand PDF logging

### DIFF
--- a/lib/pdf/templates/2025.js
+++ b/lib/pdf/templates/2025.js
@@ -3,7 +3,8 @@ import {
   StandardFonts,
   rgb,
   PDFName,
-  PDFString
+  PDFString,
+  PDFArray
 } from 'pdf-lib';
 import QRCode from 'qrcode';
 import {
@@ -244,7 +245,13 @@ function addLinkAnnotation(pdfDoc, page, x, y, width, height, url) {
       URI: PDFString.of(url)
     })
   });
-  page.node.addAnnotation(annotation);
+  const annotationRef = context.register(annotation);
+  const annotationsArray = page.node.lookup(PDFName.of('Annots'), PDFArray);
+  if (annotationsArray) {
+    annotationsArray.push(annotationRef);
+  } else {
+    page.node.set(PDFName.of('Annots'), context.obj([annotationRef]));
+  }
 }
 
 function wrapText(font, text, size, maxWidth) {


### PR DESCRIPTION
## Summary
- use pdf-lib annotations API to attach link metadata without runtime errors in the 2025 template
- add debug/error logging around template resolution and rendering steps to clarify PDF generation failures

## Testing
- npm test -- --runTestsByPath tests/generatePdf.test.js

------
https://chatgpt.com/codex/tasks/task_e_68da08677980832b908a0e23a3153268