### PR TITLE
Add original CV download link and refresh document download UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,11 @@ ownload URLs expire after one hour:
   "urlExpiresInSeconds": 3600,
   "urls": [
     {
+      "type": "original_upload",
+      "url": "https://<bucket>.s3.<region>.amazonaws.com/jane_doe/cv/2025-01-15/jane_doe.pdf?X-Amz-Expires=3600&...",
+      "expiresAt": "2025-01-15T12:00:00.000Z"
+    },
+    {
       "type": "cover_letter1",
       "url": "https://<bucket>.s3.<region>.amazonaws.com/jane_doe/cv/2025-01-15/generated/cover_letter/cover_letter1.pdf?X-Amz-Expires=3600&...",
       "expiresAt": "2025-01-15T12:00:00.000Z"
@@ -377,13 +382,15 @@ ownload URLs expire after one hour:
 S3 keys follow the pattern `<candidate>/cv/<ISO-date>/generated/<subdir>/<file>.pdf`, where `<subdir>` is `cover_letter/` or `cv/` depending on the file type. The API now returns presigned download URLs along with an ISO 8601 timestamp (`expiresAt`) that indicates when each link will expire.
 
 ```
-jane_doe/cv/2025-01-15/generated/
-├── cover_letter/
-│   ├── cover_letter1.pdf
-│   └── cover_letter2.pdf
-└── cv/
-    ├── Jane_Doe.pdf
-    └── Jane_Doe_2.pdf
+jane_doe/cv/2025-01-15/
+├── jane_doe.pdf
+└── generated/
+    ├── cover_letter/
+    │   ├── cover_letter1.pdf
+    │   └── cover_letter2.pdf
+    └── cv/
+        ├── Jane_Doe.pdf
+        └── Jane_Doe_2.pdf
 ```
 
 Each entry in `urls` points to a PDF stored in Amazon S3. If no cover letters or CVs are produced, the server responds with HTTP 500 and an error message.

--- a/server.js
+++ b/server.js
@@ -7126,6 +7126,29 @@ app.post(
       version2: versionData.version2
     };
     const urls = [];
+
+    if (originalUploadKey) {
+      try {
+        const originalSignedUrl = await getSignedUrl(
+          s3,
+          new GetObjectCommand({ Bucket: bucket, Key: originalUploadKey }),
+          { expiresIn: URL_EXPIRATION_SECONDS }
+        );
+        const expiresAt = new Date(
+          Date.now() + URL_EXPIRATION_SECONDS * 1000
+        ).toISOString();
+        urls.push({
+          type: 'original_upload',
+          url: originalSignedUrl,
+          expiresAt
+        });
+      } catch (err) {
+        logStructured('warn', 'original_download_url_failed', {
+          ...logContext,
+          error: serializeError(err)
+        });
+      }
+    }
     for (const [name, text] of Object.entries(outputs)) {
       if (!text) continue;
       const isCvDocument = name === 'version1' || name === 'version2';

--- a/tests/processCv.e2e.test.js
+++ b/tests/processCv.e2e.test.js
@@ -35,11 +35,21 @@ describe('end-to-end CV processing', () => {
     );
 
     const { urls, applicantName } = response.body;
-    expect(urls).toHaveLength(4);
-    urls.forEach(({ url, expiresAt }) => {
+    expect(urls).toHaveLength(5);
+    expect(urls.map((item) => item.type).sort()).toEqual([
+      'cover_letter1',
+      'cover_letter2',
+      'original_upload',
+      'version1',
+      'version2'
+    ]);
+    urls.forEach(({ type, url, expiresAt }) => {
       expect(url).toMatch(/https:\/\/example.com\//);
       expect(url).toMatch(/expires=3600/);
       expect(() => new Date(expiresAt)).not.toThrow();
+      if (type === 'original_upload') {
+        expect(url).not.toContain('/generated/');
+      }
     });
 
     const sanitized = applicantName
@@ -48,8 +58,11 @@ describe('end-to-end CV processing', () => {
       .slice(0, 2)
       .join('_')
       .toLowerCase();
-    urls.forEach(({ url }) => {
+    urls.forEach(({ url, type }) => {
       expect(url).toContain(`/${sanitized}/cv/`);
+      if (type !== 'original_upload') {
+        expect(url).toContain('/generated/');
+      }
     });
   });
 });

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -228,10 +228,11 @@ describe('/api/process-cv', () => {
     expect(typeof res2.body.requestId).toBe('string');
     expect(typeof res2.body.jobId).toBe('string');
     expect(res2.body.urlExpiresInSeconds).toBe(3600);
-    expect(res2.body.urls).toHaveLength(4);
+    expect(res2.body.urls).toHaveLength(5);
     expect(res2.body.urls.map((u) => u.type).sort()).toEqual([
       'cover_letter1',
       'cover_letter2',
+      'original_upload',
       'version1',
       'version2'
     ]);
@@ -251,7 +252,9 @@ describe('/api/process-cv', () => {
       expect(url).toContain('expires=3600');
       expect(() => new Date(expiresAt)).not.toThrow();
       expect(new Date(expiresAt).toString()).not.toBe('Invalid Date');
-      if (type.startsWith('cover_letter')) {
+      if (type === 'original_upload') {
+        expect(url).not.toContain('/generated/');
+      } else if (type.startsWith('cover_letter')) {
         expect(url).toContain('/generated/cover_letter/');
       } else {
         expect(url).toContain('/generated/cv/');
@@ -417,6 +420,7 @@ describe('/api/process-cv', () => {
     expect(res.body.urls.map((u) => u.type).sort()).toEqual([
       'cover_letter1',
       'cover_letter2',
+      'original_upload',
       'version1',
       'version2'
     ]);
@@ -449,6 +453,7 @@ describe('/api/process-cv', () => {
     expect(res.body.urls.map((u) => u.type).sort()).toEqual([
       'cover_letter1',
       'cover_letter2',
+      'original_upload',
       'version1',
       'version2'
     ]);
@@ -481,6 +486,7 @@ describe('/api/process-cv', () => {
     expect(res.body.urls.map((u) => u.type).sort()).toEqual([
       'cover_letter1',
       'cover_letter2',
+      'original_upload',
       'version1',
       'version2'
     ]);
@@ -1023,15 +1029,16 @@ describe('client download labels', () => {
   test('App displays correct labels for each file type', () => {
     const source = fs.readFileSync('./client/src/App.jsx', 'utf8');
     const mappings = {
-      cover_letter1: 'Cover Letter 1 (PDF)',
-      cover_letter2: 'Cover Letter 2 (PDF)',
-      version1: 'CV Version 1 (PDF)',
-      version2: 'CV Version 2 (PDF)'
+      cover_letter1: 'Cover Letter 1',
+      cover_letter2: 'Cover Letter 2',
+      original_upload: 'Original CV Upload',
+      version1: 'Enhanced CV Version 1',
+      version2: 'Enhanced CV Version 2'
     };
 
     Object.entries(mappings).forEach(([type, label]) => {
       expect(source).toContain(`case '${type}':`);
-      expect(source).toContain(`label = '${label}'`);
+      expect(source).toContain(`label: '${label}'`);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add the original CV upload to the API download payload and documentation so users can retrieve their source file
- redesign the client download experience to group original CV, enhanced CVs, and cover letters with contextual labels
- update automated tests to cover the new download type and expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd831e9f20832b9334a040b7839105