### PR TITLE
Handle conflicting SAM change sets during deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -298,6 +298,36 @@ jobs:
             fi
 
             : >"$tmp_err"
+            if printf '%s\n' "$deploy_err_normalized" | grep -Eqi 'AlreadyExistsException' && \
+               printf '%s\n' "$deploy_err_normalized" | grep -Eqi 'ChangeSet [^ ]* cannot be created due to a mismatch with existing attribute Description'; then
+              change_set_name=$(printf '%s\n' "$deploy_err" | sed -n "s/.*ChangeSet[[:space:]]\([^[:space:]]*\)[[:space:]].*/\1/p" | head -n1)
+
+              if [ -z "$change_set_name" ]; then
+                echo "sam deploy reported an AlreadyExistsException but the change set name could not be determined." >&2
+                exit 1
+              fi
+
+              echo "Existing change set '$change_set_name' has conflicting description. Deleting before retrying..."
+              : >"$tmp_err"
+              if aws cloudformation delete-change-set \
+                  --stack-name "$STACK_NAME" \
+                  --change-set-name "$change_set_name" 1>/dev/null 2>"$tmp_err"; then
+                echo "Deleted conflicting change set '$change_set_name'."
+              else
+                delete_conflict_err=$(cat "$tmp_err")
+                if echo "$delete_conflict_err" | grep -qi "does not exist"; then
+                  echo "Change set '$change_set_name' no longer exists. Proceeding with retry."
+                else
+                  echo "Failed to delete conflicting change set: $delete_conflict_err" >&2
+                  exit 1
+                fi
+              fi
+
+              deploy_attempt=$((deploy_attempt + 1))
+              sleep 15
+              continue
+            fi
+
             if printf '%s\n' "$deploy_err_normalized" | grep -Eqi 'UPDATE_ROLLBACK_COMPLETE|ROLLBACK_COMPLETE'; then
               echo "sam deploy failed because the stack entered a rollback-complete state. Deleting stack '$STACK_NAME' before retrying..."
               aws cloudformation delete-stack --stack-name "$STACK_NAME"


### PR DESCRIPTION
## Summary
- detect AWS SAM AlreadyExistsException errors caused by conflicting change set descriptions
- delete the conflicting change set and retry the deployment instead of failing immediately

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68df3cdae084832ba577dbf145ee518b