### PR TITLE
Add tests for AI response fallback handling

### DIFF
--- a/tests/geminiSections.test.js
+++ b/tests/geminiSections.test.js
@@ -1,6 +1,7 @@
 import {
   collectSectionText,
   rewriteSectionsWithGemini,
+  sanitizeGeneratedText,
 } from '../server.js';
 import { generateContentMock } from './mocks/generateContentMock.js';
 
@@ -53,5 +54,31 @@ describe('rewriteSectionsWithGemini', () => {
     expect(text).toContain('Updated Title');
     expect(modifiedTitle).toBe('Updated Title');
     expect(addedSkills).toEqual(['Skill C']);
+  });
+
+  test('falls back to sanitized resume when Gemini returns plain text', async () => {
+    const resumeText = 'Jane Doe\n# Summary\nOriginal summary';
+    const linkedinData = { experience: [], education: [], skills: [] };
+    const sections = collectSectionText(resumeText, linkedinData, []);
+    generateContentMock.mockReset();
+    generateContentMock.mockResolvedValueOnce({
+      response: { text: () => 'Sure, here is your improved resume text without JSON formatting.' },
+    });
+    const generativeModel = { generateContent: generateContentMock };
+    const options = { skipRequiredSections: true };
+
+    const result = await rewriteSectionsWithGemini(
+      'Jane Doe',
+      sections,
+      'Job description text',
+      generativeModel,
+      options
+    );
+
+    expect(generativeModel.generateContent).toHaveBeenCalledTimes(1);
+    expect(result.text).toBe(sanitizeGeneratedText('Jane Doe', options));
+    expect(result.project).toBe('');
+    expect(result.modifiedTitle).toBe('');
+    expect(result.addedSkills).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- add a unit test ensuring rewriteSectionsWithGemini falls back when Gemini returns plain text
- add an integration test covering sanitized resume fallback when resume versions lack JSON output

## Testing
- npm test -- --runTestsByPath tests/geminiSections.test.js tests/server.test.js *(fails: missing @babel/preset-env in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de06618bc0832b8d860b9ddc2a92fd