### PR TITLE
Log resume uploads to Dynamo immediately and update metadata later

### DIFF
--- a/tests/awsStorage.integration.test.js
+++ b/tests/awsStorage.integration.test.js
@@ -43,6 +43,16 @@ describe('AWS integrations for /api/process-cv', () => {
     expect(dynamoPut[0].input.Item.linkedinProfileUrl.S).toBe(
       hash('https://linkedin.com/in/example')
     );
+    expect(dynamoPut[0].input.Item.status.S).toBe('uploaded');
+
+    const dynamoUpdate = mocks.mockDynamoSend.mock.calls.find(
+      ([command]) => command.__type === 'UpdateItemCommand'
+    );
+    expect(dynamoUpdate).toBeTruthy();
+    expect(dynamoUpdate[0].input.ExpressionAttributeValues[':status'].S).toBe(
+      'completed'
+    );
+    expect(dynamoUpdate[0].input.UpdateExpression).toContain('analysisCompletedAt');
 
     expect(mocks.logEventMock).toHaveBeenCalledWith(
       expect.objectContaining({ event: 'uploaded_metadata' })
@@ -103,6 +113,7 @@ describe('AWS integrations for /api/process-cv', () => {
       'CreateTableCommand',
       'DescribeTableCommand',
       'PutItemCommand',
+      'UpdateItemCommand',
     ]);
   });
 });

--- a/tests/mocks/aws-sdk-client-dynamodb.js
+++ b/tests/mocks/aws-sdk-client-dynamodb.js
@@ -22,3 +22,9 @@ export class PutItemCommand {
     this.__type = 'PutItemCommand';
   }
 }
+export class UpdateItemCommand {
+  constructor(input) {
+    this.input = input;
+    this.__type = 'UpdateItemCommand';
+  }
+}

--- a/tests/utils/testServer.js
+++ b/tests/utils/testServer.js
@@ -73,6 +73,7 @@ export async function setupTestServer({
     CreateTableCommand: jest.fn((input) => ({ input, __type: 'CreateTableCommand' })),
     DescribeTableCommand: jest.fn((input) => ({ input, __type: 'DescribeTableCommand' })),
     PutItemCommand: jest.fn((input) => ({ input, __type: 'PutItemCommand' })),
+    UpdateItemCommand: jest.fn((input) => ({ input, __type: 'UpdateItemCommand' })),
   }));
 
   const loggerModulePath = new URL('../../logger.js', import.meta.url).pathname;


### PR DESCRIPTION
## Summary
- ensure /api/process-cv provisions the DynamoDB table once per request and writes an initial anonymised metadata record as soon as the CV is stored in S3
- update that DynamoDB entry after analysis to add generated asset URLs, scores, and status using UpdateItem, and log both success and error paths
- adjust server and integration tests to expect the new Dynamo interactions and mock the UpdateItem command

## Testing
- node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/server.test.js tests/awsStorage.integration.test.js --silent

------
https://chatgpt.com/codex/tasks/task_e_68dce9135bd0832ba10b8008e4719be5