### PR TITLE
Enhance ATS dashboard accessibility and test coverage

### DIFF
--- a/client/src/components/ATSScoreDashboard.jsx
+++ b/client/src/components/ATSScoreDashboard.jsx
@@ -31,7 +31,7 @@ function ATSScoreDashboard({ metrics = [], match }) {
   const matchDelta = formatDelta(match?.originalScore, match?.enhancedScore)
 
   return (
-    <section className="space-y-6" aria-label="ATS dashboard">
+    <section className="space-y-6" aria-label="ATS dashboard" aria-live="polite">
       <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
         <div>
           <h2 className="text-2xl font-bold text-purple-900">ATS Performance Dashboard</h2>
@@ -40,7 +40,10 @@ function ATSScoreDashboard({ metrics = [], match }) {
           </p>
         </div>
         {match && (
-          <div className="flex items-center gap-3 text-xs font-semibold uppercase tracking-widest text-purple-600">
+          <div
+            className="flex items-center gap-3 text-xs font-semibold uppercase tracking-widest text-purple-600"
+            data-testid="dashboard-live-indicator"
+          >
             <span className="rounded-full bg-purple-100 px-3 py-1">Live Update</span>
             <span>Synced with latest analysis</span>
           </div>

--- a/client/src/components/TemplateSelector.jsx
+++ b/client/src/components/TemplateSelector.jsx
@@ -3,8 +3,16 @@ function TemplateSelector({ options = [], selectedTemplate, onSelect, disabled =
 
   return (
     <div className="space-y-2">
-      <label className="text-sm font-semibold text-purple-700">Template Style</label>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3" data-testid="template-selector">
+      <label className="text-sm font-semibold text-purple-700" htmlFor="template-selector">
+        Template Style
+      </label>
+      <div
+        id="template-selector"
+        role="radiogroup"
+        className="grid grid-cols-1 md:grid-cols-2 gap-3"
+        data-testid="template-selector"
+        aria-label="Resume template styles"
+      >
         {options.map((option) => {
           const isSelected = option.id === selectedTemplate
           const stateClass = isSelected
@@ -15,11 +23,15 @@ function TemplateSelector({ options = [], selectedTemplate, onSelect, disabled =
             <button
               key={option.id}
               type="button"
+              role="radio"
+              aria-checked={isSelected}
+              aria-disabled={disabled || undefined}
               onClick={() => onSelect?.(option.id)}
               disabled={disabled}
               className={`text-left rounded-2xl border p-4 transition transform hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-purple-400 ${stateClass} ${
                 disabled ? 'cursor-not-allowed opacity-60' : ''
               }`}
+              data-testid={`template-option-${option.id}`}
             >
               <h3 className="text-lg font-semibold text-purple-800">{option.name}</h3>
               <p className="text-sm text-purple-600">{option.description}</p>

--- a/client/src/components/__tests__/ATSScoreDashboard.test.jsx
+++ b/client/src/components/__tests__/ATSScoreDashboard.test.jsx
@@ -28,6 +28,7 @@ describe('ATSScoreDashboard', () => {
     expect(screen.getByLabelText('match comparison')).toBeInTheDocument()
     expect(screen.getByTestId('original-score')).toHaveTextContent('48')
     expect(screen.getByTestId('enhanced-score')).toHaveTextContent('76')
+    expect(screen.getByTestId('dashboard-live-indicator')).toBeInTheDocument()
   })
 
   it('updates to reflect new scores immediately when data changes', () => {

--- a/client/src/components/__tests__/TemplateSelector.test.jsx
+++ b/client/src/components/__tests__/TemplateSelector.test.jsx
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import TemplateSelector from '../TemplateSelector.jsx'
+
+describe('TemplateSelector', () => {
+  const options = [
+    { id: 'modern', name: 'Modern Minimal', description: 'Two-column balance.' },
+    { id: 'professional', name: 'Professional Blue', description: 'Classic layout.' }
+  ]
+
+  it('renders options and highlights the selected template', () => {
+    const { rerender } = render(
+      <TemplateSelector
+        options={options}
+        selectedTemplate="modern"
+        onSelect={jest.fn()}
+      />
+    )
+
+    const selectedBadge = within(screen.getByTestId('template-option-modern')).getByText(/selected/i)
+    expect(selectedBadge).toBeInTheDocument()
+    expect(
+      within(screen.getByTestId('template-option-professional')).queryByText(/selected/i)
+    ).not.toBeInTheDocument()
+
+    rerender(
+      <TemplateSelector
+        options={options}
+        selectedTemplate="professional"
+        onSelect={jest.fn()}
+      />
+    )
+
+    const newlySelectedBadge = within(screen.getByTestId('template-option-professional')).getByText(/selected/i)
+    expect(newlySelectedBadge).toBeInTheDocument()
+  })
+
+  it('invokes onSelect when a template is chosen', () => {
+    const handleSelect = jest.fn()
+    render(
+      <TemplateSelector
+        options={options}
+        selectedTemplate="modern"
+        onSelect={handleSelect}
+      />
+    )
+
+    const optionButton = screen.getByTestId('template-option-professional')
+    fireEvent.click(optionButton)
+
+    expect(handleSelect).toHaveBeenCalledWith('professional')
+  })
+
+  it('respects the disabled state', () => {
+    const handleSelect = jest.fn()
+    render(
+      <TemplateSelector
+        options={options}
+        selectedTemplate="modern"
+        onSelect={handleSelect}
+        disabled
+      />
+    )
+
+    const optionButton = screen.getByTestId('template-option-professional')
+    expect(optionButton).toBeDisabled()
+    fireEvent.click(optionButton)
+    expect(handleSelect).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- mark the ATS dashboard section as live and expose a test-friendly live update indicator
- upgrade the template selector to an accessible radio-style control with testing hooks
- add TemplateSelector rendering tests and extend dashboard tests to cover the live indicator

## Testing
- npm test -- --runTestsByPath client/src/components/__tests__/ATSScoreCard.test.jsx client/src/components/__tests__/ATSScoreDashboard.test.jsx client/src/components/__tests__/TemplateSelector.test.jsx *(fails: jest-environment-jsdom and @babel/preset-env packages are not resolved in the test runner)*

------
https://chatgpt.com/codex/tasks/task_e_68dad93cd588832baf000d2143853639