### PR TITLE
Handle JD validation failures in offline flow

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -948,7 +948,19 @@ function App() {
       } else if (data.type === 'OFFLINE_UPLOAD_FAILED') {
         setQueuedMessage('')
         setIsProcessing(false)
-        setError(data.message || 'Failed to process queued upload. Please try again.')
+        const payloadError = data?.payload?.error
+        if (
+          payloadError?.details?.manualInputRequired ||
+          payloadError?.code === 'JOB_DESCRIPTION_FETCH_FAILED' ||
+          (typeof data?.message === 'string' && /unable to fetch jd/i.test(data.message))
+        ) {
+          setManualJobDescriptionRequired(true)
+        }
+        const failureMessage =
+          (typeof data?.message === 'string' && data.message.trim()) ||
+          (typeof payloadError?.message === 'string' && payloadError.message.trim()) ||
+          'Failed to process queued upload. Please try again.'
+        setError(failureMessage)
       }
     }
 


### PR DESCRIPTION
## Summary
- capture error details when queued uploads fail JD validation and forward them to the client
- surface the manual job description textarea when the service worker reports a JD fetch failure

## Testing
- npm test -- --runTestsByPath tests/server.test.js *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68ddf46ed788832bbb776c298cc0fc89