### PR TITLE
Add contextual tooltips for ATS metrics and improvements

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { formatMatchMessage } from './formatMatchMessage.js'
 import { buildApiUrl, resolveApiBase } from './resolveApiBase.js'
 import ATSScoreDashboard from './components/ATSScoreDashboard.jsx'
+import InfoTooltip from './components/InfoTooltip.jsx'
 import TemplateSelector from './components/TemplateSelector.jsx'
 import DeltaSummaryPanel from './components/DeltaSummaryPanel.jsx'
 import ProcessFlow from './components/ProcessFlow.jsx'
@@ -507,6 +508,16 @@ function ImprovementCard({ suggestion, onAccept, onReject, onPreview }) {
           ? 'text-rose-600'
           : 'text-slate-600'
       : 'text-slate-600'
+  const rawConfidence =
+    typeof suggestion.confidence === 'number' && Number.isFinite(suggestion.confidence)
+      ? suggestion.confidence
+      : null
+  const confidenceDisplay =
+    rawConfidence !== null ? `${Math.round(rawConfidence * 100)}%` : '—'
+  const confidenceDescription =
+    'Indicates how certain ResumeForge is that this change will resonate with ATS scoring and recruiter expectations based on the source analysis.'
+  const deltaDescription =
+    'Estimated impact on your ATS score if you apply this improvement. Positive values mean a projected lift; negative values signal a potential drop.'
   const acceptDisabled = Boolean(suggestion.rescorePending)
   const improvementHints = useMemo(() => {
     if (!Array.isArray(suggestion.improvementSummary)) return []
@@ -521,9 +532,16 @@ function ImprovementCard({ suggestion, onAccept, onReject, onPreview }) {
       <div className="flex items-center justify-between gap-4">
         <div>
           <h4 className="text-lg font-semibold text-purple-800">{suggestion.title}</h4>
-          <p className="text-xs uppercase tracking-wide text-purple-500">
-            Confidence: {(suggestion.confidence * 100).toFixed(0)}%
-          </p>
+          <div className="mt-1 flex items-center gap-2 text-xs uppercase tracking-wide text-purple-500">
+            <span>Confidence: {confidenceDisplay}</span>
+            <InfoTooltip
+              variant="light"
+              align="left"
+              maxWidthClass="w-72"
+              label="What does the improvement confidence mean?"
+              content={confidenceDescription}
+            />
+          </div>
         </div>
         {suggestion.accepted !== null && (
           <span
@@ -560,9 +578,18 @@ function ImprovementCard({ suggestion, onAccept, onReject, onPreview }) {
       </div>
       <div className="space-y-1">
         {deltaText && (
-          <p className={`text-sm font-semibold ${deltaTone}`}>
-            ATS score delta: {deltaText}
-          </p>
+          <div className="flex items-center gap-2">
+            <p className={`text-sm font-semibold ${deltaTone}`}>
+              ATS score delta: {deltaText}
+            </p>
+            <InfoTooltip
+              variant="light"
+              align="left"
+              maxWidthClass="w-72"
+              label="What does ATS score delta mean?"
+              content={deltaDescription}
+            />
+          </div>
         )}
         {suggestion.rescorePending && (
           <p className="text-xs font-medium text-purple-600">Updating ATS dashboard…</p>

--- a/client/src/components/ATSScoreCard.jsx
+++ b/client/src/components/ATSScoreCard.jsx
@@ -1,3 +1,5 @@
+import InfoTooltip from './InfoTooltip.jsx'
+
 const badgeThemes = {
   EXCELLENT:
     'bg-white/15 text-white border border-white/40 shadow-[0_8px_20px_rgba(255,255,255,0.18)] backdrop-blur-sm',
@@ -33,6 +35,39 @@ function formatScore(score) {
 
 const defaultAccent = 'from-indigo-500 via-purple-500 to-purple-700'
 
+const metricDescriptions = {
+  'Keyword Match':
+    'Measures how closely your resume keyword usage mirrors the job description so ATS scanners can confidently match you.',
+  'Skills Coverage':
+    'Summarises how well you showcase the core technical and soft skills the job emphasises.',
+  'Format Compliance':
+    'Checks whether your layout, headings, and file structure follow ATS-friendly formatting conventions.',
+  Readability:
+    'Looks at sentence length, clarity, and scannability to ensure recruiters can digest your story quickly.',
+  'Experience Alignment':
+    'Evaluates how your accomplishments map to the role’s responsibilities and impact areas.',
+  Structure:
+    'Reviews the ordering of sections, headings, and spacing that help ATS parsers read the resume correctly.',
+  Achievements:
+    'Highlights the presence of quantified, outcome-focused statements that prove your impact.',
+  'Core Competencies':
+    'Captures whether the resume surfaces the core competencies and proficiencies the JD prioritises.',
+}
+
+function describeMetric(metric) {
+  const explicit = typeof metric?.description === 'string' ? metric.description.trim() : ''
+  if (explicit) return explicit
+
+  const category = typeof metric?.category === 'string' ? metric.category.trim() : ''
+  if (category) {
+    const mapped = metricDescriptions[category]
+    if (mapped) return mapped
+    return `Represents how well your resume performs for ${category.toLowerCase()} when parsed by applicant tracking systems.`
+  }
+
+  return 'Shows how this aspect of your resume aligns with ATS expectations.'
+}
+
 function ATSScoreCard({ metric, accentClass = defaultAccent }) {
   const ratingLabel = normalizeLabel(metric?.ratingLabel)
   const badgeClass = badgeThemes[ratingLabel] || badgeThemes.GOOD
@@ -40,6 +75,7 @@ function ATSScoreCard({ metric, accentClass = defaultAccent }) {
   const { display: scoreDisplay, suffix: scoreSuffix } = formatScore(metric?.score)
   const tip = metric?.tip ?? metric?.tips?.[0] ?? ''
   const category = metric?.category ?? 'Metric'
+  const metricDescription = describeMetric(metric)
 
   return (
     <article
@@ -57,7 +93,15 @@ function ATSScoreCard({ metric, accentClass = defaultAccent }) {
             Metric
           </span>
           <div className="flex items-start justify-between gap-4">
-            <h3 className="text-2xl font-black leading-snug tracking-wide md:text-[26px]">{category}</h3>
+            <div className="flex items-start gap-2">
+              <h3 className="text-2xl font-black leading-snug tracking-wide md:text-[26px]">{category}</h3>
+              <InfoTooltip
+                variant="dark"
+                align="left"
+                label={`What does the ${category} score mean?`}
+                content={metricDescription}
+              />
+            </div>
             {ratingLabel && (
               <span
                 className={`text-[10px] font-semibold uppercase tracking-[0.35em] px-3 py-1 rounded-full ${badgeClass}`}

--- a/client/src/components/ATSScoreDashboard.jsx
+++ b/client/src/components/ATSScoreDashboard.jsx
@@ -1,4 +1,5 @@
 import ATSScoreCard from './ATSScoreCard.jsx'
+import InfoTooltip from './InfoTooltip.jsx'
 
 const gradientPalette = [
   'from-[#5B21B6] via-[#7C3AED] to-[#4C1D95]',
@@ -85,6 +86,17 @@ function ATSScoreDashboard({ metrics = [], match }) {
       ]
     : []
 
+  const originalScoreDescription =
+    match?.originalScoreExplanation ||
+    'Baseline ATS alignment from your uploaded resume before any ResumeForge refinements.'
+  const enhancedScoreDescription =
+    match?.enhancedScoreExplanation ||
+    'Recalculated ATS alignment after applying the recommended ResumeForge improvements.'
+  const scoreComparisonDescription =
+    'Illustrates how the enhanced resume closes gaps versus ATS benchmarks by comparing both scores side-by-side.'
+  const selectionProbabilityDescription =
+    'Combines ATS scores, keyword coverage, and credential alignment to estimate how likely you are to be shortlisted.'
+
   return (
     <section className="space-y-6" aria-label="ATS dashboard" aria-live="polite">
       <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
@@ -117,7 +129,15 @@ function ATSScoreDashboard({ metrics = [], match }) {
           aria-label="match comparison"
         >
           <div className="rounded-3xl border border-indigo-100 bg-white/80 p-6 shadow-lg backdrop-blur">
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-indigo-500">Original Match</p>
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-indigo-500">Original Match</p>
+              <InfoTooltip
+                variant="light"
+                align="right"
+                label="How is the original match score calculated?"
+                content={originalScoreDescription}
+              />
+            </div>
             <p className="mt-3 text-5xl font-black text-indigo-700" data-testid="original-score">
               {match.originalScore ?? '—'}%
             </p>
@@ -126,15 +146,23 @@ function ATSScoreDashboard({ metrics = [], match }) {
             </p>
           </div>
           <div className="rounded-3xl border border-emerald-100 bg-gradient-to-br from-emerald-100 via-white to-emerald-50 p-6 shadow-lg backdrop-blur">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-600">Enhanced Match</p>
-                <p className="mt-3 text-5xl font-black text-emerald-700" data-testid="enhanced-score">
-                  {match.enhancedScore ?? '—'}%
-                </p>
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex items-start gap-2">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-600">Enhanced Match</p>
+                  <p className="mt-3 text-5xl font-black text-emerald-700" data-testid="enhanced-score">
+                    {match.enhancedScore ?? '—'}%
+                  </p>
+                </div>
+                <InfoTooltip
+                  variant="light"
+                  align="left"
+                  label="How is the enhanced match score calculated?"
+                  content={enhancedScoreDescription}
+                />
               </div>
               {matchDelta && (
-                <span className="self-start rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700" data-testid="match-delta">
+                <span className="self-start rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-emerald-700" data-testid="match-delta">
                   {matchDelta}
                 </span>
               )}
@@ -155,11 +183,19 @@ function ATSScoreDashboard({ metrics = [], match }) {
                     Visualise how the enhanced version closes the gap against ATS expectations.
                   </p>
                 </div>
-                {matchDelta && (
-                  <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-emerald-700">
-                    {matchDelta}
-                  </span>
-                )}
+                <div className="flex items-start gap-2">
+                  <InfoTooltip
+                    variant="light"
+                    align="right"
+                    label="What does the score comparison show?"
+                    content={scoreComparisonDescription}
+                  />
+                  {matchDelta && (
+                    <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-emerald-700">
+                      {matchDelta}
+                    </span>
+                  )}
+                </div>
               </div>
               <div className="mt-4 space-y-4" role="img" aria-label={`Original score ${originalScoreValue}%, enhanced score ${enhancedScoreValue}%`}>
                 {scoreBands.map(({ label, value, tone, textTone }) => (
@@ -185,7 +221,15 @@ function ATSScoreDashboard({ metrics = [], match }) {
           )}
           {hasSelectionProbability && (
             <div className="rounded-3xl border border-emerald-200 bg-emerald-50/80 p-6 shadow-lg backdrop-blur">
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-600">Selection Probability</p>
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-600">Selection Probability</p>
+                <InfoTooltip
+                  variant="light"
+                  align="right"
+                  label="How is the selection probability estimated?"
+                  content={selectionProbabilityDescription}
+                />
+              </div>
               <div className="mt-3 flex items-baseline gap-3">
                 <p className="text-5xl font-black text-emerald-700">{selectionProbabilityValue}%</p>
                 {selectionProbabilityMeaning && (

--- a/client/src/components/InfoTooltip.jsx
+++ b/client/src/components/InfoTooltip.jsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+
+let tooltipInstanceCounter = 0
+
+const variantThemes = {
+  dark: {
+    bubble:
+      'bg-slate-900/95 text-white shadow-[0_12px_30px_rgba(15,23,42,0.45)] ring-1 ring-white/10',
+    trigger:
+      'text-white/90 border-white/40 bg-white/15 hover:bg-white/25 focus-visible:ring-white/60',
+  },
+  light: {
+    bubble:
+      'bg-white text-slate-700 shadow-[0_20px_45px_rgba(15,23,42,0.18)] ring-1 ring-slate-200/70',
+    trigger:
+      'text-slate-600 border-slate-300 bg-white/90 hover:bg-white focus-visible:ring-slate-400/70',
+  },
+}
+
+function InfoTooltip({
+  label = 'Show explanation',
+  content,
+  className = '',
+  align = 'left',
+  variant = 'dark',
+  maxWidthClass = 'w-64',
+}) {
+  const [open, setOpen] = useState(false)
+  const [tooltipId] = useState(() => {
+    tooltipInstanceCounter += 1
+    return `rf-tooltip-${tooltipInstanceCounter}`
+  })
+  const theme = variantThemes[variant] || variantThemes.dark
+
+  const show = () => setOpen(true)
+  const hide = () => setOpen(false)
+
+  return (
+    <div className={`relative inline-flex ${className}`} onMouseLeave={hide}>
+      <button
+        type="button"
+        aria-label={label}
+        aria-describedby={tooltipId}
+        onMouseEnter={show}
+        onFocus={show}
+        onBlur={hide}
+        className={`inline-flex h-6 w-6 items-center justify-center rounded-full border text-[10px] font-bold transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent ${theme.trigger}`}
+      >
+        <span aria-hidden="true">i</span>
+      </button>
+      <div
+        id={tooltipId}
+        role="tooltip"
+        aria-hidden={!open}
+        className={`pointer-events-none absolute z-40 mt-2 ${align === 'left' ? 'left-0' : 'right-0'} top-full origin-top ${maxWidthClass} rounded-xl px-4 py-3 text-left text-xs font-medium leading-relaxed opacity-0 backdrop-blur transition-all duration-150 ${theme.bubble} ${open ? 'translate-y-0 opacity-100' : '-translate-y-1 opacity-0'}`}
+      >
+        {content}
+      </div>
+    </div>
+  )
+}
+
+export default InfoTooltip

--- a/client/src/components/__tests__/__snapshots__/ATSScoreCard.test.jsx.snap
+++ b/client/src/components/__tests__/__snapshots__/ATSScoreCard.test.jsx.snap
@@ -33,11 +33,43 @@ exports[`ATSScoreCard matches the gradient snapshot for consistency 1`] = `
         <div
           class="flex items-start justify-between gap-4"
         >
-          <h3
-            class="text-2xl font-black leading-snug tracking-wide md:text-[26px]"
+          <div
+            class="flex items-start gap-2"
           >
-            Keyword Match
-          </h3>
+            <h3
+              class="text-2xl font-black leading-snug tracking-wide md:text-[26px]"
+            >
+              Keyword Match
+            </h3>
+            <div
+              class="relative inline-flex"
+              onmouseleave="[Function]"
+            >
+              <button
+                aria-describedby="rf-tooltip-1"
+                aria-label="What does the Keyword Match score mean?"
+                class="inline-flex h-6 w-6 items-center justify-center rounded-full border text-[10px] font-bold transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent text-white/90 border-white/40 bg-white/15 hover:bg-white/25 focus-visible:ring-white/60"
+                onblur="[Function]"
+                onfocus="[Function]"
+                onmouseenter="[Function]"
+                type="button"
+              >
+                <span
+                  aria-hidden="true"
+                >
+                  i
+                </span>
+              </button>
+              <div
+                aria-hidden="true"
+                class="pointer-events-none absolute z-40 mt-2 left-0 top-full origin-top w-64 rounded-xl px-4 py-3 text-left text-xs font-medium leading-relaxed opacity-0 backdrop-blur transition-all duration-150 bg-slate-900/95 text-white shadow-[0_12px_30px_rgba(15,23,42,0.45)] ring-1 ring-white/10 -translate-y-1"
+                id="rf-tooltip-1"
+                role="tooltip"
+              >
+                Measures how closely your resume keyword usage mirrors the job description so ATS scanners can confidently match you.
+              </div>
+            </div>
+          </div>
           <span
             class="text-[10px] font-semibold uppercase tracking-[0.35em] px-3 py-1 rounded-full bg-white/15 text-white border border-white/40 shadow-[0_8px_20px_rgba(255,255,255,0.18)] backdrop-blur-sm"
             data-testid="rating-badge"


### PR DESCRIPTION
## Summary
- add a reusable InfoTooltip component for consistent explanatory hover states
- surface descriptions for each ATS score in the dashboard and metric cards so users understand the metrics
- annotate improvement cards with tooltips clarifying the confidence value and ATS score delta impact

## Testing
- `npm test -- ATSScoreCard` *(fails: missing jest-environment-jsdom / @babel/preset-env in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8dd3fa2c832ba340cd8ea1ce9fb5