### PR TITLE
Fix DynamoDB update expression for status attribute

### DIFF
--- a/server.js
+++ b/server.js
@@ -6483,7 +6483,7 @@ app.post(
       'cv2Url = :cv2',
       'coverLetter1Url = :cl1',
       'coverLetter2Url = :cl2',
-      'status = :status',
+      '#status = :status',
       'analysisCompletedAt = :completedAt',
       'missingSkills = :missingSkills',
       'addedSkills = :addedSkills'
@@ -6521,6 +6521,7 @@ app.post(
         Key: { linkedinProfileUrl: { S: anonymizedLinkedIn } },
         UpdateExpression: `SET ${updateParts.join(', ')}`,
         ExpressionAttributeValues: expressionValues,
+        ExpressionAttributeNames: { '#status': 'status' },
         ConditionExpression: 'jobId = :jobId'
       })
     );

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -305,6 +305,10 @@ describe('/api/process-cv', () => {
     expect(updateCall[0].input.ExpressionAttributeValues[':status'].S).toBe(
       'completed'
     );
+    expect(updateCall[0].input.ExpressionAttributeNames['#status']).toBe(
+      'status'
+    );
+    expect(updateCall[0].input.UpdateExpression).toContain('#status');
     expect(updateCall[0].input.UpdateExpression).toContain('cv1Url');
     expect(updateCall[0].input.UpdateExpression).toContain('coverLetter1Url');
 


### PR DESCRIPTION
## Summary
- alias the DynamoDB `status` attribute when updating processed resume metadata to avoid reserved word errors
- update the server test expectations to cover the aliased status attribute

## Testing
- npm test -- tests/server.test.js *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68dd075a3044832b92f100a4be2ef5ab