### PR TITLE
Add integration coverage for scoring and improvement endpoints

### DIFF
--- a/tests/improvementRoutes.test.js
+++ b/tests/improvementRoutes.test.js
@@ -1,0 +1,94 @@
+import request from 'supertest';
+import app from '../server.js';
+import { generateContentMock } from './mocks/generateContentMock.js';
+
+const baseResume = [
+  'Alex Candidate',
+  'Senior Software Engineer',
+  '# Summary',
+  'Original summary line focused on delivery.',
+  '# Skills',
+  '- JavaScript',
+  '# Experience',
+  '- Built scalable services.',
+].join('\n');
+
+const jobDescription = [
+  'We need a Lead Software Engineer to drive leadership and product execution.',
+  'Ideal candidates mentor teams and expand cloud expertise.',
+].join(' ');
+
+describe('targeted improvement routes', () => {
+  beforeEach(() => {
+    generateContentMock.mockReset();
+  });
+
+  it('returns a structured improvement summary for improve-summary', async () => {
+    generateContentMock.mockResolvedValueOnce({
+      response: {
+        text: () =>
+          JSON.stringify({
+            updatedResume: baseResume.replace(
+              'Original summary line focused on delivery.',
+              'Refined summary that highlights leadership impact.'
+            ),
+            beforeExcerpt: 'Original summary line focused on delivery.',
+            afterExcerpt: 'Refined summary that highlights leadership impact.',
+            explanation: 'Clarified the summary to emphasize leadership.',
+            confidence: 0.82,
+            changeDetails: [
+              {
+                section: 'Summary',
+                before: '- Original summary line focused on delivery.',
+                after: '- Refined summary that highlights leadership impact.',
+                reasons: ['Highlights leadership accomplishments.'],
+              },
+            ],
+          }),
+      },
+    });
+
+    const response = await request(app).post('/api/improve-summary').send({
+      resumeText: baseResume,
+      jobDescription,
+      jobSkills: ['Leadership', 'JavaScript'],
+      resumeSkills: ['JavaScript'],
+      missingSkills: ['Leadership'],
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        success: true,
+        type: 'improve-summary',
+        title: expect.any(String),
+        beforeExcerpt: 'Original summary line focused on delivery.',
+        afterExcerpt: 'Refined summary that highlights leadership impact.',
+        confidence: expect.any(Number),
+        updatedResume: expect.stringContaining('Refined summary'),
+        missingSkills: ['Leadership'],
+      })
+    );
+
+    expect(Array.isArray(response.body.improvementSummary)).toBe(true);
+    expect(response.body.improvementSummary[0]).toEqual(
+      expect.objectContaining({
+        section: 'Summary',
+        added: ['Refined summary that highlights leadership impact.'],
+        removed: ['Original summary line focused on delivery.'],
+        reason: ['Highlights leadership accomplishments.'],
+      })
+    );
+  });
+
+  it('validates required fields for improvement requests', async () => {
+    const response = await request(app)
+      .post('/api/add-missing-skills')
+      .send({ jobDescription });
+
+    expect(response.status).toBe(400);
+    expect(response.body?.error?.code).toBe('IMPROVEMENT_INPUT_REQUIRED');
+    expect(generateContentMock).not.toHaveBeenCalled();
+  });
+});
+

