### PR TITLE
Normalize score breakdown tips in dashboard

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -373,7 +373,13 @@ function App() {
       const breakdownArray = Array.isArray(data.scoreBreakdown)
         ? data.scoreBreakdown
         : Object.values(data.scoreBreakdown || {})
-      setScoreBreakdown(breakdownArray)
+      const normalizedBreakdown = breakdownArray
+        .filter(Boolean)
+        .map((metric) => ({
+          ...metric,
+          tip: metric?.tip ?? metric?.tips?.[0] ?? '',
+        }))
+      setScoreBreakdown(normalizedBreakdown)
       setResumeText(data.resumeText || '')
       setJobDescriptionText(data.jobDescriptionText || '')
       setJobSkills(data.jobSkills || [])

--- a/client/src/components/ATSScoreCard.jsx
+++ b/client/src/components/ATSScoreCard.jsx
@@ -38,7 +38,7 @@ function ATSScoreCard({ metric, accentClass = defaultAccent }) {
   const badgeClass = badgeThemes[ratingLabel] || badgeThemes.GOOD
   const labelClass = labelTone[ratingLabel] || labelTone.GOOD
   const { display: scoreDisplay, suffix: scoreSuffix } = formatScore(metric?.score)
-  const tip = metric?.tip ?? ''
+  const tip = metric?.tip ?? metric?.tips?.[0] ?? ''
   const category = metric?.category ?? 'Metric'
 
   return (

--- a/client/src/components/__tests__/ATSScoreDashboard.test.jsx
+++ b/client/src/components/__tests__/ATSScoreDashboard.test.jsx
@@ -6,11 +6,36 @@ import ATSScoreDashboard from '../ATSScoreDashboard.jsx'
 
 describe('ATSScoreDashboard', () => {
   const metrics = [
-    { category: 'Keyword Match', score: 82, ratingLabel: 'Excellent', tip: 'Optimise your summary to mirror the JD headline.' },
-    { category: 'Skills Coverage', score: 76, ratingLabel: 'Good', tip: 'Blend missing keywords into experience bullets.' },
-    { category: 'Format Compliance', score: 91, ratingLabel: 'Excellent', tip: 'Keep headings concise for ATS parsing.' },
-    { category: 'Readability', score: 70, ratingLabel: 'Good', tip: 'Shorten longer paragraphs into high-impact bullets.' },
-    { category: 'Experience Alignment', score: 65, ratingLabel: 'Needs Improvement', tip: 'Lead with quantified outcomes tied to job priorities.' }
+    {
+      category: 'Keyword Match',
+      score: 82,
+      ratingLabel: 'Excellent',
+      tips: ['Optimise your summary to mirror the JD headline.'],
+    },
+    {
+      category: 'Skills Coverage',
+      score: 76,
+      ratingLabel: 'Good',
+      tips: ['Blend missing keywords into experience bullets.'],
+    },
+    {
+      category: 'Format Compliance',
+      score: 91,
+      ratingLabel: 'Excellent',
+      tips: ['Keep headings concise for ATS parsing.'],
+    },
+    {
+      category: 'Readability',
+      score: 70,
+      ratingLabel: 'Good',
+      tips: ['Shorten longer paragraphs into high-impact bullets.'],
+    },
+    {
+      category: 'Experience Alignment',
+      score: 65,
+      ratingLabel: 'Needs Improvement',
+      tips: ['Lead with quantified outcomes tied to job priorities.'],
+    }
   ]
 
   const match = {


### PR DESCRIPTION
## Summary
- normalize score breakdown metrics in the client to expose a primary tip for the ATS dashboard
- ensure ATS score cards fallback to API-provided tips arrays and adjust component tests accordingly

## Testing
- npm test -- --runTestsByPath client/src/components/__tests__/ATSScoreDashboard.test.jsx *(fails: missing jest-environment-jsdom / @babel/preset-env in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2a2bc478832b8123eec1fc96fc23