### PR TITLE
Ensure job posting classifier reason mentions job-posting keyword

### DIFF
--- a/server.js
+++ b/server.js
@@ -4263,6 +4263,12 @@ function formatQuotedList(items = []) {
 function buildClassifierReason(description = '', matches = []) {
   const docType = stripLeadingArticle(description || 'non-resume document');
   const quoted = formatQuotedList(matches);
+  if (/job description/i.test(docType)) {
+    if (quoted) {
+      return `Detected job-posting keywords such as ${quoted}.`;
+    }
+    return 'Detected patterns typical of a job-posting document.';
+  }
   if (quoted) {
     return `Detected ${docType} keywords such as ${quoted}.`;
   }


### PR DESCRIPTION
## Summary
- ensure the job description classifier reason explicitly references job-posting keywords so downstream checks detect the expected phrasing

## Testing
- npm test -- --runInBand *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68ddee691fec832baa7a74de7a0b049c