### PR TITLE
Stabilize tooltip identifiers for ATS snapshots

### DIFF
--- a/client/src/components/InfoTooltip.jsx
+++ b/client/src/components/InfoTooltip.jsx
@@ -1,6 +1,4 @@
-import { useState } from 'react'
-
-let tooltipInstanceCounter = 0
+import { useMemo, useState } from 'react'
 
 const variantThemes = {
   dark: {
@@ -17,6 +15,23 @@ const variantThemes = {
   },
 }
 
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function hashString(value) {
+  let hash = 0
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value.charCodeAt(index)
+    hash = (hash << 5) - hash + char
+    hash |= 0
+  }
+  return Math.abs(hash).toString(36)
+}
+
 function InfoTooltip({
   label = 'Show explanation',
   content,
@@ -26,17 +41,25 @@ function InfoTooltip({
   maxWidthClass = 'w-64',
 }) {
   const [open, setOpen] = useState(false)
-  const [tooltipId] = useState(() => {
-    tooltipInstanceCounter += 1
-    return `rf-tooltip-${tooltipInstanceCounter}`
-  })
+  const tooltipId = useMemo(() => {
+    const baseLabel = typeof label === 'string' ? label.trim() : ''
+    const labelSlug = baseLabel ? slugify(baseLabel) : 'tooltip'
+    const contentKey =
+      typeof content === 'string' && content.trim().length > 0
+        ? hashString(content.trim())
+        : ''
+    return `rf-tooltip-${labelSlug}${contentKey ? `-${contentKey}` : ''}`
+  }, [label, content])
   const theme = variantThemes[variant] || variantThemes.dark
 
   const show = () => setOpen(true)
   const hide = () => setOpen(false)
 
   return (
-    <div className={`relative inline-flex ${className}`} onMouseLeave={hide}>
+    <div
+      className={`relative inline-flex${className ? ` ${className}` : ''}`}
+      onMouseLeave={hide}
+    >
       <button
         type="button"
         aria-label={label}
@@ -52,7 +75,7 @@ function InfoTooltip({
         id={tooltipId}
         role="tooltip"
         aria-hidden={!open}
-        className={`pointer-events-none absolute z-40 mt-2 ${align === 'left' ? 'left-0' : 'right-0'} top-full origin-top ${maxWidthClass} rounded-xl px-4 py-3 text-left text-xs font-medium leading-relaxed opacity-0 backdrop-blur transition-all duration-150 ${theme.bubble} ${open ? 'translate-y-0 opacity-100' : '-translate-y-1 opacity-0'}`}
+        className={`pointer-events-none absolute z-40 mt-2 ${align === 'left' ? 'left-0' : 'right-0'} top-full origin-top ${maxWidthClass} rounded-xl px-4 py-3 text-left text-xs font-medium leading-relaxed backdrop-blur transition-all duration-150 ${theme.bubble} ${open ? 'translate-y-0 opacity-100' : '-translate-y-1 opacity-0'}`}
       >
         {content}
       </div>

--- a/client/src/components/__tests__/__snapshots__/ATSScoreCard.test.jsx.snap
+++ b/client/src/components/__tests__/__snapshots__/ATSScoreCard.test.jsx.snap
@@ -43,15 +43,11 @@ exports[`ATSScoreCard matches the gradient snapshot for consistency 1`] = `
             </h3>
             <div
               class="relative inline-flex"
-              onmouseleave="[Function]"
             >
               <button
-                aria-describedby="rf-tooltip-1"
+                aria-describedby="rf-tooltip-what-does-the-keyword-match-score-mean-eol9q4"
                 aria-label="What does the Keyword Match score mean?"
                 class="inline-flex h-6 w-6 items-center justify-center rounded-full border text-[10px] font-bold transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent text-white/90 border-white/40 bg-white/15 hover:bg-white/25 focus-visible:ring-white/60"
-                onblur="[Function]"
-                onfocus="[Function]"
-                onmouseenter="[Function]"
                 type="button"
               >
                 <span
@@ -62,8 +58,8 @@ exports[`ATSScoreCard matches the gradient snapshot for consistency 1`] = `
               </button>
               <div
                 aria-hidden="true"
-                class="pointer-events-none absolute z-40 mt-2 left-0 top-full origin-top w-64 rounded-xl px-4 py-3 text-left text-xs font-medium leading-relaxed opacity-0 backdrop-blur transition-all duration-150 bg-slate-900/95 text-white shadow-[0_12px_30px_rgba(15,23,42,0.45)] ring-1 ring-white/10 -translate-y-1"
-                id="rf-tooltip-1"
+                class="pointer-events-none absolute z-40 mt-2 left-0 top-full origin-top w-64 rounded-xl px-4 py-3 text-left text-xs font-medium leading-relaxed backdrop-blur transition-all duration-150 bg-slate-900/95 text-white shadow-[0_12px_30px_rgba(15,23,42,0.45)] ring-1 ring-white/10 -translate-y-1 opacity-0"
+                id="rf-tooltip-what-does-the-keyword-match-score-mean-eol9q4"
                 role="tooltip"
               >
                 Measures how closely your resume keyword usage mirrors the job description so ATS scanners can confidently match you.


### PR DESCRIPTION
## Summary
- derive deterministic tooltip identifiers from the tooltip label/content to keep client snapshots stable across test runs
- normalize tooltip markup to drop duplicate spacing and opacity classes in the rendered output
- refresh the ATSScoreCard snapshot to align with the updated tooltip structure

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ddf04ffdc8832ba1e9279f90f4a8a7