### PR TITLE
Gracefully handle missing pdf-lib dependency

### DIFF
--- a/lib/pdf/templates/2025.js
+++ b/lib/pdf/templates/2025.js
@@ -1,11 +1,3 @@
-import {
-  PDFDocument,
-  StandardFonts,
-  rgb,
-  PDFName,
-  PDFString,
-  PDFArray
-} from 'pdf-lib';
 import QRCode from 'qrcode';
 import {
   buildSectionMap,
@@ -13,52 +5,40 @@ import {
   uniqueByLowercase
 } from '../utils.js';
 
-const COLOR_VARIANTS = {
-  slate: {
-    accent: rgb(46 / 255, 84 / 255, 140 / 255),
-    accentHighlight: rgb(96 / 255, 140 / 255, 220 / 255),
-    sidebar: rgb(32 / 255, 43 / 255, 64 / 255),
-    sidebarText: rgb(1, 1, 1),
-    sidebarMuted: rgb(208 / 255, 217 / 255, 234 / 255),
-    sidebarBarBackground: rgb(56 / 255, 70 / 255, 98 / 255),
-    text: rgb(36 / 255, 36 / 255, 40 / 255),
-    muted: rgb(108 / 255, 112 / 255, 122 / 255),
-    divider: rgb(200 / 255, 205 / 255, 215 / 255)
-  },
-  midnight: {
-    accent: rgb(38 / 255, 72 / 255, 128 / 255),
-    accentHighlight: rgb(80 / 255, 120 / 255, 210 / 255),
-    sidebar: rgb(18 / 255, 26 / 255, 46 / 255),
-    sidebarText: rgb(233 / 255, 238 / 255, 255 / 255),
-    sidebarMuted: rgb(190 / 255, 198 / 255, 218 / 255),
-    sidebarBarBackground: rgb(42 / 255, 60 / 255, 96 / 255),
-    text: rgb(32 / 255, 32 / 255, 36 / 255),
-    muted: rgb(102 / 255, 106 / 255, 118 / 255),
-    divider: rgb(198 / 255, 205 / 255, 220 / 255)
-  },
-  sunrise: {
-    accent: rgb(198 / 255, 92 / 255, 56 / 255),
-    accentHighlight: rgb(228 / 255, 132 / 255, 92 / 255),
-    sidebar: rgb(78 / 255, 40 / 255, 32 / 255),
-    sidebarText: rgb(255 / 255, 239 / 255, 224 / 255),
-    sidebarMuted: rgb(250 / 255, 210 / 255, 190 / 255),
-    sidebarBarBackground: rgb(112 / 255, 64 / 255, 50 / 255),
-    text: rgb(44 / 255, 36 / 255, 32 / 255),
-    muted: rgb(122 / 255, 88 / 255, 76 / 255),
-    divider: rgb(222 / 255, 196 / 255, 184 / 255)
-  },
-  emerald: {
-    accent: rgb(40 / 255, 132 / 255, 102 / 255),
-    accentHighlight: rgb(84 / 255, 180 / 255, 150 / 255),
-    sidebar: rgb(20 / 255, 70 / 255, 62 / 255),
-    sidebarText: rgb(224 / 255, 246 / 255, 240 / 255),
-    sidebarMuted: rgb(188 / 255, 226 / 255, 216 / 255),
-    sidebarBarBackground: rgb(46 / 255, 108 / 255, 94 / 255),
-    text: rgb(34 / 255, 46 / 255, 40 / 255),
-    muted: rgb(94 / 255, 116 / 255, 104 / 255),
-    divider: rgb(190 / 255, 210 / 255, 204 / 255)
+class PdfLibUnavailableError extends Error {
+  constructor(cause) {
+    super(
+      'pdf-lib dependency is not available. Install pdf-lib to enable the 2025 template.'
+    );
+    this.name = 'PdfLibUnavailableError';
+    this.code = 'PDF_LIB_MISSING';
+    if (cause) {
+      this.cause = cause;
+    }
   }
-};
+}
+
+let pdfLibPromise;
+
+async function loadPdfLib() {
+  if (!pdfLibPromise) {
+    pdfLibPromise = (async () => {
+      try {
+        return await import('pdf-lib');
+      } catch (error) {
+        const message = error?.message || '';
+        if (
+          error?.code === 'ERR_MODULE_NOT_FOUND' ||
+          /Cannot find package 'pdf-lib'/i.test(message)
+        ) {
+          throw new PdfLibUnavailableError(error);
+        }
+        throw error;
+      }
+    })();
+  }
+  return pdfLibPromise;
+}
 
 const PROFICIENCY_MAP = {
   beginner: 0.35,
@@ -73,12 +53,6 @@ const PROFICIENCY_MAP = {
 };
 
 const DEFAULT_VARIANT = 'slate';
-
-function pickPalette(variant) {
-  if (!variant) return COLOR_VARIANTS[DEFAULT_VARIANT];
-  const key = variant.toLowerCase();
-  return COLOR_VARIANTS[key] || COLOR_VARIANTS[DEFAULT_VARIANT];
-}
 
 function parseNumber(value, fallback) {
   const num = Number(value);
@@ -228,12 +202,13 @@ function extractLanguages(languageEntries) {
   return uniqueByLowercase(collected);
 }
 
-function addLinkAnnotation(pdfDoc, page, x, y, width, height, url) {
+function addLinkAnnotation(pdfDoc, page, x, y, width, height, url, primitives) {
   if (!url) return;
   const safeWidth = Math.max(0, width);
   const safeHeight = Math.max(0, height);
   if (!safeWidth || !safeHeight) return;
   const { context } = pdfDoc;
+  const { PDFName, PDFString, PDFArray } = primitives;
   const annotation = context.obj({
     Type: PDFName.of('Annot'),
     Subtype: PDFName.of('Link'),
@@ -288,7 +263,7 @@ function drawSidebarHeading(ctx, text) {
 }
 
 function drawSidebarText(ctx, item) {
-  const { page, fonts, palette, pdfDoc } = ctx;
+  const { page, fonts, palette, pdfDoc, pdfPrimitives } = ctx;
   const lines = (item.value || item.text || '')
     .split(/\n+/)
     .map((line) => line.trim())
@@ -306,7 +281,16 @@ function drawSidebarText(ctx, item) {
     });
     if (item.href) {
       const width = fonts.regular.widthOfTextAtSize(line, ctx.sidebarBodySize);
-      addLinkAnnotation(pdfDoc, page, ctx.x, y - 2, width, ctx.sidebarBodySize + 4, item.href);
+      addLinkAnnotation(
+        pdfDoc,
+        page,
+        ctx.x,
+        y - 2,
+        width,
+        ctx.sidebarBodySize + 4,
+        item.href,
+        pdfPrimitives
+      );
     }
     ctx.y = y - ctx.sidebarBodySize - ctx.sidebarLineGap;
   }
@@ -375,7 +359,7 @@ function drawRightHeading(ctx, text) {
 }
 
 function drawParagraph(ctx, text, { bullet = false, font, color, link } = {}) {
-  const { page, fonts, palette, pdfDoc } = ctx;
+  const { page, fonts, palette, pdfDoc, pdfPrimitives } = ctx;
   const bodyFont = font || fonts.regular;
   const size = ctx.bodySize;
   const paragraphs = text.split(/\n+/).filter(Boolean);
@@ -405,7 +389,16 @@ function drawParagraph(ctx, text, { bullet = false, font, color, link } = {}) {
       });
       if (link && index === 0) {
         const width = bodyFont.widthOfTextAtSize(line, size);
-        addLinkAnnotation(pdfDoc, page, textX, y - 2, width, size + 4, link);
+        addLinkAnnotation(
+          pdfDoc,
+          page,
+          textX,
+          y - 2,
+          width,
+          size + 4,
+          link,
+          pdfPrimitives
+        );
       }
       ctx.y = y - size - lineGap;
     });
@@ -479,6 +472,70 @@ export async function render2025Template({
   options = {},
   templateParams = {}
 }) {
+  const {
+    PDFDocument,
+    StandardFonts,
+    rgb,
+    PDFName,
+    PDFString,
+    PDFArray
+  } = await loadPdfLib();
+
+  const COLOR_VARIANTS = {
+    slate: {
+      accent: rgb(46 / 255, 84 / 255, 140 / 255),
+      accentHighlight: rgb(96 / 255, 140 / 255, 220 / 255),
+      sidebar: rgb(32 / 255, 43 / 255, 64 / 255),
+      sidebarText: rgb(1, 1, 1),
+      sidebarMuted: rgb(208 / 255, 217 / 255, 234 / 255),
+      sidebarBarBackground: rgb(56 / 255, 70 / 255, 98 / 255),
+      text: rgb(36 / 255, 36 / 255, 40 / 255),
+      muted: rgb(108 / 255, 112 / 255, 122 / 255),
+      divider: rgb(200 / 255, 205 / 255, 215 / 255)
+    },
+    midnight: {
+      accent: rgb(38 / 255, 72 / 255, 128 / 255),
+      accentHighlight: rgb(80 / 255, 120 / 255, 210 / 255),
+      sidebar: rgb(18 / 255, 26 / 255, 46 / 255),
+      sidebarText: rgb(233 / 255, 238 / 255, 255 / 255),
+      sidebarMuted: rgb(190 / 255, 198 / 255, 218 / 255),
+      sidebarBarBackground: rgb(42 / 255, 60 / 255, 96 / 255),
+      text: rgb(32 / 255, 32 / 255, 36 / 255),
+      muted: rgb(102 / 255, 106 / 255, 118 / 255),
+      divider: rgb(198 / 255, 205 / 255, 220 / 255)
+    },
+    sunrise: {
+      accent: rgb(198 / 255, 92 / 255, 56 / 255),
+      accentHighlight: rgb(228 / 255, 132 / 255, 92 / 255),
+      sidebar: rgb(78 / 255, 40 / 255, 32 / 255),
+      sidebarText: rgb(255 / 255, 239 / 255, 224 / 255),
+      sidebarMuted: rgb(250 / 255, 210 / 255, 190 / 255),
+      sidebarBarBackground: rgb(112 / 255, 64 / 255, 50 / 255),
+      text: rgb(44 / 255, 36 / 255, 32 / 255),
+      muted: rgb(122 / 255, 88 / 255, 76 / 255),
+      divider: rgb(222 / 255, 196 / 255, 184 / 255)
+    },
+    emerald: {
+      accent: rgb(40 / 255, 132 / 255, 102 / 255),
+      accentHighlight: rgb(84 / 255, 180 / 255, 150 / 255),
+      sidebar: rgb(20 / 255, 70 / 255, 62 / 255),
+      sidebarText: rgb(224 / 255, 246 / 255, 240 / 255),
+      sidebarMuted: rgb(188 / 255, 226 / 255, 216 / 255),
+      sidebarBarBackground: rgb(46 / 255, 108 / 255, 94 / 255),
+      text: rgb(34 / 255, 46 / 255, 40 / 255),
+      muted: rgb(94 / 255, 116 / 255, 104 / 255),
+      divider: rgb(190 / 255, 210 / 255, 204 / 255)
+    }
+  };
+
+  function pickPalette(variant) {
+    if (!variant) return COLOR_VARIANTS[DEFAULT_VARIANT];
+    const key = variant.toLowerCase();
+    return COLOR_VARIANTS[key] || COLOR_VARIANTS[DEFAULT_VARIANT];
+  }
+
+  const pdfPrimitives = { PDFName, PDFString, PDFArray };
+
   const pdfDoc = await PDFDocument.create();
   const fonts = {
     regular: await pdfDoc.embedFont(StandardFonts.Helvetica),
@@ -592,6 +649,7 @@ export async function render2025Template({
 
   const sidebarContext = {
     pdfDoc,
+    pdfPrimitives,
     page: firstPage.page,
     x: marginLeft - sidebarPadding + sidebarPadding,
     y: columnStartY,
@@ -610,6 +668,7 @@ export async function render2025Template({
 
   const rightContext = {
     pdfDoc,
+    pdfPrimitives,
     page: firstPage.page,
     x: rightColumnX,
     y: columnStartY,
@@ -698,7 +757,8 @@ export async function render2025Template({
           sidebarContext.y - 2,
           width,
           sidebarBodySize + 4,
-          detail.href
+          detail.href,
+          pdfPrimitives
         );
       }
       sidebarContext.y -= sidebarBodySize + sidebarLineGap;


### PR DESCRIPTION
## Summary
- load the pdf-lib module lazily for the 2025 renderer and raise a clear PDF_LIB_MISSING error when the dependency is absent
- attach pdf-lib primitives to rendering contexts so link annotations work after the lazy import refactor
- add structured logging for successful PDF renderer completion and fallback when pdf-lib is unavailable, defaulting to the modern template instead of failing

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68da113ce78c832b989f9f49717c7343