### PR TITLE
Improve resume alignment prompts with job description

### DIFF
--- a/tests/geminiPrompts.unit.test.js
+++ b/tests/geminiPrompts.unit.test.js
@@ -45,6 +45,7 @@ describe('rewriteSectionsWithGemini prompt construction', () => {
       'Jane Doe',
       sections,
       'Exciting job description here',
+      ['JavaScript', 'AWS'],
       generativeModelMock,
       { skipRequiredSections: true }
     );
@@ -54,12 +55,14 @@ describe('rewriteSectionsWithGemini prompt construction', () => {
     expect(prompt).toContain('elite resume architect');
     expect(prompt).toContain('Exciting job description here');
     expect(prompt).toContain('Never degrade CV structure');
+    expect(prompt).toContain('Align work experience bullets');
     expect(prompt).toContain('OUTPUT_SCHEMA');
     expect(prompt).toContain('INPUT_CONTEXT');
     expect(prompt).toMatch(/"resumeSections"/);
     expect(prompt).toMatch(/"summary"/);
     expect(prompt).toMatch(/"experience"/);
     expect(prompt).toMatch(/"projects"/);
+    expect(prompt).toMatch(/"jobSkills"/);
   });
 
   test('falls back gracefully when no generative model is provided', async () => {
@@ -70,6 +73,7 @@ describe('rewriteSectionsWithGemini prompt construction', () => {
       'Jane Doe',
       sections,
       'Job description',
+      [],
       null,
       { skipRequiredSections: true }
     );

--- a/tests/geminiSections.test.js
+++ b/tests/geminiSections.test.js
@@ -40,6 +40,7 @@ describe('rewriteSectionsWithGemini', () => {
       'John Doe',
       sections,
       'JD text',
+      ['Leadership', 'Skill C'],
       generativeModel,
       { skipRequiredSections: true }
     );
@@ -71,6 +72,7 @@ describe('rewriteSectionsWithGemini', () => {
       'Jane Doe',
       sections,
       'Job description text',
+      ['Communication'],
       generativeModel,
       options
     );


### PR DESCRIPTION
## Summary
- update the Gemini rewrite prompt to factor in job skills and demand experience, skills, and highlights align tightly with the job description
- strengthen the verifyResume prompt so it emphasises measurable, JD-linked experience, skill, and highlight updates without keyword stuffing
- adjust Gemini-related unit tests for the new function signature and prompt expectations

## Testing
- npm test -- --runTestsByPath tests/geminiPrompts.unit.test.js tests/geminiSections.test.js tests/verifyResume.test.js *(fails: missing @babel/preset-env preset in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de08d5fe14832b81376fdd341aedf7