### PR TITLE
Add workflow concurrency to prevent overlapping deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ on:
       - v2
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary
- add a workflow-level concurrency group so only one deploy job runs per branch at a time
- avoid overlapping AWS CloudFormation updates that caused stack status validation errors

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dcdf0b8e38832ba659e9e2641fc5b9