### PR TITLE
Preserve resume formatting in sanitized output

### DIFF
--- a/tests/sanitizeGeneratedText.test.js
+++ b/tests/sanitizeGeneratedText.test.js
@@ -127,4 +127,27 @@ describe('sanitizeGeneratedText', () => {
       ].join('\n')
     );
   });
+
+  test('preserves multiline bullets and job separators', () => {
+    const input = [
+      'Taylor Doe',
+      '# Work Experience',
+      '- Senior Engineer | Big Co | 2022 - Present',
+      '  Led cross-functional initiatives across 5 teams',
+      '- Built analytics platform',
+      '  Increased NPS by 20%',
+      '# Skills',
+      '- JavaScript',
+      '- Python'
+    ].join('\n');
+
+    const sanitized = sanitizeGeneratedText(input, { skipRequiredSections: true });
+
+    expect(sanitized).toMatch(
+      /Senior Engineer \| Big Co \| 2022 - Present/
+    );
+    expect(sanitized).toMatch(
+      /Built analytics platform\nIncreased NPS by 20%/
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- ensure pipe-delimited experience entries keep every separator when parsing resume bullets
- reuse a token-aware stringifier so sanitized resumes preserve bullets, newlines, and job separators
- cover the new formatting guarantees with a sanitizeGeneratedText test for multi-line bullets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df4ba90810832b8a17f88b7cdbd655