### PR TITLE
Document CloudFront URL reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ https://<api-id>.execute-api.<region>.amazonaws.com/<stage>
 
 ### Publish the active CloudFront URL
 
-After each deployment, publish the fresh CloudFront domain so the team knows the canonical entry point for candidates. The helper script stores the URL in `config/published-cloudfront.json` and automatically invalidates the previously published distribution so caches stop serving stale assets.
+After each deployment, publish the fresh CloudFront domain so the team knows the canonical entry point for candidates. The helper script stores the URL in `config/published-cloudfront.json` and automatically invalidates the previously published distribution so caches stop serving stale assets. A human-readable snapshot of the latest URL also lives in [`docs/cloudfront-url.md`](docs/cloudfront-url.md) so you can surface the current domain in changelogs or onboarding docs without digging through JSON.
 
 ```bash
 npm run publish:cloudfront-url -- <stack-name>

--- a/docs/cloudfront-url.md
+++ b/docs/cloudfront-url.md
@@ -1,0 +1,25 @@
+# CloudFront distribution reference
+
+The **canonical production CloudFront domain** for ResumeForge lives in [`config/published-cloudfront.json`](../config/published-cloudfront.json). Treat that JSON file as the single source of truth for downstream docs, announcements, and redirects.
+
+```json
+{
+  "stackName": "ResumeForge",
+  "url": "https://d3exampleabcdef8.cloudfront.net",
+  "distributionId": "E123456789ABC",
+  "updatedAt": "2024-05-28T00:00:00.000Z"
+}
+```
+
+## Updating the published URL
+
+1. Deploy the CloudFormation/SAM stack.
+2. Run `npm run publish:cloudfront-url -- <stack-name>` to refresh `config/published-cloudfront.json` with the most recent distribution metadata.
+3. Commit the updated JSON file so the new domain is visible to the team.
+
+The script automatically invalidates the previous distribution (when it changes) and updates the helper endpoints that surface the active domain:
+
+- `GET /api/published-cloudfront`
+- `GET /go/cloudfront` (alias `/redirect/latest`)
+
+These endpoints reflect whatever value is stored in `config/published-cloudfront.json`, so keeping that file current keeps all documentation and redirects accurate.


### PR DESCRIPTION
## Summary
- add a docs/cloudfront-url reference capturing the canonical CloudFront domain and update flow
- link the README CloudFront publishing section to the new quick-reference doc

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68de274332ac832b90ddd72d4f4affb5