### PR TITLE
Support DOC and DOCX resume uploads

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -210,8 +210,8 @@ function App() {
   const handleDrop = useCallback((e) => {
     e.preventDefault()
     const file = e.dataTransfer.files[0]
-    if (file && !file.name.toLowerCase().match(/\.(pdf|docx)$/)) {
-      setError('Only PDF or DOCX files are supported.')
+    if (file && !file.name.toLowerCase().match(/\.(pdf|docx?)$/)) {
+      setError('Only PDF, DOC, or DOCX files are supported.')
       return
     }
     if (file) setCvFile(file)
@@ -219,8 +219,8 @@ function App() {
 
   const handleFileChange = (e) => {
     const file = e.target.files[0]
-    if (file && !file.name.toLowerCase().match(/\.(pdf|docx)$/)) {
-      setError('Only PDF or DOCX files are supported.')
+    if (file && !file.name.toLowerCase().match(/\.(pdf|docx?)$/)) {
+      setError('Only PDF, DOC, or DOCX files are supported.')
       return
     }
     if (file) setCvFile(file)
@@ -486,12 +486,12 @@ function App() {
               <p className="text-purple-800 font-semibold">{cvFile.name}</p>
             ) : (
               <p className="text-purple-700">
-                Drag and drop your CV here, or click to select (PDF or DOCX, max 5MB)
+                Drag and drop your CV here, or click to select (PDF, DOC, or DOCX · max 5MB)
               </p>
             )}
             <input
               type="file"
-              accept=".pdf,.docx"
+              accept=".pdf,.doc,.docx"
               onChange={handleFileChange}
               className="hidden"
               id="cv-input"

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "pdf-parse": "^1.1.1",
         "pdfkit": "^0.13.0",
         "qrcode": "^1.5.4",
-        "ua-parser-js": "^1.0.35"
+        "ua-parser-js": "^1.0.35",
+        "word-extractor": "^1.0.4"
       },
       "devDependencies": {
         "@babel/core": "^7.24.5",
@@ -6366,6 +6367,15 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -7404,6 +7414,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fill-range": {
@@ -10152,6 +10171,12 @@
         "png-js": "^1.0.0"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -11798,6 +11823,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/word-extractor": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/word-extractor/-/word-extractor-1.0.4.tgz",
+      "integrity": "sha512-PyAGZQ2gjnVA5kcZAOAxoYciCMaAvu0dbVlw/zxHphhy+3be8cDeYKHJPO8iedIM3Sx0arA/ugKTJyXhZNgo6g==",
+      "license": "MIT",
+      "dependencies": {
+        "saxes": "^5.0.1",
+        "yauzl": "^2.10.0"
+      }
+    },
+    "node_modules/word-extractor/node_modules/saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -11906,7 +11953,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/xtend": {
@@ -11962,6 +12008,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "pdf-parse": "^1.1.1",
     "pdfkit": "^0.13.0",
     "qrcode": "^1.5.4",
-    "ua-parser-js": "^1.0.35"
+    "ua-parser-js": "^1.0.35",
+    "word-extractor": "^1.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",

--- a/tests/utils/testServer.js
+++ b/tests/utils/testServer.js
@@ -88,6 +88,21 @@ export async function setupTestServer({
     default: jest.fn().mockResolvedValue({ text: pdfText }),
   }));
 
+  const wordExtractorExtractMock = jest.fn().mockResolvedValue({
+    getBody: () => 'Doc body text',
+    getHeaders: () => ['Header text'],
+    getFooters: () => ['Footer text'],
+    getText: () => 'Doc fallback text',
+  });
+
+  jest.unstable_mockModule('word-extractor', () => ({
+    default: class WordExtractorMock {
+      extract(filePath) {
+        return wordExtractorExtractMock(filePath);
+      }
+    }
+  }));
+
   jest.unstable_mockModule('mammoth', () => ({
     default: { extractRawText: jest.fn().mockResolvedValue({ value: 'Doc text' }) },
   }));


### PR DESCRIPTION
## Summary
- allow PDF, DOC, and DOCX resumes to be uploaded and parsed end-to-end, including new Word extraction logic
- refine invalid document messaging to guide users to upload a correct CV
- expand test coverage and mocks to exercise the new document support paths

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dce54e043c832ba2a08a5533d71aca