### PR TITLE
Fix DynamoDB import compatibility with Jest mocks

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,7 +18,8 @@ import {
   DeleteObjectCommand,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import {
+import * as DynamoDB from '@aws-sdk/client-dynamodb';
+const {
   DynamoDBClient,
   CreateTableCommand,
   DescribeTableCommand,
@@ -27,7 +28,7 @@ import {
   UpdateItemCommand,
   ScanCommand,
   DeleteItemCommand,
-} from '@aws-sdk/client-dynamodb';
+} = DynamoDB;
 import fs from 'fs/promises';
 import fsSync from 'fs';
 import { logEvent, logErrorTrace } from './logger.js';


### PR DESCRIPTION
## Summary
- switch the DynamoDB client import in `server.js` to a namespace import
- destructure the commands from the namespace so Jest ESM module mocks resolve correctly

## Testing
- npm test -- --runInBand *(fails: environment is missing @babel/preset-env even though it is listed in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68de5f09ec44832b8033c00fd59266cd