### PR TITLE
Fix misplaced brace in process CV handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -8801,9 +8801,6 @@ app.post(
         coverTemplate2,
       },
     });
-}
-
-
 
   } catch (err) {
     const failureMessage = describeProcessingFailure(err);


### PR DESCRIPTION
## Summary
- remove the stray closing brace before the process CV catch clause so the file parses correctly

## Testing
- npm test -- --runInBand *(fails: missing @babel/preset-env package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de521e9b44832b9b4ee5e26a86627f