### PR TITLE
Add comparative change view with highlights

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,6 +5,7 @@ import ATSScoreDashboard from './components/ATSScoreDashboard.jsx'
 import TemplateSelector from './components/TemplateSelector.jsx'
 import DeltaSummaryPanel from './components/DeltaSummaryPanel.jsx'
 import ProcessFlow from './components/ProcessFlow.jsx'
+import ChangeComparisonView from './components/ChangeComparisonView.jsx'
 import { deriveDeltaSummary } from './deriveDeltaSummary.js'
 
 const improvementActions = [
@@ -1584,6 +1585,7 @@ function App() {
   const handlePreviewImprovement = useCallback(
     (suggestion) => {
       if (!suggestion) return
+      const previewEntry = buildChangeLogEntry(suggestion)
       setPreviewSuggestion({
         id: suggestion.id,
         title: suggestion.title,
@@ -1591,7 +1593,10 @@ function App() {
         beforeExcerpt: suggestion.beforeExcerpt || '',
         afterExcerpt: suggestion.afterExcerpt || '',
         explanation: suggestion.explanation || '',
-        baseResume: resumeText
+        baseResume: resumeText,
+        summarySegments: previewEntry?.summarySegments || suggestion.improvementSummary || [],
+        addedItems: previewEntry?.addedItems || [],
+        removedItems: previewEntry?.removedItems || []
       })
     },
     [resumeText]
@@ -1978,21 +1983,18 @@ function App() {
                       {CHANGE_TYPE_LABELS[entry.label] || CHANGE_TYPE_LABELS.fixed}
                     </span>
                   </div>
-                  {(entry.before || entry.after) && (
-                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2 text-sm text-purple-800">
-                      {entry.before && (
-                        <div className="rounded-xl border border-purple-100 bg-purple-50/70 p-3">
-                          <p className="text-xs font-semibold uppercase tracking-wide text-purple-500">Before</p>
-                          <p className="mt-1 whitespace-pre-wrap leading-snug">{entry.before}</p>
-                        </div>
-                      )}
-                      {entry.after && (
-                        <div className="rounded-xl border border-indigo-100 bg-indigo-50/60 p-3">
-                          <p className="text-xs font-semibold uppercase tracking-wide text-indigo-500">After</p>
-                          <p className="mt-1 whitespace-pre-wrap leading-snug">{entry.after}</p>
-                        </div>
-                      )}
-                    </div>
+                  {(entry.before ||
+                    entry.after ||
+                    (entry.summarySegments && entry.summarySegments.length > 0) ||
+                    (entry.addedItems && entry.addedItems.length > 0) ||
+                    (entry.removedItems && entry.removedItems.length > 0)) && (
+                    <ChangeComparisonView
+                      before={entry.before}
+                      after={entry.after}
+                      summarySegments={entry.summarySegments}
+                      addedItems={entry.addedItems}
+                      removedItems={entry.removedItems}
+                    />
                   )}
                 </li>
               ))}
@@ -2109,19 +2111,18 @@ function App() {
                   Close
                 </button>
               </div>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-0 md:gap-6 px-6 py-6 text-sm text-purple-900">
-                <div className="space-y-3">
-                  <h4 className="text-xs font-semibold uppercase tracking-wide text-purple-500">Current Resume</h4>
-                  <div className="h-64 md:h-72 overflow-y-auto rounded-2xl border border-purple-200 bg-purple-50/70 p-4 whitespace-pre-wrap leading-relaxed">
-                    {previewSuggestion.baseResume || 'No resume content available.'}
-                  </div>
-                </div>
-                <div className="space-y-3">
-                  <h4 className="text-xs font-semibold uppercase tracking-wide text-indigo-500">With Improvement</h4>
-                  <div className="h-64 md:h-72 overflow-y-auto rounded-2xl border border-indigo-200 bg-indigo-50/60 p-4 whitespace-pre-wrap leading-relaxed">
-                    {previewSuggestion.updatedResume || 'No preview available for this improvement.'}
-                  </div>
-                </div>
+              <div className="px-6 py-6 text-sm text-purple-900">
+                <ChangeComparisonView
+                  before={previewSuggestion.baseResume}
+                  after={previewSuggestion.updatedResume}
+                  beforeLabel="Current Resume"
+                  afterLabel="With Improvement"
+                  summarySegments={previewSuggestion.summarySegments}
+                  addedItems={previewSuggestion.addedItems}
+                  removedItems={previewSuggestion.removedItems}
+                  variant="modal"
+                  className="text-purple-900"
+                />
               </div>
               {(previewSuggestion.beforeExcerpt || previewSuggestion.afterExcerpt) && (
                 <div className="border-t border-purple-100 bg-slate-50 px-6 py-4 text-sm text-slate-700">

--- a/client/src/components/ChangeComparisonView.jsx
+++ b/client/src/components/ChangeComparisonView.jsx
@@ -1,0 +1,275 @@
+import { Fragment, useMemo, useState } from 'react'
+
+const viewOptions = [
+  { key: 'split', label: 'Side by side' },
+  { key: 'stack', label: 'Sequential' }
+]
+
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function normaliseList(items) {
+  if (!Array.isArray(items)) return []
+  const seen = new Set()
+  const output = []
+  items.forEach((item) => {
+    const text = typeof item === 'string' ? item.trim() : String(item || '').trim()
+    if (!text) return
+    const key = text.toLowerCase()
+    if (seen.has(key)) return
+    seen.add(key)
+    output.push(text)
+  })
+  return output
+}
+
+function ChangeComparisonView({
+  before,
+  after,
+  beforeLabel = 'Before',
+  afterLabel = 'After',
+  summarySegments = [],
+  addedItems = [],
+  removedItems = [],
+  variant = 'compact',
+  className = ''
+}) {
+  const availableSplit = Boolean(before && after)
+  const [view, setView] = useState(availableSplit ? 'split' : 'stack')
+
+  const highlightData = useMemo(() => {
+    const addedList = normaliseList(addedItems)
+    const removedList = normaliseList(removedItems)
+    const addedSet = new Set(addedList.map((item) => item.toLowerCase()))
+    const removedSet = new Set(removedList.map((item) => item.toLowerCase()))
+    const patternSources = [...addedSet, ...removedSet]
+      .filter(Boolean)
+      .sort((a, b) => b.length - a.length)
+      .map((item) => escapeRegExp(item))
+    const regex = patternSources.length ? new RegExp(`(${patternSources.join('|')})`, 'gi') : null
+    return { addedSet, removedSet, regex }
+  }, [addedItems, removedItems])
+
+  const renderHighlighted = (text) => {
+    if (!text) return null
+    if (!highlightData.regex) return text
+    const parts = text.split(highlightData.regex)
+    return parts.map((part, index) => {
+      if (!part) {
+        return <Fragment key={`empty-${index}`} />
+      }
+      const lower = part.toLowerCase()
+      if (highlightData.addedSet.has(lower)) {
+        return (
+          <mark
+            key={`added-${index}`}
+            className="rounded-md bg-emerald-100 px-1.5 py-0.5 font-semibold text-emerald-800"
+          >
+            {part}
+          </mark>
+        )
+      }
+      if (highlightData.removedSet.has(lower)) {
+        return (
+          <mark
+            key={`removed-${index}`}
+            className="rounded-md bg-rose-100 px-1.5 py-0.5 font-semibold text-rose-800"
+          >
+            {part}
+          </mark>
+        )
+      }
+      return (
+        <Fragment key={`text-${index}`}>
+          {part}
+        </Fragment>
+      )
+    })
+  }
+
+  const hasHighlights = useMemo(() => {
+    const segmentCount = Array.isArray(summarySegments) ? summarySegments.length : 0
+    return (
+      segmentCount > 0 ||
+      (Array.isArray(addedItems) && addedItems.length > 0) ||
+      (Array.isArray(removedItems) && removedItems.length > 0)
+    )
+  }, [summarySegments, addedItems, removedItems])
+
+  const containerClass = `space-y-4 ${className}`.trim()
+  const baseContentClass =
+    variant === 'modal'
+      ? 'max-h-72 md:max-h-80 overflow-y-auto whitespace-pre-wrap leading-relaxed'
+      : 'whitespace-pre-wrap leading-relaxed'
+
+  const beforeWrapperClass =
+    variant === 'modal'
+      ? 'rounded-2xl border border-purple-200 bg-purple-50/70 p-4'
+      : 'rounded-xl border border-purple-100 bg-purple-50/70 p-3'
+
+  const afterWrapperClass =
+    variant === 'modal'
+      ? 'rounded-2xl border border-indigo-200 bg-indigo-50/60 p-4'
+      : 'rounded-xl border border-indigo-100 bg-indigo-50/60 p-3'
+
+  const summaryList = Array.isArray(summarySegments) ? summarySegments : []
+
+  return (
+    <div className={containerClass}>
+      {availableSplit && (
+        <div className="inline-flex rounded-full border border-purple-200 bg-white/70 p-1 text-xs font-semibold text-purple-600">
+          {viewOptions.map((option) => {
+            if (option.key === 'split' && !availableSplit) {
+              return null
+            }
+            const active = view === option.key
+            return (
+              <button
+                key={option.key}
+                type="button"
+                onClick={() => setView(option.key)}
+                className={`px-3 py-1 rounded-full transition ${
+                  active
+                    ? 'bg-purple-600 text-white shadow'
+                    : 'text-purple-600 hover:bg-purple-100'
+                }`}
+              >
+                {option.label}
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      {view === 'split' && availableSplit ? (
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 text-sm text-purple-800">
+          {before && (
+            <div className={beforeWrapperClass}>
+              <p className="text-xs font-semibold uppercase tracking-wide text-purple-500">{beforeLabel}</p>
+              <div className={`mt-2 ${baseContentClass}`}>
+                {renderHighlighted(before)}
+              </div>
+            </div>
+          )}
+          {after && (
+            <div className={afterWrapperClass}>
+              <p className="text-xs font-semibold uppercase tracking-wide text-indigo-500">{afterLabel}</p>
+              <div className={`mt-2 ${baseContentClass}`}>
+                {renderHighlighted(after)}
+              </div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-3 text-sm text-purple-800">
+          {before && (
+            <div className={beforeWrapperClass}>
+              <p className="text-xs font-semibold uppercase tracking-wide text-purple-500">{beforeLabel}</p>
+              <div className={`mt-2 ${baseContentClass}`}>
+                {renderHighlighted(before)}
+              </div>
+            </div>
+          )}
+          {after && (
+            <div className={afterWrapperClass}>
+              <p className="text-xs font-semibold uppercase tracking-wide text-indigo-500">{afterLabel}</p>
+              <div className={`mt-2 ${baseContentClass}`}>
+                {renderHighlighted(after)}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {hasHighlights && (
+        <div className="space-y-3 rounded-2xl border border-purple-100 bg-white/70 p-4">
+          <div className="space-y-2">
+            {(Array.isArray(addedItems) && addedItems.length > 0) ||
+            (Array.isArray(removedItems) && removedItems.length > 0) ? (
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-purple-500">Key highlights</p>
+                <div className="flex flex-wrap gap-2">
+                  {normaliseList(addedItems).map((item) => (
+                    <span
+                      key={`added-chip-${item}`}
+                      className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50/80 px-3 py-1 text-xs font-semibold text-emerald-700"
+                    >
+                      <span aria-hidden="true">＋</span>
+                      {item}
+                    </span>
+                  ))}
+                  {normaliseList(removedItems).map((item) => (
+                    <span
+                      key={`removed-chip-${item}`}
+                      className="inline-flex items-center gap-1 rounded-full border border-rose-200 bg-rose-50/80 px-3 py-1 text-xs font-semibold text-rose-700"
+                    >
+                      <span aria-hidden="true">–</span>
+                      {item}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {summaryList.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-purple-500">Section breakdown</p>
+                <div className="space-y-2">
+                  {summaryList.map((segment, index) => {
+                    if (!segment) return null
+                    const label = (segment.section || `Section ${index + 1}`).trim()
+                    const reasonLines = Array.isArray(segment.reason)
+                      ? segment.reason.filter(Boolean)
+                      : []
+                    const isSkillSegment = /skill|cert/i.test(label)
+                    const containerTone = isSkillSegment
+                      ? 'border-emerald-200 bg-emerald-50/70'
+                      : 'border-slate-200 bg-slate-50/70'
+                    return (
+                      <div
+                        key={`${label}-${index}`}
+                        className={`rounded-2xl border ${containerTone} p-3 text-sm text-slate-700`}
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <p className="font-semibold text-slate-800">{label}</p>
+                          {reasonLines.length > 0 && (
+                            <span className="text-xs font-medium text-slate-500">
+                              {reasonLines.join(' ')}
+                            </span>
+                          )}
+                        </div>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {normaliseList(segment.added).map((item) => (
+                            <span
+                              key={`segment-added-${label}-${item}`}
+                              className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-white/70 px-2.5 py-1 text-xs font-semibold text-emerald-700"
+                            >
+                              <span aria-hidden="true">＋</span>
+                              {item}
+                            </span>
+                          ))}
+                          {normaliseList(segment.removed).map((item) => (
+                            <span
+                              key={`segment-removed-${label}-${item}`}
+                              className="inline-flex items-center gap-1 rounded-full border border-rose-200 bg-white/70 px-2.5 py-1 text-xs font-semibold text-rose-700"
+                            >
+                              <span aria-hidden="true">–</span>
+                              {item}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ChangeComparisonView


### PR DESCRIPTION
## Summary
- add a reusable comparison view that toggles between side-by-side and sequential layouts while highlighting additions and removals
- embed the enhanced comparison view in the change log and preview modal so improvements call out key skills, highlights, and certifications

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd88af3980832b98cf726daa29b193