### PR TITLE
Require pasted job descriptions

### DIFF
--- a/docs/user-journey.md
+++ b/docs/user-journey.md
@@ -8,9 +8,9 @@ This guide walks a candidate through ResumeForge end to end so every action has 
 - **Expected result:** If the document passes validation, the upload progress bar completes and the session status changes to **Résumé received**. When the file is rejected the UI surfaces a blocking alert (for example, “This looks like a presentation deck. Please upload a CV.”) and the candidate can try again without losing form progress.
 
 ## 2. Supply the job description
-- **What to do:** Paste a public job-description URL or the raw description text.
-- **Behind the scenes:** The backend attempts to fetch and clean the job description. If the host blocks the request (login walls, geo-fencing, expired links) the API flags `manualInputRequired`.
-- **Expected result:** Successful fetches show a formatted preview so the candidate confirms the correct vacancy. When fetching fails, the interface automatically expands a text box with guidance to paste the full description manually.
+- **What to do:** Paste the entire job description into the textbox.
+- **Behind the scenes:** The backend accepts the pasted text as the canonical JD—no scraping or external fetch is attempted—so protected or expired postings no longer block the flow.
+- **Expected result:** The candidate sees the pasted JD captured instantly and can move straight to scoring without worrying about URL accessibility.
 
 ## 3. Launch the ATS analysis
 - **What to do:** Press **Evaluate me against the JD**.
@@ -28,6 +28,6 @@ This guide walks a candidate through ResumeForge end to end so every action has 
 - **Expected result:** The candidate receives ATS-optimised résumé PDFs (2025 design), a tailored cover letter, and a summary of the enhancements to reference during interviews. Sessions automatically expire after the retention window to satisfy GDPR requirements.
 
 ## Troubleshooting quick reference
-- **Blocked job description:** Paste the content manually when prompted.
+- **Blocked job description:** Already resolved—the experience now always relies on the pasted text rather than remote fetching.
 - **Missing configuration error:** Ask an administrator to supply the required environment variables or runtime config file (see README).
 - **Need to restart:** Refreshing the browser restores the latest saved state from DynamoDB so the candidate never loses accepted improvements.

--- a/server.js
+++ b/server.js
@@ -9155,11 +9155,20 @@ app.post(
   };
 
   const { jobDescriptionUrl, linkedinProfileUrl, credlyProfileUrl } = req.body;
+  const manualJobDescriptionInput =
+    typeof req.body.manualJobDescription === 'string'
+      ? req.body.manualJobDescription
+      : typeof req.body.jobDescriptionText === 'string'
+        ? req.body.jobDescriptionText
+        : '';
+  const manualJobDescription = sanitizeManualJobDescription(manualJobDescriptionInput);
+  const hasManualJobDescription = Boolean(manualJobDescription);
   logStructured('info', 'process_cv_started', {
     ...logContext,
     jobDescriptionHost: getUrlHost(jobDescriptionUrl),
     linkedinHost: getUrlHost(linkedinProfileUrl),
     credlyHost: getUrlHost(credlyProfileUrl),
+    manualJobDescriptionProvided: hasManualJobDescription,
   });
   const bodyTemplate =
     typeof req.body.template === 'string' ? req.body.template.trim() : '';
@@ -9219,13 +9228,14 @@ app.post(
       { field: 'resume' }
     );
   }
-  if (!jobDescriptionUrl) {
+  if (!hasManualJobDescription) {
     logStructured('warn', 'job_description_missing', logContext);
     return sendError(
       res,
       400,
-      'JOB_DESCRIPTION_URL_REQUIRED',
-      'jobDescriptionUrl required'
+      'JOB_DESCRIPTION_REQUIRED',
+      'manualJobDescription required',
+      { field: 'manualJobDescription' }
     );
   }
   const ext = (path.extname(req.file.originalname) || '').toLowerCase();
@@ -9621,16 +9631,6 @@ app.post(
       event: 'selected_templates',
       message: `template1=${template1}; template2=${template2}`
     });
