### PR TITLE
Fix improvement flow initialization order

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -679,6 +679,7 @@ function App() {
       : !jdValidationComplete
         ? 'Job description validation is still in progress. Please wait until it completes.'
         : ''
+  const improvementBusy = Boolean(activeImprovement)
   const flowSteps = useMemo(() => {
     const improvementsComplete = improvementCount > 0
     const downloadComplete = downloadCount > 0
@@ -1267,7 +1268,6 @@ function App() {
 
   const improvementAvailable =
     improvementsUnlocked && Boolean(resumeText && resumeText.trim()) && Boolean(jobDescriptionText && jobDescriptionText.trim())
-  const improvementBusy = Boolean(activeImprovement)
   const manualJobDescriptionActive =
     manualJobDescriptionRequired || manualJobDescription.trim().length > 0
 


### PR DESCRIPTION
## Summary
- compute the improvement busy flag before building the flow step memoization to avoid referencing it before initialization

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de2f722160832bbe93c3459af9a7a8