### PR TITLE
Invalidate previous CloudFront domain when publishing new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ npm run publish:cloudfront-url -- <stack-name>
 ```
 
 - **`config/published-cloudfront.json`** is regenerated with the latest domain, distribution id, and timestamp. Commit this file (or surface it through your release notes) to broadcast the production URL.
-- If the script detects that the previously published distribution differs from the new one, it issues a `/*` invalidation so the retired distribution immediately stops caching portal assets.
+- If the script detects that the previously published distribution differs from the new one—or that the domain itself changed—it issues a `/*` invalidation so the retired distribution immediately stops caching portal assets.
 
 The recorded CloudFront URL is the entry point shared with users; redirect any legacy bookmarks to this domain to keep traffic on the latest deployment.
 

--- a/scripts/publish-cloudfront-url.mjs
+++ b/scripts/publish-cloudfront-url.mjs
@@ -71,13 +71,17 @@ async function main() {
     }
   }
 
+  const urlChanged = previous?.url && previous.url !== urlOutput.OutputValue
+
   if (
     previous?.distributionId &&
-    previous.distributionId !== distributionId
+    (previous.distributionId !== distributionId || urlChanged)
   ) {
     const callerReference = `resumeforge-${Date.now()}`
     console.log(
-      `Invalidating previous CloudFront distribution ${previous.distributionId} (/*)`
+      urlChanged
+        ? `Domain changed from ${previous.url} to ${urlOutput.OutputValue}; invalidating previous CloudFront distribution ${previous.distributionId} (/*)`
+        : `Invalidating previous CloudFront distribution ${previous.distributionId} (/*)`
     )
     await cloudFront.send(
       new CreateInvalidationCommand({


### PR DESCRIPTION
## Summary
- trigger an invalidation of the previously published CloudFront distribution whenever the stored domain changes
- clarify the README so operators know the script clears caches when the domain or distribution changes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de17003a40832ba862564294df59c4