### PR TITLE
Automate CloudFront URL publication after deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -477,3 +477,32 @@ jobs:
           fi
 
           echo "Health check response: $response"
+
+      - name: Publish CloudFront URL
+        if: success()
+        shell: bash
+        env:
+          STACK_NAME: ${{ env.STACK_NAME }}
+        run: |
+          set -euo pipefail
+
+          npm run publish:cloudfront-url -- "$STACK_NAME"
+
+          summary_path="${GITHUB_STEP_SUMMARY:-}"
+          if [ -n "$summary_path" ]; then
+            {
+              printf '\n## Published CloudFront Distribution\n\n'
+              printf 'The active distribution details have been written to `config/published-cloudfront.json`.\n\n'
+              printf '```json\n'
+              cat config/published-cloudfront.json
+              printf '```\n'
+            } >>"$summary_path"
+          fi
+
+      - name: Upload published CloudFront metadata
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: published-cloudfront
+          path: config/published-cloudfront.json
+          if-no-files-found: error

--- a/config/published-cloudfront.json
+++ b/config/published-cloudfront.json
@@ -1,6 +1,6 @@
 {
-  "stackName": "",
-  "url": "https://example.cloudfront.net",
-  "distributionId": "",
-  "updatedAt": ""
+  "stackName": null,
+  "url": null,
+  "distributionId": null,
+  "updatedAt": null
 }


### PR DESCRIPTION
## Summary
- add a deployment workflow step that runs the CloudFront publishing script and exposes the resulting metadata in the job summary
- upload the generated published-cloudfront.json as a workflow artifact for easy download
- initialize the published-cloudfront.json placeholder with null values so it is safely overwritten by the script

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68de164a48b4832b8bc9ec93ca0321c1