### PR TITLE
Normalize LinkedIn and certification links in PDFs

### DIFF
--- a/lib/pdf/templates/2025.js
+++ b/lib/pdf/templates/2025.js
@@ -72,10 +72,48 @@ function findPhone(rawText) {
   return match ? match[0] : '';
 }
 
+function stripLinkPunctuation(value = '') {
+  if (!value) return '';
+  let trimmed = String(value).trim();
+  trimmed = trimmed.replace(/^[\[({<]+/, '');
+  while (/[)>.,;:!]+$/.test(trimmed)) {
+    trimmed = trimmed.slice(0, -1);
+  }
+  return trimmed;
+}
+
+function normalizeLinkHref(value = '') {
+  let trimmed = stripLinkPunctuation(value);
+  if (!trimmed) return '';
+  if (/^(?:https?|mailto|tel):/i.test(trimmed)) return trimmed;
+  if (trimmed.startsWith('//')) return `https:${trimmed}`;
+  if (/^www\./i.test(trimmed)) return `https://${trimmed}`;
+  if (/^(?:[a-z0-9.-]*\.)?linkedin\.com/i.test(trimmed)) return `https://${trimmed}`;
+  if (/^(?:[a-z0-9.-]*\.)?credly\.com/i.test(trimmed)) return `https://${trimmed}`;
+  return trimmed;
+}
+
+function detectLinkInText(text = '') {
+  if (!text) return '';
+  const explicit = text.match(/https?:\/\/[^\s)]+/i);
+  if (explicit) {
+    return normalizeLinkHref(explicit[0]);
+  }
+  const domainMatch = text.match(
+    /\b(?:www\.)?(?:[a-z0-9.-]*linkedin\.com|credly\.com)[^\s)]+/i
+  );
+  if (domainMatch) {
+    return normalizeLinkHref(domainMatch[0]);
+  }
+  return '';
+}
+
 function findLinkedIn(rawText) {
   if (!rawText) return '';
-  const match = rawText.match(/https?:\/\/[^\s]*linkedin\.com[^\s]*/i);
-  return match ? match[0].replace(/[).,]+$/, '') : '';
+  const match = rawText.match(
+    /(https?:\/\/[^\s]*linkedin\.com[^\s]*|(?:www\.)?linkedin\.com[^\s]*)/i
+  );
+  return match ? normalizeLinkHref(match[0]) : '';
 }
 
 function sanitizeTel(value) {
@@ -95,7 +133,18 @@ function collectContactDetails(sectionEntries, rawText, options = {}) {
     const key = `${label || 'value'}:${normalized}`.toLowerCase();
     if (seen.has(key)) return;
     seen.add(key);
-    details.push({ label, value: normalized, href });
+    let normalizedHref = normalizeLinkHref(href);
+    if (!normalizedHref) {
+      normalizedHref = detectLinkInText(normalized);
+      if (!normalizedHref && label) {
+        if (/linkedin/i.test(label)) {
+          normalizedHref = normalizeLinkHref(normalized);
+        } else if (/credly/i.test(label) || /cert/i.test(label)) {
+          normalizedHref = normalizeLinkHref(normalized);
+        }
+      }
+    }
+    details.push({ label, value: normalized, href: normalizedHref });
   }
 
   for (const entry of sectionEntries) {
@@ -105,7 +154,8 @@ function collectContactDetails(sectionEntries, rawText, options = {}) {
       const label = entry.text.includes(':')
         ? entry.text.split(':')[0].trim()
         : link.text;
-      pushDetail(label || link.text, link.text || entry.text, link.href);
+      const linkHref = normalizeLinkHref(link.href || link.text || entry.text);
+      pushDetail(label || link.text, link.text || entry.text, linkHref);
       continue;
     }
     if (entry.text.includes(':')) {
@@ -371,6 +421,7 @@ function drawSidebarText(ctx, item) {
     .map((line) => line.trim())
     .filter(Boolean);
   if (!lines.length) return;
+  const baseHref = normalizeLinkHref(item.href);
   for (const line of lines) {
     if (ctx.y < ctx.marginBottom + ctx.sidebarBodySize + 2) break;
     const y = ctx.y;
@@ -381,7 +432,8 @@ function drawSidebarText(ctx, item) {
       font: fonts.regular,
       color: palette.sidebarText
     });
-    if (item.href) {
+    const resolvedHref = baseHref || detectLinkInText(line);
+    if (resolvedHref) {
       const width = fonts.regular.widthOfTextAtSize(line, ctx.sidebarBodySize);
       addLinkAnnotation(
         pdfDoc,
@@ -390,7 +442,7 @@ function drawSidebarText(ctx, item) {
         y - 2,
         width,
         ctx.sidebarBodySize + 4,
-        item.href,
+        resolvedHref,
         pdfPrimitives
       );
     }

--- a/tests/fetchCredlyProfile.test.js
+++ b/tests/fetchCredlyProfile.test.js
@@ -36,6 +36,26 @@ describe('fetchCredlyProfile', () => {
     ]);
   });
 
+  test('normalizes relative badge URLs', async () => {
+    const html = `
+      <div class="badge">
+        <a href="/badges/aws-dev"><span class="badge-name">AWS Certified Developer</span></a>
+        <span class="issuer-name">Amazon</span>
+        <span class="badge-status">Active</span>
+      </div>
+    `;
+    mockGet.mockResolvedValueOnce({ data: html });
+    const certs = await fetchCredlyProfile('http://example.com');
+    expect(certs).toEqual([
+      {
+        name: 'AWS Certified Developer',
+        provider: 'Amazon',
+        url: 'https://www.credly.com/badges/aws-dev',
+        source: 'credly'
+      }
+    ]);
+  });
+
   test('integrates with ensureRequiredSections to render certification hyperlink and profile link', async () => {
     const html = `
       <div class="badge">


### PR DESCRIPTION
## Summary
- normalize LinkedIn and Credly URLs within the PDF template so detected contact, certification, and sidebar entries receive link annotations
- extend server-side parsing to coerce bare LinkedIn/Credly URLs into HTTPS links, improve certification extraction, and normalize Credly profile data
- add regression coverage for bare LinkedIn/Credly detection, certification normalization, and Credly profile URL handling

## Testing
- `npm test -- --runInBand` *(fails: missing @babel/preset-env in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd68bb19e8832ba8d5c79ee7c06e72