### PR TITLE
Fix versions prompt join string formatting

### DIFF
--- a/server.js
+++ b/server.js
@@ -7431,8 +7431,8 @@ app.post(
         '',
         'INPUT_CONTEXT:',
         JSON.stringify(versionsContext, null, 2),
-      ].join('
-');
+      ].join('\n');
+
 
       logStructured('info', 'generation_versions_prompt_created', {
         ...logContext,


### PR DESCRIPTION
## Summary
- fix the versions prompt assembly to use a single-line join call with a newline separator so Jest can parse server.js

## Testing
- npm test -- --runInBand *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68de4d380c14832b8d358dc26ea8644e