### PR TITLE
Normalize improvement excerpts and defer LinkedIn validation

### DIFF
--- a/tests/processCv.e2e.test.js
+++ b/tests/processCv.e2e.test.js
@@ -88,6 +88,6 @@ describe('end-to-end CV processing', () => {
     expect(response.status).toBe(400);
     expect(response.body?.error?.code).toBe('INVALID_RESUME_CONTENT');
     expect(response.body?.error?.details?.description).toContain('job description');
-    expect(response.body?.message).toMatch(/Please upload a correct CV/i);
+    expect(response.body?.error?.message).toMatch(/Please upload a correct CV/i);
   });
 });


### PR DESCRIPTION
## Summary
- strip duplicated heading lines when merging targeted improvement sections and expose a reusable helper for excerpt normalization
- ensure AI change details propagate into improvement summaries and normalize before/after excerpts before responding
- defer LinkedIn URL validation until after document classification and adjust the E2E assertion for the structured error message

## Testing
- `npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68de0d0a424c832b88aff6a5b53bc78c