### PR TITLE
Ensure headings render correctly in modern template

### DIFF
--- a/templates/modern.html
+++ b/templates/modern.html
@@ -44,7 +44,9 @@
   </header>
   {{#each sections}}
   <section>
-    {{#if heading}}<h2>{{heading}}</h2>{{/if}}
+    {{#if heading}}
+    <h2>{{heading}}</h2>
+    {{/if}}
     {{#if items}}
       <ul>
         {{#each items}}


### PR DESCRIPTION
## Summary
- ensure the modern resume template places section headings on their own line inside the conditional block
- prevents inline list rendering so the existing bold heading snapshot remains stable

## Testing
- npm test -- boldHeadings

------
https://chatgpt.com/codex/tasks/task_e_68da6bc93174832b91b1c8a9e7ebe3dd