### PR TITLE
Refine Gemini prompts with structured JSON instructions

### DIFF
--- a/tests/geminiPrompts.unit.test.js
+++ b/tests/geminiPrompts.unit.test.js
@@ -51,10 +51,12 @@ describe('rewriteSectionsWithGemini prompt construction', () => {
 
     expect(generativeModelMock.generateContent).toHaveBeenCalledTimes(1);
     const prompt = promptRecorder[0];
-    expect(prompt).toContain('expert resume writer');
+    expect(prompt).toContain('elite resume architect');
     expect(prompt).toContain('Exciting job description here');
-    expect(prompt).toMatch(/Sections: \{/);
-    expect(prompt).toMatch(/Experienced engineer/);
+    expect(prompt).toContain('Never degrade CV structure');
+    expect(prompt).toContain('OUTPUT_SCHEMA');
+    expect(prompt).toContain('INPUT_CONTEXT');
+    expect(prompt).toMatch(/"resumeSections"/);
     expect(prompt).toMatch(/"summary"/);
     expect(prompt).toMatch(/"experience"/);
     expect(prompt).toMatch(/"projects"/);


### PR DESCRIPTION
## Summary
- make the Gemini section rewrite prompt context-rich with explicit JSON schema guidance and an instruction to never degrade CV structure
- update resume version and cover letter prompts to provide structured JSON output requirements while preserving existing CV formatting cues
- adjust unit coverage to validate the new structured prompt language

## Testing
- npm test -- --runTestsByPath tests/geminiPrompts.unit.test.js tests/generateProjectSummary.test.js tests/geminiSections.test.js *(fails: missing @babel/preset-env preset in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddffda27fc832bbca2be05c536edcc