### PR TITLE
Add delta summary panel for ATS insights

### DIFF
--- a/client/src/__tests__/deriveDeltaSummary.test.js
+++ b/client/src/__tests__/deriveDeltaSummary.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, it } from '@jest/globals'
+import { deriveDeltaSummary } from '../deriveDeltaSummary.js'
+
+describe('deriveDeltaSummary', () => {
+  it('combines match data, change logs, and certificates into category buckets', () => {
+    const summary = deriveDeltaSummary({
+      match: {
+        addedSkills: ['AWS', 'React'],
+        missingSkills: ['GraphQL'],
+        originalTitle: 'Software Engineer',
+        modifiedTitle: 'Senior Software Engineer'
+      },
+      changeLog: [
+        {
+          type: 'align-experience',
+          addedItems: ['Scaled API throughput 3x'],
+          removedItems: ['Maintained legacy module'],
+          summarySegments: [
+            {
+              section: 'Experience',
+              added: ['Scaled API throughput 3x'],
+              removed: ['Maintained legacy module'],
+              reason: ['Expanded metrics to mirror JD emphasis.']
+            }
+          ]
+        },
+        {
+          type: 'add-missing-skills',
+          addedItems: ['Node.js'],
+          summarySegments: [
+            {
+              section: 'Skills',
+              added: ['Node.js'],
+              removed: []
+            }
+          ]
+        }
+      ],
+      certificateInsights: {
+        known: [{ name: 'AWS Certified Solutions Architect', provider: 'Amazon' }],
+        suggestions: ['PMP'],
+        manualEntryRequired: true
+      },
+      manualCertificates: [{ name: 'Scrum Master', provider: 'Scrum.org' }],
+      jobSkills: ['AWS', 'GraphQL', 'Leadership'],
+      resumeSkills: ['AWS', 'React', 'Leadership']
+    })
+
+    expect(summary.skills.added).toEqual(expect.arrayContaining(['AWS', 'React', 'Node.js']))
+    expect(summary.skills.missing).toEqual(expect.arrayContaining(['GraphQL']))
+    expect(summary.experience.added).toEqual(expect.arrayContaining(['Scaled API throughput 3x']))
+    expect(summary.experience.missing).toEqual(expect.arrayContaining(['Maintained legacy module']))
+    expect(summary.designation.added).toContain('Senior Software Engineer')
+    expect(summary.designation.missing).toContain('Software Engineer')
+    expect(summary.keywords.missing).toEqual(expect.arrayContaining(['GraphQL']))
+    expect(summary.certificates.added).toEqual(
+      expect.arrayContaining(['AWS Certified Solutions Architect — Amazon', 'Scrum Master — Scrum.org'])
+    )
+    expect(summary.certificates.missing).toEqual(expect.arrayContaining(['PMP', 'Manual entry required']))
+  })
+
+  it('returns empty buckets when no data is provided', () => {
+    const summary = deriveDeltaSummary({})
+
+    expect(summary.skills.added).toEqual([])
+    expect(summary.skills.missing).toEqual([])
+    expect(summary.certificates.added).toEqual([])
+    expect(summary.certificates.missing).toEqual([])
+  })
+})

