### PR TITLE
Add aggregated enhance-all change summaries

### DIFF
--- a/tests/enforceTargetedUpdate.test.js
+++ b/tests/enforceTargetedUpdate.test.js
@@ -62,5 +62,15 @@ describe('enforceTargetedUpdate', () => {
     expect(educationIndex).toBeGreaterThan(-1);
     expect(projectsIndex).toBeLessThan(experienceIndex);
     expect(experienceIndex).toBeLessThan(educationIndex);
+
+    expect(Array.isArray(result.changeDetails)).toBe(true);
+    const sections = result.changeDetails.map((detail) => detail.section || detail.label);
+    expect(sections).toEqual(
+      expect.arrayContaining(['Summary', 'Skills', 'Work Experience', 'Headline'])
+    );
+    result.changeDetails.forEach((detail) => {
+      expect(Array.isArray(detail.reasons)).toBe(true);
+      expect(detail.reasons.length).toBeGreaterThan(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- capture per-section change metadata when running the enhance-all improvement on the backend
- expose the aggregated summary to the client so the change log and explanations show a combined "Improve All" changelog
- extend the enhance-all unit test to assert the new change details payload

## Testing
- npm test -- --runTestsByPath tests/enforceTargetedUpdate.test.js *(fails: Cannot find package '@babel/preset-env' imported from babel-virtual-resolve-base.js)*

------
https://chatgpt.com/codex/tasks/task_e_68dd58ba3ad0832b92c0d153615e4dfb