### PR TITLE
Ensure GDPR purge removes Dynamo metadata for expired sessions

### DIFF
--- a/tests/mocks/aws-sdk-client-dynamodb.js
+++ b/tests/mocks/aws-sdk-client-dynamodb.js
@@ -28,3 +28,17 @@ export class UpdateItemCommand {
     this.__type = 'UpdateItemCommand';
   }
 }
+
+export class ScanCommand {
+  constructor(input) {
+    this.input = input;
+    this.__type = 'ScanCommand';
+  }
+}
+
+export class DeleteItemCommand {
+  constructor(input) {
+    this.input = input;
+    this.__type = 'DeleteItemCommand';
+  }
+}

--- a/tests/purgeExpiredSessions.test.js
+++ b/tests/purgeExpiredSessions.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, test } from '@jest/globals';
+import { setupTestServer } from './utils/testServer.js';
+
+const buildS3Object = (Key) => ({ Key });
+
+describe('purgeExpiredSessions', () => {
+  test('deletes S3 objects and DynamoDB metadata for expired sessions', async () => {
+    const { serverModule, mocks } = await setupTestServer();
+    const oldDate = '2023-01-01';
+    const freshDate = '2024-01-15';
+    const sessionPrefix = `candidate/cv/${oldDate}/`;
+    const freshPrefix = `candidate/cv/${freshDate}/`;
+
+    const listedObjects = [
+      buildS3Object(`${sessionPrefix}candidate.pdf`),
+      buildS3Object(`${sessionPrefix}generated/cv/candidate.pdf`),
+      buildS3Object(`${freshPrefix}candidate.pdf`),
+    ];
+
+    const deleteChunks = [];
+    mocks.mockS3Send.mockImplementation((command) => {
+      switch (command.__type) {
+        case 'ListObjectsV2Command':
+          return Promise.resolve({
+            Contents: listedObjects,
+            IsTruncated: false,
+          });
+        case 'DeleteObjectsCommand':
+          deleteChunks.push(command.input.Delete.Objects);
+          return Promise.resolve({ Deleted: command.input.Delete.Objects });
+        default:
+          return Promise.resolve({});
+      }
+    });
+
+    const dynamoDeletes = [];
+    mocks.mockDynamoSend.mockImplementation((command) => {
+      switch (command.__type) {
+        case 'ScanCommand':
+          return Promise.resolve({
+            Items: [
+              {
+                linkedinProfileUrl: { S: 'expired-hash' },
+                s3Key: { S: `${sessionPrefix}candidate.pdf` },
+                cv1Url: {
+                  S: `https://example.com/${sessionPrefix}generated/cv/candidate.pdf?expires=100`,
+                },
+              },
+              {
+                linkedinProfileUrl: { S: 'fresh-hash' },
+                s3Key: { S: `${freshPrefix}candidate.pdf` },
+              },
+            ],
+          });
+        case 'DeleteItemCommand':
+          dynamoDeletes.push(command.input.Key);
+          return Promise.resolve({});
+        default:
+          return Promise.resolve({ Table: { TableStatus: 'ACTIVE' } });
+      }
+    });
+
+    const now = new Date('2024-02-01T00:00:00Z');
+    const result = await serverModule.purgeExpiredSessions({
+      retentionDays: 30,
+      now,
+    });
+
+    expect(result.deleted).toBe(2);
+    expect(result.metadataDeleted).toBe(1);
+
+    expect(deleteChunks).toHaveLength(1);
+    const deletedKeys = deleteChunks.flat().map((entry) => entry.Key);
+    expect(deletedKeys).toEqual(
+      expect.arrayContaining([
+        `${sessionPrefix}candidate.pdf`,
+        `${sessionPrefix}generated/cv/candidate.pdf`,
+      ])
+    );
+
+    expect(dynamoDeletes).toEqual([
+      { linkedinProfileUrl: { S: 'expired-hash' } },
+    ]);
+  });
+});

--- a/tests/utils/testServer.js
+++ b/tests/utils/testServer.js
@@ -76,6 +76,8 @@ export async function setupTestServer({
     DescribeTableCommand: jest.fn((input) => ({ input, __type: 'DescribeTableCommand' })),
     PutItemCommand: jest.fn((input) => ({ input, __type: 'PutItemCommand' })),
     UpdateItemCommand: jest.fn((input) => ({ input, __type: 'UpdateItemCommand' })),
+    ScanCommand: jest.fn((input) => ({ input, __type: 'ScanCommand' })),
+    DeleteItemCommand: jest.fn((input) => ({ input, __type: 'DeleteItemCommand' })),
   }));
 
   const loggerModulePath = new URL('../../logger.js', import.meta.url).pathname;


### PR DESCRIPTION
## Summary
- extend the GDPR retention sweep to delete DynamoDB metadata linked to expired session prefixes
- expose the extra metadata deletion count in the purge result returned to retention handlers
- add focused tests and mocks to verify DynamoDB cleanup alongside S3 deletions

## Testing
- npm test -- purgeExpiredSessions

------
https://chatgpt.com/codex/tasks/task_e_68ddfc0bafd8832bb110a5b08486f93e