-
-    const manualJobDescriptionInput =
-      typeof req.body.manualJobDescription === 'string'
-        ? req.body.manualJobDescription
-        : typeof req.body.jobDescriptionText === 'string'
-          ? req.body.jobDescriptionText
-          : '';
-    const manualJobDescription = sanitizeManualJobDescription(
-      manualJobDescriptionInput
-    );
 
     let jobDescriptionHtml;
     if (manualJobDescription) {

--- a/templates/portal.html
+++ b/templates/portal.html
@@ -183,7 +183,7 @@
     <main class="card">
       <h1>Evaluate Your CV</h1>
       <p class="lead">
-        Upload your CV and provide the job description URL to evaluate how well it matches.
+        Upload your CV and paste the full job description to evaluate how well it matches.
       </p>
       <form id="portal-form">
         <label>
@@ -192,13 +192,14 @@
           <span class="hint">Drag &amp; drop supported. Maximum size: 5&nbsp;MB.</span>
         </label>
         <label>
-          Job description URL
-          <input
-            type="url"
-            name="jobDescriptionUrl"
-            placeholder="https://company.com/careers/role"
+          Paste full job description
+          <textarea
+            name="manualJobDescription"
+            placeholder="Paste the entire job post here"
+            rows="6"
             required
-          />
+          ></textarea>
+          <span class="hint">We’ll analyse this text directly—no URL scraping required.</span>
         </label>
         <label>
           LinkedIn profile URL

--- a/tests/awsStorage.integration.test.js
+++ b/tests/awsStorage.integration.test.js
@@ -5,6 +5,11 @@ import { setupTestServer, primeSuccessfulAi } from './utils/testServer.js';
 
 const hash = (value) => crypto.createHash('sha256').update(String(value)).digest('hex');
 
+const MANUAL_JOB_DESCRIPTION = `
+Join our platform engineering team to build resilient infrastructure and developer tooling.
+Collaborate across functions, automate deployments, and improve service reliability.
+`;
+
 describe('AWS integrations for /api/process-cv', () => {
   test('writes uploads and metadata to S3 and DynamoDB', async () => {
     const { app, mocks } = await setupTestServer();
@@ -12,7 +17,7 @@ describe('AWS integrations for /api/process-cv', () => {
 
     const response = await request(app)
       .post('/api/process-cv')
-      .field('jobDescriptionUrl', 'https://example.com/job')
+      .field('manualJobDescription', MANUAL_JOB_DESCRIPTION)
       .field('linkedinProfileUrl', 'https://linkedin.com/in/example')
       .attach('resume', Buffer.from('dummy'), 'resume.pdf');
 
@@ -106,7 +111,7 @@ describe('AWS integrations for /api/process-cv', () => {
 
     const response = await request(app)
       .post('/api/process-cv')
-      .field('jobDescriptionUrl', 'https://example.com/job')
+      .field('manualJobDescription', MANUAL_JOB_DESCRIPTION)
       .field('linkedinProfileUrl', 'https://linkedin.com/in/example')
       .attach('resume', Buffer.from('dummy'), 'resume.pdf');
 
@@ -133,7 +138,7 @@ describe('AWS integrations for /api/process-cv', () => {
 
     const response = await request(app)
       .post('/api/process-cv')
-      .field('jobDescriptionUrl', 'https://example.com/job')
+      .field('manualJobDescription', MANUAL_JOB_DESCRIPTION)
       .field('linkedinProfileUrl', 'https://linkedin.com/in/example')
       .attach('resume', Buffer.from('dummy'), 'resume.pdf');
 

--- a/tests/processCv.e2e.test.js
+++ b/tests/processCv.e2e.test.js
@@ -1,6 +1,11 @@
 import request from 'supertest';
 import { setupTestServer, primeSuccessfulAi } from './utils/testServer.js';
 
+const MANUAL_JOB_DESCRIPTION = `
+We are hiring a backend engineer to build APIs, manage cloud infrastructure, and mentor teammates.
+Deliver resilient services, partner with product, and drive continuous improvement.
+`;
+
 describe('end-to-end CV processing', () => {
   test('returns scoring insights without generating downloads', async () => {
     const { app } = await setupTestServer();
@@ -10,7 +15,7 @@ describe('end-to-end CV processing', () => {
       .post('/api/process-cv')
       .set('User-Agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36')
       .set('X-Forwarded-For', '198.51.100.23')
-      .field('jobDescriptionUrl', 'https://example.com/job')
+      .field('manualJobDescription', MANUAL_JOB_DESCRIPTION)
       .field('linkedinProfileUrl', 'https://linkedin.com/in/example')
       .attach('resume', Buffer.from('dummy'), 'resume.pdf');
 
@@ -59,7 +64,8 @@ describe('end-to-end CV processing', () => {
       .post('/api/process-cv')
       .set('User-Agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_0) AppleWebKit/605.1.15')
       .set('X-Forwarded-For', '198.51.100.24')
-      .field('jobDescriptionUrl', 'https://example.com/job')
+      .field('manualJobDescription', MANUAL_JOB_DESCRIPTION)
+      .field('linkedinProfileUrl', 'https://linkedin.com/in/example')
       .attach('resume', Buffer.from('dummy'), 'resume.pdf');
 
     expect(response.status).toBe(400);


### PR DESCRIPTION
## Summary
- require candidates to paste the job description in the React client and portal template instead of entering a URL
- update the API to validate manual job description text and adjust documentation to reflect the new flow
- refresh automated tests to exercise the manual JD path in unit, integration, and e2e suites

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df6ed0f1e4832bacf7fead2d248929