--- a/client/src/components/DeltaSummaryPanel.jsx
+++ b/client/src/components/DeltaSummaryPanel.jsx
@@ -1,0 +1,116 @@
+const categories = [
+  {
+    key: 'skills',
+    label: 'Skills',
+    description: 'Core abilities recognised in your resume versus the job description.'
+  },
+  {
+    key: 'experience',
+    label: 'Experience',
+    description: 'Achievements and stories added to or still missing from work history.'
+  },
+  {
+    key: 'designation',
+    label: 'Designation',
+    description: 'Visible job titles aligned to the target role.'
+  },
+  {
+    key: 'keywords',
+    label: 'Keywords',
+    description: 'JD keywords surfaced in your documents.'
+  },
+  {
+    key: 'certificates',
+    label: 'Certificates',
+    description: 'Credential coverage detected across LinkedIn, resume, and manual inputs.'
+  }
+]
+
+const addedBadgeClass = 'bg-emerald-100 text-emerald-700 border border-emerald-200'
+const missingBadgeClass = 'bg-rose-100 text-rose-700 border border-rose-200'
+
+function renderItems(items, type, label) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return (
+      <p className="mt-2 text-sm text-purple-700/70">
+        {type === 'added'
+          ? `No new ${label.toLowerCase()} added yet.`
+          : `No missing ${label.toLowerCase()} detected.`}
+      </p>
+    )
+  }
+
+  const visible = items.slice(0, 6)
+  const remainder = items.length - visible.length
+
+  return (
+    <ul className="mt-2 flex flex-wrap gap-2">
+      {visible.map((item) => (
+        <li
+          key={`${type}-${item}`}
+          className={`rounded-full px-3 py-1 text-xs font-semibold shadow-sm backdrop-blur ${
+            type === 'added' ? addedBadgeClass : missingBadgeClass
+          }`}
+        >
+          {item}
+        </li>
+      ))}
+      {remainder > 0 && (
+        <li className="rounded-full border border-purple-200 bg-white/70 px-3 py-1 text-xs font-semibold text-purple-700">
+          +{remainder} more
+        </li>
+      )}
+    </ul>
+  )
+}
+
+function DeltaSummaryPanel({ summary }) {
+  if (!summary) {
+    return null
+  }
+
+  return (
+    <section
+      className="space-y-6 rounded-3xl border border-purple-200/70 bg-white/85 p-6 shadow-xl"
+      aria-labelledby="delta-summary-title"
+      data-testid="delta-summary-panel"
+    >
+      <header className="space-y-2">
+        <h2 id="delta-summary-title" className="text-xl font-semibold text-purple-900">
+          Immediate Match Deltas
+        </h2>
+        <p className="text-sm text-purple-700/80">
+          Instantly review what new signals were added and which gaps still need attention across critical categories.
+        </p>
+      </header>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {categories.map((category) => {
+          const bucket = summary[category.key] || { added: [], missing: [] }
+          return (
+            <article
+              key={category.key}
+              className="flex h-full flex-col justify-between gap-3 rounded-2xl border border-purple-100/70 bg-white/70 p-4 shadow-sm"
+            >
+              <div className="space-y-1">
+                <h3 className="text-base font-semibold text-purple-900">{category.label}</h3>
+                <p className="text-sm text-purple-700/75">{category.description}</p>
+              </div>
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-600">Added</p>
+                  {renderItems(bucket.added, 'added', category.label)}
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-rose-600">Missing</p>
+                  {renderItems(bucket.missing, 'missing', category.label)}
+                </div>
+              </div>
+            </article>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+export default DeltaSummaryPanel

--- a/client/src/components/__tests__/DeltaSummaryPanel.test.jsx
+++ b/client/src/components/__tests__/DeltaSummaryPanel.test.jsx
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react'
+import DeltaSummaryPanel from '../DeltaSummaryPanel.jsx'
+
+describe('DeltaSummaryPanel', () => {
+  const summary = {
+    skills: { added: ['AWS', 'React'], missing: ['GraphQL'] },
+    experience: { added: ['Scaled API throughput'], missing: [] },
+    designation: { added: ['Senior Engineer'], missing: ['Engineer'] },
+    keywords: { added: ['Leadership'], missing: ['Serverless'] },
+    certificates: { added: ['AWS SA — Amazon'], missing: ['PMP'] }
+  }
+
+  it('renders chips for added and missing items', () => {
+    render(<DeltaSummaryPanel summary={summary} />)
+
+    expect(screen.getByText('Immediate Match Deltas')).toBeInTheDocument()
+    expect(screen.getByText('Skills')).toBeInTheDocument()
+    expect(screen.getByText('AWS')).toBeInTheDocument()
+    expect(screen.getByText('GraphQL')).toBeInTheDocument()
+    expect(screen.getByText('Senior Engineer')).toBeInTheDocument()
+    expect(screen.getByText('PMP')).toBeInTheDocument()
+  })
+
+  it('shows placeholders when a category has no entries', () => {
+    render(
+      <DeltaSummaryPanel
+        summary={{
+          skills: { added: [], missing: [] },
+          experience: { added: [], missing: [] },
+          designation: { added: [], missing: [] },
+          keywords: { added: [], missing: [] },
+          certificates: { added: [], missing: [] }
+        }}
+      />
+    )
+
+    expect(screen.getAllByText(/No new/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/No missing/i).length).toBeGreaterThan(0)
+  })
+})

--- a/client/src/deriveDeltaSummary.js
+++ b/client/src/deriveDeltaSummary.js
@@ -1,0 +1,195 @@
+const CATEGORY_KEYS = ['skills', 'experience', 'designation', 'keywords', 'certificates']
+
+function createAccumulator() {
+  return CATEGORY_KEYS.reduce((acc, key) => {
+    acc[key] = { added: new Set(), missing: new Set() }
+    return acc
+  }, {})
+}
+
+function normalizeText(value) {
+  if (typeof value === 'string') {
+    return value.trim()
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value)
+  }
+  return ''
+}
+
+function normalizeStringList(value) {
+  if (Array.isArray(value)) {
+    return value
+      .map(normalizeText)
+      .filter(Boolean)
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed ? [trimmed] : []
+  }
+  return []
+}
+
+function normalizeCertificateList(value) {
+  if (!value) return []
+  const list = Array.isArray(value) ? value : [value]
+  return list
+    .map((item) => {
+      if (!item) return ''
+      if (typeof item === 'string') {
+        return item.trim()
+      }
+      if (typeof item === 'object') {
+        const name = normalizeText(item.name || item.title)
+        const provider = normalizeText(item.provider || item.issuer || item.organization)
+        const combined = [name, provider].filter(Boolean).join(' — ')
+        return combined || name || provider
+      }
+      return ''
+    })
+    .filter(Boolean)
+}
+
+function finalise(accumulator) {
+  return CATEGORY_KEYS.reduce((result, key) => {
+    const added = Array.from(accumulator[key].added).filter(Boolean)
+    const missing = Array.from(accumulator[key].missing).filter(Boolean)
+    result[key] = { added, missing }
+    return result
+  }, {})
+}
+
+function pushItems(targetSet, items) {
+  items.forEach((item) => {
+    const text = normalizeText(item)
+    if (text) {
+      targetSet.add(text)
+    }
+  })
+}
+
+export function deriveDeltaSummary({
+  match,
+  changeLog,
+  certificateInsights,
+  manualCertificates,
+  jobSkills,
+  resumeSkills
+}) {
+  const accumulator = createAccumulator()
+  const addToCategory = (key, items) => {
+    if (!CATEGORY_KEYS.includes(key)) return
+    pushItems(accumulator[key].added, normalizeStringList(items))
+  }
+  const markMissingInCategory = (key, items) => {
+    if (!CATEGORY_KEYS.includes(key)) return
+    pushItems(accumulator[key].missing, normalizeStringList(items))
+  }
+
+  const addCertificates = (items) => {
+    normalizeCertificateList(items).forEach((item) => {
+      const text = normalizeText(item)
+      if (text) {
+        accumulator.certificates.added.add(text)
+      }
+    })
+  }
+  const markCertificatesMissing = (items) => {
+    normalizeCertificateList(items).forEach((item) => {
+      const text = normalizeText(item)
+      if (text) {
+        accumulator.certificates.missing.add(text)
+      }
+    })
+  }
+
+  const addedSkills = normalizeStringList(match?.addedSkills)
+  const missingSkills = normalizeStringList(match?.missingSkills)
+  addToCategory('skills', addedSkills)
+  addToCategory('keywords', addedSkills)
+  markMissingInCategory('skills', missingSkills)
+  markMissingInCategory('keywords', missingSkills)
+
+  const originalTitle = normalizeText(match?.originalTitle)
+  const modifiedTitle = normalizeText(match?.modifiedTitle)
+  if (modifiedTitle) {
+    accumulator.designation.added.add(modifiedTitle)
+  }
+  if (originalTitle && modifiedTitle && originalTitle.toLowerCase() !== modifiedTitle.toLowerCase()) {
+    accumulator.designation.missing.add(originalTitle)
+  }
+
+  const normalisedJobSkills = normalizeStringList(jobSkills)
+  const normalisedResumeSkills = normalizeStringList(resumeSkills)
+  const resumeSkillSet = new Set(normalisedResumeSkills.map((skill) => skill.toLowerCase()))
+  const jobSkillSet = new Set(normalisedJobSkills.map((skill) => skill.toLowerCase()))
+
+  const jobOnlySkills = normalisedJobSkills.filter((skill) => !resumeSkillSet.has(skill.toLowerCase()))
+  markMissingInCategory('skills', jobOnlySkills)
+  markMissingInCategory('keywords', jobOnlySkills)
+
+  const resumeOnlySkills = normalisedResumeSkills.filter((skill) => !jobSkillSet.has(skill.toLowerCase()))
+  addToCategory('skills', resumeOnlySkills)
+
+  addCertificates(certificateInsights?.known)
+  addCertificates(manualCertificates)
+  markCertificatesMissing(certificateInsights?.suggestions)
+  if (certificateInsights?.manualEntryRequired) {
+    accumulator.certificates.missing.add('Manual entry required')
+  }
+
+  const changeLogEntries = Array.isArray(changeLog) ? changeLog : []
+  changeLogEntries.forEach((entry) => {
+    const entryType = normalizeText(entry?.type)
+    const entryAdded = normalizeStringList(entry?.addedItems)
+    const entryRemoved = normalizeStringList(entry?.removedItems)
+    if (entryType === 'add-missing-skills') {
+      addToCategory('skills', entryAdded)
+      addToCategory('keywords', entryAdded)
+      markMissingInCategory('skills', entryRemoved)
+      markMissingInCategory('keywords', entryRemoved)
+    }
+    if (entryType === 'align-experience') {
+      addToCategory('experience', entryAdded)
+      markMissingInCategory('experience', entryRemoved)
+    }
+    if (entryType === 'change-designation') {
+      addToCategory('designation', entryAdded)
+      markMissingInCategory('designation', entryRemoved)
+    }
+
+    const segments = Array.isArray(entry?.summarySegments) ? entry.summarySegments : []
+    segments.forEach((segment) => {
+      const section = normalizeText(segment?.section)
+      const sectionLower = section.toLowerCase()
+      const segmentAdded = normalizeStringList(segment?.added)
+      const segmentRemoved = normalizeStringList(segment?.removed)
+
+      if (sectionLower && /skill|keyword/.test(sectionLower)) {
+        addToCategory('skills', segmentAdded)
+        addToCategory('keywords', segmentAdded)
+        markMissingInCategory('skills', segmentRemoved)
+        markMissingInCategory('keywords', segmentRemoved)
+      }
+
+      if (sectionLower && /experience|career|project|achievement|impact/.test(sectionLower)) {
+        addToCategory('experience', segmentAdded)
+        markMissingInCategory('experience', segmentRemoved)
+      }
+
+      if (sectionLower && /certificate|certification|badge/.test(sectionLower)) {
+        addToCategory('certificates', segmentAdded)
+        markCertificatesMissing(segmentRemoved)
+      }
+
+      if (sectionLower && /designation|title|headline|position/.test(sectionLower)) {
+        addToCategory('designation', segmentAdded)
+        markMissingInCategory('designation', segmentRemoved)
+      }
+    })
+  })
+
+  return finalise(accumulator)
+}
+
+export default deriveDeltaSummary


### PR DESCRIPTION
## Summary
- surface an Immediate Match Deltas panel so candidates instantly see added and missing skills, experience, designations, keywords, and certificates
- derive delta data by enriching change-log entries with structured sections and aggregating match, skill, and credential context
- cover the new summary utility and panel with focused unit tests

## Testing
- npm test -- --runInBand *(fails: missing @babel/preset-env in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6f0010e4832bae6362179482fa97