### PR TITLE
Add GetItemCommand mock for DynamoDB

### DIFF
--- a/tests/mocks/aws-sdk-client-dynamodb.js
+++ b/tests/mocks/aws-sdk-client-dynamodb.js
@@ -42,3 +42,10 @@ export class DeleteItemCommand {
     this.__type = 'DeleteItemCommand';
   }
 }
+
+export class GetItemCommand {
+  constructor(input) {
+    this.input = input;
+    this.__type = 'GetItemCommand';
+  }
+}


### PR DESCRIPTION
## Summary
- add a GetItemCommand export to the DynamoDB client mock so tests can import it without syntax errors

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68de5391c4f4832b95be44d75d44ebb5