### PR TITLE
Preserve resume formatting cues in pdf-lib renderer

### DIFF
--- a/lib/pdf/templates/2025.js
+++ b/lib/pdf/templates/2025.js
@@ -231,22 +231,123 @@ function addLinkAnnotation(pdfDoc, page, x, y, width, height, url, primitives) {
 }
 
 function wrapText(font, text, size, maxWidth) {
-  const words = text.split(/\s+/);
+  if (!text) return [''];
+  const tokens = text.match(/(\s+|\S+)/g) || [];
   const lines = [];
   let current = '';
-  for (const word of words) {
-    if (!word) continue;
-    const tentative = current ? `${current} ${word}` : word;
-    const width = font.widthOfTextAtSize(tentative, size);
-    if (width <= maxWidth || !current) {
-      current = tentative;
-    } else {
-      lines.push(current);
-      current = word;
+  let currentWidth = 0;
+
+  const measure = (value) => font.widthOfTextAtSize(value, size);
+
+  for (const token of tokens) {
+    if (!token) continue;
+    const tokenWidth = measure(token);
+    const isWhitespace = /^\s+$/.test(token);
+    if (!current) {
+      current = token;
+      currentWidth = tokenWidth;
+      continue;
     }
+    if (!isWhitespace && currentWidth + tokenWidth > maxWidth) {
+      lines.push(current);
+      current = token;
+      currentWidth = tokenWidth;
+      continue;
+    }
+    current += token;
+    currentWidth += tokenWidth;
   }
+
   if (current) lines.push(current);
   return lines.length ? lines : [''];
+}
+
+function selectFont(fonts, style) {
+  if (style === 'bold' || style === 'bolditalic') return fonts.bold;
+  if (style === 'italic') return fonts.italic;
+  return fonts.regular;
+}
+
+function paragraphSlices(text) {
+  const slices = [];
+  if (!text) return slices;
+  let index = 0;
+  const length = text.length;
+  while (index < length) {
+    while (index < length && text[index] === '\n') index += 1;
+    if (index >= length) break;
+    let end = index;
+    while (end < length && text[end] !== '\n') end += 1;
+    const chunk = text.slice(index, end);
+    if (/[^\s]/.test(chunk)) {
+      slices.push({ text: chunk, start: index, end });
+    }
+    index = end + 1;
+  }
+  return slices;
+}
+
+function segmentLine(line, absoluteStart, styleRanges = [], linkRanges = []) {
+  const boundaries = new Set([0, line.length]);
+  for (const range of styleRanges) {
+    if (range.start > absoluteStart && range.start < absoluteStart + line.length) {
+      boundaries.add(range.start - absoluteStart);
+    }
+    if (range.end > absoluteStart && range.end < absoluteStart + line.length) {
+      boundaries.add(range.end - absoluteStart);
+    }
+  }
+  for (const range of linkRanges) {
+    if (range.start > absoluteStart && range.start < absoluteStart + line.length) {
+      boundaries.add(range.start - absoluteStart);
+    }
+    if (range.end > absoluteStart && range.end < absoluteStart + line.length) {
+      boundaries.add(range.end - absoluteStart);
+    }
+  }
+  const sorted = Array.from(boundaries).sort((a, b) => a - b);
+  const segments = [];
+  for (let i = 0; i < sorted.length - 1; i += 1) {
+    const segStart = sorted[i];
+    const segEnd = sorted[i + 1];
+    if (segEnd <= segStart) continue;
+    const text = line.slice(segStart, segEnd);
+    if (!text) continue;
+    const absoluteSegStart = absoluteStart + segStart;
+    const absoluteSegEnd = absoluteStart + segEnd;
+    const styleRange = styleRanges.find(
+      (range) => range.start < absoluteSegEnd && range.end > absoluteSegStart
+    );
+    const linkRange = linkRanges.find(
+      (range) => range.start < absoluteSegEnd && range.end > absoluteSegStart
+    );
+    segments.push({
+      text,
+      style: styleRange?.style,
+      href: linkRange?.href
+    });
+  }
+  return segments;
+}
+
+function normalizeEntry(entryOrText) {
+  if (entryOrText && typeof entryOrText === 'object' && entryOrText.text !== undefined) {
+    return {
+      text: entryOrText.text || '',
+      bullet: Boolean(entryOrText.bullet),
+      links: Array.isArray(entryOrText.links) ? entryOrText.links : [],
+      styleRanges: entryOrText.styleRanges || [],
+      linkRanges: entryOrText.linkRanges || []
+    };
+  }
+  const text = typeof entryOrText === 'string' ? entryOrText : '';
+  return {
+    text,
+    bullet: false,
+    links: [],
+    styleRanges: [],
+    linkRanges: []
+  };
 }
 
 function drawSidebarHeading(ctx, text) {
@@ -359,50 +460,82 @@ function drawRightHeading(ctx, text) {
   ctx.y = lineY - ctx.sectionGap / 2;
 }
 
-function drawParagraph(ctx, text, { bullet = false, font, color, link } = {}) {
+function drawParagraph(ctx, entryInput, { bullet = false, font, color } = {}) {
+  const entry = normalizeEntry(entryInput);
+  if (!entry.text) return;
   const { page, fonts, palette, pdfDoc, pdfPrimitives } = ctx;
-  const bodyFont = font || fonts.regular;
+  const baseFont = font || fonts.regular;
   const size = ctx.bodySize;
-  const paragraphs = text.split(/\n+/).filter(Boolean);
   const lineGap = ctx.lineGap;
   const bulletIndent = bullet ? ctx.bulletIndent : 0;
-  for (const paragraph of paragraphs) {
-    const lines = wrapText(bodyFont, paragraph, size, ctx.width - bulletIndent);
-    lines.forEach((line, index) => {
+  const segments = paragraphSlices(entry.text);
+  if (!segments.length) return;
+
+  let firstLine = true;
+  const defaultColor = color || palette.text;
+
+  for (const paragraph of segments) {
+    const lines = wrapText(baseFont, paragraph.text, size, ctx.width - bulletIndent);
+    if (!lines.length) continue;
+    let consumed = 0;
+    for (const line of lines) {
       ensureRightSpace(ctx, size + lineGap + 1);
       const y = ctx.y;
-      if (bullet && index === 0) {
+      if (bullet && firstLine) {
         page.drawText('•', {
           x: ctx.x,
           y,
           size,
           font: fonts.bold,
-          color: color || palette.text
+          color: defaultColor
         });
       }
+      const lineStart = paragraph.start + consumed;
+      consumed += line.length;
       const textX = ctx.x + bulletIndent;
-      page.drawText(line, {
-        x: textX,
-        y,
-        size,
-        font: bodyFont,
-        color: color || palette.text
-      });
-      if (link && index === 0) {
-        const width = bodyFont.widthOfTextAtSize(line, size);
-        addLinkAnnotation(
-          pdfDoc,
-          page,
-          textX,
-          y - 2,
-          width,
-          size + 4,
-          link,
-          pdfPrimitives
-        );
+      let cursorX = textX;
+      const lineSegments = segmentLine(
+        line,
+        lineStart,
+        entry.styleRanges,
+        entry.linkRanges
+      );
+      const renderSegments = lineSegments.length ? lineSegments : [{ text: line }];
+      for (const segment of renderSegments) {
+        const segText = segment.text;
+        if (!segText) continue;
+        const segmentFont = segment.style ? selectFont(fonts, segment.style) : baseFont;
+        const segIsWhitespace = /^\s+$/.test(segText);
+        const width = segmentFont.widthOfTextAtSize(segText, size);
+        if (segIsWhitespace && !segment.href) {
+          cursorX += width;
+          continue;
+        }
+        const segColor = segment.href ? palette.accent : defaultColor;
+        page.drawText(segText, {
+          x: cursorX,
+          y,
+          size,
+          font: segmentFont,
+          color: segColor
+        });
+        if (segment.href) {
+          addLinkAnnotation(
+            pdfDoc,
+            page,
+            cursorX,
+            y - 2,
+            width,
+            size + 4,
+            segment.href,
+            pdfPrimitives
+          );
+        }
+        cursorX += width;
       }
       ctx.y = y - size - lineGap;
-    });
+      firstLine = false;
+    }
   }
 }
 
@@ -411,8 +544,7 @@ function drawRightEntries(ctx, entries, { allowBullets = true, placeholder } = {
   for (const entry of items) {
     if (!entry || !entry.text) continue;
     const bullet = allowBullets && entry.bullet;
-    const hasLink = entry.links && entry.links.length ? entry.links[0].href : undefined;
-    drawParagraph(ctx, entry.text, { bullet, link: hasLink });
+    drawParagraph(ctx, entry, { bullet });
     ctx.y -= ctx.paragraphGap;
   }
 }
@@ -421,7 +553,7 @@ function drawProjectSection(ctx, entries, fallback) {
   const items = entries && entries.length ? entries : fallback ? [{ text: fallback }] : [];
   for (const entry of items) {
     if (!entry || !entry.text) continue;
-    drawParagraph(ctx, entry.text, { bullet: true });
+    drawParagraph(ctx, entry, { bullet: true });
     ctx.y -= ctx.paragraphGap;
   }
 }

--- a/lib/pdf/utils.js
+++ b/lib/pdf/utils.js
@@ -20,50 +20,89 @@ export function buildSectionMap(sections = []) {
 }
 
 export function tokensToEntry(tokens = []) {
-  const entry = { text: '', bullet: false, links: [] };
+  const entry = {
+    text: '',
+    bullet: false,
+    links: [],
+    tokens: [],
+    styleRanges: [],
+    linkRanges: []
+  };
   if (!Array.isArray(tokens)) return entry;
+
   const parts = [];
+  const normalizedTokens = [];
+  const seenLinks = new Set();
+  let cursor = 0;
+
+  const pushRange = (collection, range) => {
+    if (range.start >= range.end) return;
+    collection.push(range);
+  };
+
   for (const token of tokens) {
     if (!token) continue;
+
+    const copy = {};
+    if (token.type) copy.type = token.type;
+    if (typeof token.text === 'string') copy.text = token.text;
+    if (token.style) copy.style = token.style;
+    if (token.href) copy.href = token.href;
+    normalizedTokens.push(copy);
+
     switch (token.type) {
       case 'bullet':
         entry.bullet = true;
         break;
       case 'newline':
         parts.push('\n');
+        cursor += 1;
         break;
-      case 'tab':
-        parts.push('    ');
+      case 'tab': {
+        const tab = '    ';
+        parts.push(tab);
+        cursor += tab.length;
+        break;
+      }
+      case 'jobsep':
         break;
       case 'link': {
-        const text = (token.text || '').replace(/\s+/g, ' ').trim();
-        if (text) parts.push(text);
-        if (token.href) {
-          entry.links.push({
-            text: text || token.href,
-            href: token.href
-          });
+        const text = (token.text || '').replace(/\u00a0/g, ' ');
+        if (!text) break;
+        parts.push(text);
+        const start = cursor;
+        cursor += text.length;
+        const end = cursor;
+        const linkKey = `${token.href || ''}|${text}`.toLowerCase();
+        if (token.href && !seenLinks.has(linkKey)) {
+          seenLinks.add(linkKey);
+          entry.links.push({ text: text.trim() || token.href, href: token.href });
+        }
+        pushRange(entry.linkRanges, { start, end, href: token.href });
+        if (token.style) {
+          pushRange(entry.styleRanges, { start, end, style: token.style });
         }
         break;
       }
-      case 'paragraph':
-        if (token.text) parts.push(token.text);
+      default: {
+        const text = (token.text || '').replace(/\u00a0/g, ' ');
+        if (!text) break;
+        parts.push(text);
+        const start = cursor;
+        cursor += text.length;
+        if (token.style) {
+          pushRange(entry.styleRanges, { start, end: cursor, style: token.style });
+        }
         break;
-      default:
-        if (token.text) parts.push(token.text);
-        break;
+      }
     }
   }
-  const raw = parts.join('');
-  const normalized = raw
-    .replace(/\u00a0/g, ' ')
-    .replace(/\s+\n/g, '\n')
-    .replace(/\n\s+/g, '\n');
-  const lines = normalized
-    .split('\n')
-    .map((line) => line.replace(/\s{2,}/g, ' ').trim())
-    .filter((line) => line.length > 0);
-  entry.text = lines.join('\n');
+
+  const raw = parts.join('').replace(/\r/g, '');
+  entry.text = raw;
+  entry.tokens = normalizedTokens;
+  entry.styleRanges.sort((a, b) => a.start - b.start || a.end - b.end);
+  entry.linkRanges.sort((a, b) => a.start - b.start || a.end - b.end);
   return entry;
 }
 
@@ -71,7 +110,7 @@ export function extractEntries(section) {
   if (!section || !Array.isArray(section.items)) return [];
   return section.items
     .map((tokens) => tokensToEntry(tokens))
-    .filter((entry) => entry.text && entry.text.length > 0);
+    .filter((entry) => /[^\s]/.test(entry.text || ''));
 }
 
 export function parseTemplateParams(value) {


### PR DESCRIPTION
## Summary
- preserve token-level metadata when extracting resume sections so formatting cues survive downstream rendering
- enhance the pdf-lib 2025 template renderer to wrap text with whitespace intact and render bold, italic, and linked segments with annotations

## Testing
- `npm test -- --runTestsByPath tests/generatePdf.test.js` *(fails: environment is missing @babel/preset-env)*

------
https://chatgpt.com/codex/tasks/task_e_68dd65c13c60832b8810a166792759bc