### PR TITLE
feat: add multi-template resume selection

### DIFF
--- a/templates/ats.html
+++ b/templates/ats.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Resume</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;600;700&display=swap');
+
+    body {
+      margin: 0;
+      padding: 48px 40px;
+      font-family: 'Source Sans 3', Arial, sans-serif;
+      color: #1f2937;
+      background: #f3f4f6;
+    }
+
+    .page {
+      max-width: 800px;
+      margin: 0 auto;
+      background: #ffffff;
+      border: 1px solid #d1d5db;
+      box-shadow: 0 18px 42px rgba(17, 24, 39, 0.1);
+      padding: 48px 56px;
+    }
+
+    header {
+      border-bottom: 1px solid #d1d5db;
+      padding-bottom: 16px;
+      margin-bottom: 24px;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: 32px;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+    }
+
+    header p {
+      margin: 4px 0 0;
+      font-size: 14px;
+      color: #4b5563;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    section {
+      margin-bottom: 22px;
+    }
+
+    h2 {
+      margin: 0 0 12px;
+      font-size: 16px;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: #1f2937;
+    }
+
+    ul {
+      list-style: disc;
+      margin: 0;
+      padding-left: 20px;
+      display: grid;
+      gap: 8px;
+    }
+
+    li {
+      line-height: 1.55;
+      color: #111827;
+      white-space: pre-wrap;
+    }
+
+    li strong {
+      color: #111827;
+    }
+
+    li em {
+      color: #4b5563;
+    }
+
+    @media print {
+      body {
+        padding: 0;
+        background: #ffffff;
+      }
+      .page {
+        box-shadow: none;
+        border: none;
+        padding: 32px 40px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <header>
+      <h1>{{name}}</h1>
+      <p>ATS Optimized Resume</p>
+    </header>
+    {{#each sections}}
+    <section>
+      {{#if heading}}
+      <h2>{{heading}}</h2>
+      {{/if}}
+      {{#if items}}
+      <ul>
+        {{#each items}}
+        <li>{{{this}}}</li>
+        {{/each}}
+      </ul>
+      {{/if}}
+    </section>
+    {{/each}}
+  </div>
+</body>
+</html>

--- a/templates/classic.html
+++ b/templates/classic.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Resume</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Source+Serif+4:wght@300;400;500;600&display=swap');
+
+    :root {
+      --ink: #1f2933;
+      --muted: #52606d;
+      --accent: #2d5a9e;
+      --background: #fbfaf7;
+      --border: rgba(31, 41, 51, 0.12);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      padding: 48px 56px;
+      font-family: 'Source Serif 4', 'Times New Roman', serif;
+      color: var(--ink);
+      background: linear-gradient(180deg, rgba(241, 245, 249, 0.9), transparent 120%),
+        var(--background);
+    }
+
+    .sheet {
+      max-width: 820px;
+      margin: 0 auto;
+      background: #fff;
+      border: 1px solid var(--border);
+      box-shadow: 0 24px 50px rgba(31, 41, 51, 0.08);
+      padding: 56px 64px;
+      border-radius: 12px;
+    }
+
+    header {
+      border-bottom: 2px solid var(--accent);
+      padding-bottom: 24px;
+      margin-bottom: 32px;
+    }
+
+    header h1 {
+      font-family: 'Playfair Display', 'Times New Roman', serif;
+      font-size: 38px;
+      letter-spacing: 0.04em;
+      margin: 0 0 6px;
+      text-transform: uppercase;
+    }
+
+    header p {
+      margin: 0;
+      font-size: 16px;
+      letter-spacing: 0.12em;
+      color: var(--muted);
+      text-transform: uppercase;
+    }
+
+    .sections {
+      display: grid;
+      gap: 28px;
+    }
+
+    section {
+      position: relative;
+      padding-left: 18px;
+    }
+
+    section::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 2px;
+      bottom: 6px;
+      width: 3px;
+      background: linear-gradient(180deg, var(--accent), transparent);
+      border-radius: 999px;
+      opacity: 0.4;
+    }
+
+    h2 {
+      font-family: 'Playfair Display', 'Times New Roman', serif;
+      font-size: 20px;
+      font-weight: 600;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      margin: 0 0 14px;
+      color: var(--accent);
+    }
+
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 12px;
+    }
+
+    li {
+      position: relative;
+      padding-left: 16px;
+      line-height: 1.6;
+      color: var(--ink);
+      white-space: pre-wrap;
+    }
+
+    li::before {
+      content: '•';
+      position: absolute;
+      left: 0;
+      top: 0.1em;
+      color: var(--accent);
+      font-size: 18px;
+    }
+
+    strong {
+      color: var(--ink);
+      font-weight: 600;
+    }
+
+    em {
+      color: var(--muted);
+    }
+
+    @media (max-width: 720px) {
+      body {
+        padding: 24px;
+      }
+      .sheet {
+        padding: 36px 28px;
+      }
+      header h1 {
+        font-size: 32px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="sheet">
+    <header>
+      <h1>{{name}}</h1>
+      <p>Curriculum Vitae</p>
+    </header>
+    <div class="sections">
+      {{#each sections}}
+      <section>
+        {{#if heading}}
+        <h2>{{heading}}</h2>
+        {{/if}}
+        {{#if items}}
+        <ul>
+          {{#each items}}
+          <li>{{{this}}}</li>
+          {{/each}}
+        </ul>
+        {{/if}}
+      </section>
+      {{/each}}
+    </div>
+  </main>
+</body>
+</html>

--- a/templates/creative.html
+++ b/templates/creative.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Resume</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&family=Fira+Sans:wght@400;500;600&display=swap');
+
+    body {
+      margin: 0;
+      padding: 44px;
+      font-family: 'Fira Sans', 'Poppins', sans-serif;
+      color: #1a202c;
+      background: radial-gradient(circle at top left, rgba(236, 72, 153, 0.22), transparent 60%),
+        radial-gradient(circle at bottom right, rgba(56, 189, 248, 0.24), transparent 55%),
+        #f9fafb;
+    }
+
+    .canvas {
+      max-width: 840px;
+      margin: 0 auto;
+      background: #ffffff;
+      border-radius: 24px;
+      box-shadow: 0 26px 60px rgba(15, 23, 42, 0.14);
+      overflow: hidden;
+    }
+
+    header {
+      background: linear-gradient(135deg, #6366f1, #ec4899);
+      color: #fff;
+      padding: 48px 56px 42px;
+      position: relative;
+    }
+
+    header::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.22), transparent 55%);
+      mix-blend-mode: screen;
+      pointer-events: none;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: 40px;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+    }
+
+    header p {
+      margin: 12px 0 0;
+      font-size: 16px;
+      text-transform: uppercase;
+      letter-spacing: 0.22em;
+      opacity: 0.85;
+    }
+
+    .sections {
+      padding: 40px 56px 52px;
+      display: grid;
+      gap: 28px;
+    }
+
+    section {
+      border-left: 6px solid rgba(99, 102, 241, 0.16);
+      padding-left: 22px;
+      background: linear-gradient(120deg, rgba(236, 72, 153, 0.05), rgba(56, 189, 248, 0.06));
+      border-radius: 18px;
+      box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.08);
+      padding-top: 24px;
+      padding-bottom: 24px;
+    }
+
+    h2 {
+      margin: 0 0 14px;
+      font-size: 19px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      color: #4338ca;
+    }
+
+    ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: grid;
+      gap: 14px;
+    }
+
+    li {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 12px;
+      align-items: start;
+      color: #1f2937;
+      white-space: pre-wrap;
+      line-height: 1.6;
+    }
+
+    .marker {
+      width: 1.2em;
+      height: 1.2em;
+      border-radius: 12px;
+      background: rgba(236, 72, 153, 0.2);
+      color: #ec4899;
+      display: grid;
+      place-items: center;
+      font-weight: 700;
+      font-size: 0.72rem;
+      margin-top: 4px;
+    }
+
+    li strong {
+      color: #111827;
+    }
+
+    li em {
+      color: #64748b;
+    }
+
+    @media (max-width: 768px) {
+      body {
+        padding: 24px;
+      }
+      header {
+        padding: 36px 32px 30px;
+      }
+      .sections {
+        padding: 28px 32px 36px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <article class="canvas">
+    <header>
+      <h1>{{name}}</h1>
+      <p>Creative Resume</p>
+    </header>
+    <div class="sections">
+      {{#each sections}}
+      <section>
+        {{#if heading}}
+        <h2>{{heading}}</h2>
+        {{/if}}
+        {{#if items}}
+        <ul>
+          {{#each items}}
+          <li>
+            <span class="marker">◆</span>
+            <span>{{{this}}}</span>
+          </li>
+          {{/each}}
+        </ul>
+        {{/if}}
+      </section>
+      {{/each}}
+    </div>
+  </article>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add canonical resume template handling with new classic, creative, and ATS options while persisting selections in templateContext
- extend server template resolution and API payloads to accept templateId aliases and return available templates
- add new classic, creative, and ats HTML resume templates under /templates

## Testing
- npm test *(fails: missing optional dependency @babel/preset-env in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df4d8a9980832b9cfa9260705bfb20