### PR TITLE
Add job description preview before scoring

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,6 +7,7 @@ import TemplateSelector from './components/TemplateSelector.jsx'
 import DeltaSummaryPanel from './components/DeltaSummaryPanel.jsx'
 import ProcessFlow from './components/ProcessFlow.jsx'
 import ChangeComparisonView from './components/ChangeComparisonView.jsx'
+import JobDescriptionPreview from './components/JobDescriptionPreview.jsx'
 import { deriveDeltaSummary } from './deriveDeltaSummary.js'
 
 const CV_GENERATION_ERROR_MESSAGE =
@@ -2495,6 +2496,9 @@ function App() {
                   ? 'This job post blocked automatic access. Paste the full JD to continue.'
                   : 'Paste the JD text here or provide the job post URL above and we will fetch it automatically.'}
               </p>
+              {hasManualJobDescriptionInput && (
+                <JobDescriptionPreview text={manualJobDescription} />
+              )}
             </div>
             <input
               type="url"

--- a/client/src/components/JobDescriptionPreview.jsx
+++ b/client/src/components/JobDescriptionPreview.jsx
@@ -1,0 +1,82 @@
+import { useMemo } from 'react'
+import parseJobDescriptionText from '../utils/parseJobDescriptionText.js'
+
+function JobDescriptionPreview({ text }) {
+  const parsed = useMemo(() => parseJobDescriptionText(text), [text])
+
+  if (!parsed) return null
+
+  const { title, sections, keywords, wordCount, meta } = parsed
+
+  return (
+    <section
+      className="space-y-4 rounded-2xl border border-purple-200 bg-white/70 p-4 text-left shadow-sm"
+      data-testid="job-description-preview"
+    >
+      <header className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-purple-900">Job Description Preview</h2>
+          <p className="text-sm text-purple-600/80">
+            Confirm the parsed JD content below before running the ATS score so we analyse the exact role you pasted.
+          </p>
+        </div>
+        <div className="flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.35em] text-purple-500">
+          <span data-testid="jd-word-count">{wordCount} words</span>
+          {sections.length > 0 && <span data-testid="jd-section-count">{sections.length} sections</span>}
+        </div>
+      </header>
+
+      <div className="space-y-3 rounded-xl bg-gradient-to-r from-purple-50 to-white p-4">
+        <h3 className="text-xl font-bold text-purple-900" data-testid="jd-title">
+          {title}
+        </h3>
+        {meta.length > 0 && (
+          <dl className="grid gap-2 text-sm text-purple-700 sm:grid-cols-2" data-testid="jd-meta">
+            {meta.map((item) => (
+              <div key={`${item.label}-${item.value}`} className="flex items-center gap-2">
+                <dt className="text-xs font-semibold uppercase tracking-wide text-purple-500">{item.label}</dt>
+                <dd className="font-medium text-purple-800">{item.value}</dd>
+              </div>
+            ))}
+          </dl>
+        )}
+        {keywords.length > 0 && (
+          <div className="flex flex-wrap gap-2" data-testid="jd-keywords">
+            {keywords.map((keyword) => (
+              <span
+                key={keyword}
+                className="inline-flex items-center rounded-full bg-purple-100 px-3 py-1 text-xs font-semibold text-purple-700"
+              >
+                {keyword}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-4">
+        {sections.map((section) => (
+          <article key={section.heading} className="space-y-2 rounded-xl border border-purple-100 bg-white/90 p-4">
+            <h4 className="text-sm font-semibold uppercase tracking-[0.3em] text-purple-500" data-testid="jd-section-title">
+              {section.heading}
+            </h4>
+            <div className="space-y-2 text-sm leading-relaxed text-purple-900" data-testid="jd-section-content">
+              {section.paragraphs.map((paragraph, index) => (
+                <p key={`paragraph-${index}`}>{paragraph}</p>
+              ))}
+              {section.bullets.length > 0 && (
+                <ul className="list-disc space-y-1 pl-5 marker:text-purple-400">
+                  {section.bullets.map((bullet, index) => (
+                    <li key={`bullet-${index}`}>{bullet}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export default JobDescriptionPreview

--- a/client/src/utils/__tests__/parseJobDescriptionText.test.js
+++ b/client/src/utils/__tests__/parseJobDescriptionText.test.js
@@ -1,0 +1,54 @@
+import { parseJobDescriptionText } from '../parseJobDescriptionText.js'
+
+describe('parseJobDescriptionText', () => {
+  it('extracts title, meta, sections, and bullets from a pasted JD', () => {
+    const text = `
+Senior Product Manager
+Company: Innovate Labs
+Location: Remote (US)
+Responsibilities:
+- Lead product roadmap and prioritisation
+- Partner with engineering and design to deliver releases
+Requirements:
+- 5+ years product management experience
+- Comfortable with SQL and experimentation frameworks
+Nice to have:
+- Fintech or payments background
+`
+
+    const parsed = parseJobDescriptionText(text)
+
+    expect(parsed.title).toBe('Senior Product Manager')
+    expect(parsed.wordCount).toBeGreaterThan(10)
+    expect(parsed.meta).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'Company', value: 'Innovate Labs' }),
+        expect.objectContaining({ label: 'Location', value: 'Remote (US)' }),
+      ])
+    )
+    const responsibilities = parsed.sections.find((section) => section.heading === 'Responsibilities')
+    expect(responsibilities).toBeDefined()
+    expect(responsibilities.bullets).toEqual(
+      expect.arrayContaining([
+        'Lead product roadmap and prioritisation',
+        'Partner with engineering and design to deliver releases',
+      ])
+    )
+    const requirements = parsed.sections.find((section) => section.heading === 'Requirements')
+    expect(requirements).toBeDefined()
+    expect(requirements.bullets).toEqual(
+      expect.arrayContaining([
+        '5+ years product management experience',
+        'Comfortable with SQL and experimentation frameworks',
+      ])
+    )
+    expect(parsed.keywords.length).toBeGreaterThan(0)
+    expect(parsed.keywords).toContain('product')
+  })
+
+  it('returns null when no meaningful text is supplied', () => {
+    expect(parseJobDescriptionText('')).toBeNull()
+    expect(parseJobDescriptionText('   ')).toBeNull()
+    expect(parseJobDescriptionText(null)).toBeNull()
+  })
+})

--- a/client/src/utils/parseJobDescriptionText.js
+++ b/client/src/utils/parseJobDescriptionText.js
@@ -1,0 +1,316 @@
+const SECTION_KEYWORDS = [
+  {
+    label: 'Overview',
+    patterns: [
+      /^overview$/i,
+      /^about (the )?role/i,
+      /^role overview/i,
+      /^about us/i,
+      /^mission$/i,
+    ],
+  },
+  {
+    label: 'Responsibilities',
+    patterns: [
+      /responsibil/i,
+      /what (you('ll| will) do|we expect)/i,
+      /day[-\s]*to[-\s]*day/i,
+      /duties/i,
+      /in this role/i,
+    ],
+  },
+  {
+    label: 'Requirements',
+    patterns: [
+      /requirement/i,
+      /qualification/i,
+      /what you bring/i,
+      /skills you/i,
+      /you(('|\s)ll) need/i,
+      /experience/i,
+    ],
+  },
+  {
+    label: 'Preferred Qualifications',
+    patterns: [
+      /preferred/i,
+      /nice to have/i,
+      /bonus/i,
+      /plus$/i,
+    ],
+  },
+  {
+    label: 'Benefits',
+    patterns: [
+      /benefit/i,
+      /perks/i,
+      /what we offer/i,
+      /compensation/i,
+      /why you'll love/i,
+    ],
+  },
+  {
+    label: 'Company',
+    patterns: [
+      /about (the )?company/i,
+      /who we are/i,
+      /our team/i,
+      /culture/i,
+    ],
+  },
+]
+
+const STOP_WORDS = new Set([
+  'about',
+  'above',
+  'after',
+  'also',
+  'an',
+  'and',
+  'any',
+  'are',
+  'as',
+  'at',
+  'be',
+  'being',
+  'both',
+  'but',
+  'by',
+  'can',
+  'company',
+  'candidate',
+  'day',
+  'do',
+  'each',
+  'ensure',
+  'every',
+  'for',
+  'from',
+  'have',
+  'help',
+  'including',
+  'into',
+  'is',
+  'it',
+  'its',
+  'join',
+  'make',
+  'may',
+  'more',
+  'must',
+  'new',
+  'of',
+  'on',
+  'our',
+  'role',
+  'skills',
+  'such',
+  'team',
+  'the',
+  'their',
+  'this',
+  'to',
+  'we',
+  'what',
+  'will',
+  'with',
+  'work',
+  'you',
+  'your',
+])
+
+const META_PATTERNS = [
+  { label: 'Company', regex: /^company\s*[:\-]\s*(.+)$/i },
+  { label: 'Location', regex: /^location\s*[:\-]\s*(.+)$/i },
+  { label: 'Employment Type', regex: /^(employment|contract)\s*type\s*[:\-]\s*(.+)$/i },
+  { label: 'Salary', regex: /^(salary|compensation|pay range)\s*[:\-]\s*(.+)$/i },
+  { label: 'Experience', regex: /^(experience|years of experience)\s*[:\-]\s*(.+)$/i },
+]
+
+function normalizeLine(line = '') {
+  return line.replace(/\s+/g, ' ').trim()
+}
+
+function isBulletLine(line = '') {
+  return /^(?:[\u2022\u2023\u25CF\u25CB\u25A0\u25AA\-\*\+\•\▪\◦\‣]\s+|\d+\.\s+)/.test(line)
+}
+
+function detectSectionHeading(line = '') {
+  if (!line) return null
+  const trimmed = line.replace(/[\s:;\-–—]+$/g, '').trim()
+  if (!trimmed) return null
+
+  const lower = trimmed.toLowerCase()
+  const keywordMatch = SECTION_KEYWORDS.find((entry) =>
+    entry.patterns.some((pattern) => pattern.test(lower))
+  )
+  if (keywordMatch) {
+    return keywordMatch.label
+  }
+
+  const wordCount = trimmed.split(/\s+/).length
+  const looksLikeHeading =
+    (trimmed === trimmed.toUpperCase() && wordCount <= 10) ||
+    (line.endsWith(':') && wordCount <= 12)
+
+  if (looksLikeHeading) {
+    return toTitleCase(trimmed)
+  }
+
+  return null
+}
+
+function toTitleCase(value = '') {
+  if (!value) return ''
+  const lower = value.toLowerCase()
+  return lower.replace(/(^|[\s-/])([a-z])/g, (match, separator, char) =>
+    `${separator}${char.toUpperCase()}`
+  )
+}
+
+function extractKeywords(text = '') {
+  const tokens = text
+    .toLowerCase()
+    .match(/[a-z0-9][a-z0-9+#\.\-/]{1,}/g)
+  if (!tokens) return []
+
+  const counts = new Map()
+  for (const token of tokens) {
+    if (token.length < 4) continue
+    if (STOP_WORDS.has(token)) continue
+    const cleaned = token.replace(/^(?:and|the)\-/, '')
+    const current = counts.get(cleaned) || 0
+    counts.set(cleaned, current + 1)
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => {
+      if (b[1] === a[1]) {
+        return a[0].localeCompare(b[0])
+      }
+      return b[1] - a[1]
+    })
+    .slice(0, 12)
+    .map(([token]) => token.replace(/\+\+/g, '++'))
+}
+
+function isLikelyTitle(line = '') {
+  if (!line) return false
+  if (isBulletLine(line)) return false
+  if (/^(company|location|employment type|job description|about|overview|responsibil)/i.test(line)) {
+    return false
+  }
+  const wordCount = line.split(/\s+/).length
+  return wordCount > 0 && wordCount <= 16
+}
+
+function extractMeta(lines = []) {
+  const meta = []
+  for (const line of lines) {
+    for (const pattern of META_PATTERNS) {
+      const match = line.match(pattern.regex)
+      if (match) {
+        const value = normalizeLine(match[1] || match[2] || '')
+        if (value && value.length <= 120 && !meta.some((item) => item.label === pattern.label)) {
+          meta.push({ label: pattern.label, value })
+        }
+      }
+    }
+  }
+  return meta
+}
+
+export function parseJobDescriptionText(rawText = '') {
+  if (typeof rawText !== 'string') return null
+  const text = rawText.replace(/\r\n?/g, '\n')
+  const lines = text.split('\n').map(normalizeLine)
+  const nonEmpty = lines.filter(Boolean)
+  if (!nonEmpty.length) return null
+
+  let title = ''
+  const contentLines = []
+  for (const line of nonEmpty) {
+    if (!title && isLikelyTitle(line)) {
+      title = toTitleCase(line)
+      continue
+    }
+    contentLines.push(line)
+  }
+
+  if (!title && contentLines.length) {
+    title = toTitleCase(contentLines.shift())
+  }
+  if (!title) {
+    title = 'Job Description'
+  }
+
+  const meta = extractMeta(contentLines.slice(0, 12))
+
+  const sections = []
+  let currentSection = {
+    heading: 'Overview',
+    bullets: [],
+    paragraphs: [],
+  }
+
+  const pushSection = () => {
+    if (currentSection.bullets.length || currentSection.paragraphs.length) {
+      sections.push(currentSection)
+    }
+  }
+
+  for (const line of contentLines) {
+    const heading = detectSectionHeading(line)
+    if (heading) {
+      if (
+        currentSection.heading !== heading &&
+        (currentSection.bullets.length || currentSection.paragraphs.length)
+      ) {
+        pushSection()
+        currentSection = {
+          heading,
+          bullets: [],
+          paragraphs: [],
+        }
+      } else {
+        currentSection = {
+          heading,
+          bullets: [],
+          paragraphs: [],
+        }
+      }
+      continue
+    }
+
+    const bulletMatch = line.match(/^(?:[\u2022\u2023\u25CF\u25CB\u25A0\u25AA\-\*\+\•\▪\◦\‣]\s+|\d+\.\s+)(.+)$/)
+    if (bulletMatch) {
+      const bulletText = normalizeLine(bulletMatch[1])
+      if (bulletText) currentSection.bullets.push(bulletText)
+      continue
+    }
+
+    if (line) {
+      currentSection.paragraphs.push(line)
+    }
+  }
+
+  pushSection()
+
+  if (!sections.length && (currentSection.bullets.length || currentSection.paragraphs.length)) {
+    sections.push(currentSection)
+  }
+
+  const combinedText = [title, ...contentLines].join(' ')
+  const keywords = extractKeywords(combinedText)
+  const wordCount = combinedText.split(/\s+/).filter(Boolean).length
+
+  return {
+    title,
+    sections,
+    keywords,
+    wordCount,
+    meta,
+  }
+}
+
+export default parseJobDescriptionText


### PR DESCRIPTION
## Summary
- parse pasted job descriptions into sections, meta details, and keywords so applicants can confirm the content
- display a structured job description preview in the upload form before ATS scoring starts
- cover the parser with unit tests to ensure consistent extraction of bullets and metadata

## Testing
- npm test *(fails: Cannot find package '@babel/preset-env' in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df7900b6ec832b9a9e4b79dc3c47b1