### PR TITLE
Document CloudFront URL publication flow

### DIFF
--- a/docs/cloudfront-url.md
+++ b/docs/cloudfront-url.md
@@ -14,8 +14,9 @@ The **canonical production CloudFront domain** for ResumeForge lives in [`config
 ## Updating the published URL
 
 1. Deploy the CloudFormation/SAM stack.
-2. Run `npm run publish:cloudfront-url -- <stack-name>` to refresh `config/published-cloudfront.json` with the most recent distribution metadata.
-3. Commit the updated JSON file so the new domain is visible to the team.
+2. Run `npm run print:cloudfront-url -- <stack-name>` to confirm the CloudFront domain that the deployment produced.
+3. When you are ready to publish that domain, run `npm run publish:cloudfront-url -- <stack-name>`. This both writes the latest distribution metadata to `config/published-cloudfront.json` and issues an invalidation for the previously published distribution (when it changes).
+4. Commit the updated JSON file so the new domain is visible to the team.
 
 The script automatically invalidates the previous distribution (when it changes) and updates the helper endpoints that surface the active domain:
 
@@ -23,3 +24,5 @@ The script automatically invalidates the previous distribution (when it changes)
 - `GET /go/cloudfront` (alias `/redirect/latest`)
 
 These endpoints reflect whatever value is stored in `config/published-cloudfront.json`, so keeping that file current keeps all documentation and redirects accurate.
+
+After publishing, share the refreshed domain from `config/published-cloudfront.json` with downstream consumers so they can update bookmarks, integrations, or public references.


### PR DESCRIPTION
## Summary
- document the post-deploy workflow for checking and publishing CloudFront domains
- clarify that publishing updates the JSON metadata, issues an invalidation, and should be shared downstream

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68de2b3c76ec832ba6725f1baa092a88