--- a/tests/improvements.e2e.test.js
+++ b/tests/improvements.e2e.test.js
@@ -1,0 +1,131 @@
+import request from 'supertest';
+import { setupTestServer } from './utils/testServer.js';
+
+const baseResume = [
+  'Alex Candidate',
+  'Senior Software Engineer',
+  '# Summary',
+  'Original summary line focused on delivery.',
+  '# Skills',
+  '- JavaScript',
+  '# Experience',
+  '- Built scalable services.',
+].join('\n');
+
+const jobDescription = [
+  'Looking for a Lead Software Engineer to guide teams and scale cloud systems.',
+  'Must demonstrate leadership and communication skills.',
+].join(' ');
+
+const basePayload = {
+  resumeText: baseResume,
+  jobDescription,
+  jobSkills: ['Leadership', 'Cloud Architecture', 'JavaScript'],
+  resumeSkills: ['JavaScript'],
+  missingSkills: ['Leadership', 'Cloud Architecture'],
+  jobTitle: 'Lead Software Engineer',
+  currentTitle: 'Senior Software Engineer',
+};
+
+describe('targeted improvement endpoints (integration)', () => {
+  test('each improvement route returns structured updates and scoring context', async () => {
+    const { app } = await setupTestServer();
+    const { generateContentMock } = await import('./mocks/generateContentMock.js');
+
+    generateContentMock.mockReset();
+    const aiResponses = [
+      {
+        route: '/api/improve-summary',
+        type: 'improve-summary',
+        expectation: {
+          summary: 'Refined summary spotlighting leadership wins.',
+          section: 'Summary',
+        },
+      },
+      {
+        route: '/api/add-missing-skills',
+        type: 'add-missing-skills',
+        expectation: {
+          summary: 'Added targeted skills including leadership and cloud.',
+          section: 'Skills',
+        },
+      },
+      {
+        route: '/api/change-designation',
+        type: 'change-designation',
+        expectation: {
+          summary: 'Aligned title with target role.',
+          section: 'Designation',
+        },
+      },
+      {
+        route: '/api/align-experience',
+        type: 'align-experience',
+        expectation: {
+          summary: 'Expanded experience bullets for leadership initiatives.',
+          section: 'Experience',
+        },
+      },
+      {
+        route: '/api/enhance-all',
+        type: 'enhance-all',
+        expectation: {
+          summary: 'Applied holistic improvements across resume sections.',
+          section: '',
+        },
+      },
+    ];
+
+    aiResponses.forEach(({ expectation }) => {
+      const updated = baseResume
+        .replace('Original summary line focused on delivery.', expectation.summary)
+        .replace('Senior Software Engineer', 'Lead Software Engineer');
+      generateContentMock.mockResolvedValueOnce({
+        response: {
+          text: () =>
+            JSON.stringify({
+              updatedResume: updated,
+              beforeExcerpt: 'Original summary line focused on delivery.',
+              afterExcerpt: expectation.summary,
+              explanation: expectation.summary,
+              confidence: 0.74,
+              changeDetails: [
+                {
+                  section: expectation.section || 'Summary',
+                  before: '- Original summary line focused on delivery.',
+                  after: `- ${expectation.summary}`,
+                  reasons: [expectation.summary],
+                },
+              ],
+            }),
+        },
+      });
+    });
+
+    for (const { route, type, expectation } of aiResponses) {
+      const response = await request(app)
+        .post(route)
+        .send({
+          ...basePayload,
+          jobTitle: basePayload.jobTitle,
+          currentTitle: basePayload.currentTitle,
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.type).toBe(type);
+      expect(typeof response.body.confidence).toBe('number');
+      expect(Array.isArray(response.body.missingSkills)).toBe(true);
+      expect(Array.isArray(response.body.improvementSummary)).toBe(true);
+      expect(response.body.improvementSummary.length).toBeGreaterThan(0);
+      const summaryEntry = response.body.improvementSummary[0];
+      if (expectation.section) {
+        expect(summaryEntry.section).toMatch(new RegExp(expectation.section, 'i'));
+      }
+      expect(summaryEntry.reason.join(' ')).toContain(expectation.summary.split(' ')[0]);
+    }
+
+    expect(generateContentMock).toHaveBeenCalledTimes(aiResponses.length);
+  });
+});
+

--- a/tests/rescoreImprovement.e2e.test.js
+++ b/tests/rescoreImprovement.e2e.test.js
@@ -1,0 +1,41 @@
+import request from 'supertest';
+import { setupTestServer } from './utils/testServer.js';
+
+describe('rescore improvement integration', () => {
+  test('calculates enhanced score, sub scores, and coverage details', async () => {
+    const { app } = await setupTestServer();
+
+    const response = await request(app)
+      .post('/api/rescore-improvement')
+      .send({
+        resumeText: [
+          'Summary',
+          'Leader in automation and cloud migrations.',
+          'Skills',
+          '- JavaScript',
+          '- AWS',
+          'Experience',
+          '- Built CI/CD pipelines and automated deployments.',
+        ].join('\n'),
+        jobDescriptionText:
+          'Looking for an engineer with JavaScript, AWS, and testing automation experience.',
+        jobSkills: ['JavaScript', 'AWS', 'Automation Testing'],
+        previousMissingSkills: ['JavaScript', 'AWS', 'Automation Testing'],
+        baselineScore: 45,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(typeof response.body.enhancedScore).toBe('number');
+    expect(Array.isArray(response.body.atsSubScores)).toBe(true);
+    expect(response.body.atsSubScores.length).toBeGreaterThan(0);
+    expect(Array.isArray(response.body.table)).toBe(true);
+    expect(Array.isArray(response.body.coveredSkills)).toBe(true);
+    expect(response.body.coveredSkills).toEqual(expect.arrayContaining(['JavaScript', 'AWS']));
+    expect(response.body.missingSkills).toEqual(
+      expect.arrayContaining(['Automation Testing'])
+    );
+    expect(typeof response.body.scoreDelta).toBe('number');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add backend coverage for targeted improvement endpoints and enhanced rescore assertions
- extend process CV e2e suite to cover classification failures
- add e2e coverage for each targeted improvement route and rescore scoring outputs

## Testing
- `npm test -- --runTestsByPath tests/rescoreImprovement.test.js tests/improvementRoutes.test.js tests/processCv.e2e.test.js tests/improvements.e2e.test.js tests/rescoreImprovement.e2e.test.js` *(fails: missing optional Babel preset in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de07b8f790832ba000e069421849dc