### PR TITLE
Add improvement actions for certifications, projects, and highlights

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -21,18 +21,33 @@ const improvementActions = [
   },
   {
     key: 'add-missing-skills',
-    label: 'Add Missing Skills',
+    label: 'Improve Skills',
     helper: 'Blend missing keywords into the skills and experience sections.'
   },
   {
+    key: 'align-experience',
+    label: 'Improve Experience',
+    helper: 'Emphasise accomplishments that mirror the job requirements.'
+  },
+  {
     key: 'change-designation',
-    label: 'Change Designation',
+    label: 'Improve Designation',
     helper: 'Align your visible job title with the target role.'
   },
   {
-    key: 'align-experience',
-    label: 'Align Experience',
-    helper: 'Emphasise accomplishments that mirror the job requirements.'
+    key: 'improve-certifications',
+    label: 'Improve Certifications',
+    helper: 'Surface credentials that validate your readiness for this JD.'
+  },
+  {
+    key: 'improve-projects',
+    label: 'Improve Projects',
+    helper: 'Spotlight portfolio wins that map directly to the role priorities.'
+  },
+  {
+    key: 'improve-highlights',
+    label: 'Improve Highlights',
+    helper: 'Refine top achievements so they echo the job’s success metrics.'
   },
   {
     key: 'enhance-all',
@@ -435,7 +450,14 @@ function deriveChangeLabel(suggestion) {
   if (before && after && before !== after) {
     if (type === 'improve-summary') return 'rephrased'
     if (type === 'change-designation') return 'fixed'
-    if (type === 'add-missing-skills' || type === 'align-experience') return 'added'
+    if (
+      type === 'add-missing-skills' ||
+      type === 'align-experience' ||
+      type === 'improve-certifications' ||
+      type === 'improve-projects' ||
+      type === 'improve-highlights'
+    )
+      return 'added'
     if (type === 'enhance-all') return 'fixed'
   }
 
@@ -444,7 +466,11 @@ function deriveChangeLabel(suggestion) {
       ? 'rephrased'
       : type === 'change-designation'
         ? 'fixed'
-        : type === 'add-missing-skills' || type === 'align-experience'
+        : type === 'add-missing-skills' ||
+            type === 'align-experience' ||
+            type === 'improve-certifications' ||
+            type === 'improve-projects' ||
+            type === 'improve-highlights'
           ? 'added'
           : 'fixed'
 
@@ -459,10 +485,16 @@ function buildChangeLogEntry(suggestion) {
       'Reframed your summary so the opener mirrors the job description priorities.',
     'add-missing-skills':
       'Inserted missing keywords so the CV satisfies the role requirements.',
-    'change-designation':
-      'Aligned the visible designation with the target role title.',
     'align-experience':
       'Expanded experience bullets to reflect the selection criteria.',
+    'change-designation':
+      'Aligned the visible designation with the target role title.',
+    'improve-certifications':
+      'Elevated certifications that validate the role’s compliance or technical focus.',
+    'improve-projects':
+      'Reframed project wins to demonstrate alignment with the JD priorities.',
+    'improve-highlights':
+      'Tuned top highlights so they emphasise the outcomes hiring managers expect.',
     'enhance-all':
       'Rolled out combined updates so every section aligns with the JD.'
   }
@@ -476,8 +508,11 @@ function buildChangeLogEntry(suggestion) {
   const selectionNotes = {
     'improve-summary': 'Selection focus: mirrors JD tone and value propositions.',
     'add-missing-skills': 'Selection focus: surfaces keywords recruiters screen for.',
-    'change-designation': 'Selection focus: resolves designation mismatch flagged in ATS scans.',
     'align-experience': 'Selection focus: evidences accomplishments tied to job metrics.',
+    'change-designation': 'Selection focus: resolves designation mismatch flagged in ATS scans.',
+    'improve-certifications': 'Selection focus: spotlights credentials recruiters validate first.',
+    'improve-projects': 'Selection focus: proves project impact mirrors hiring goals.',
+    'improve-highlights': 'Selection focus: amplifies headline wins that catch recruiter attention.',
     'enhance-all': 'Selection focus: synchronises every section with the job criteria.'
   }
 

--- a/server.js
+++ b/server.js
@@ -2099,6 +2099,16 @@ function extractSectionContent(resumeText = '', headingPattern) {
   };
 }
 
+const SUMMARY_SECTION_PATTERN = /^#\s*summary/i;
+const SKILLS_SECTION_PATTERN = /^#\s*skills/i;
+const EXPERIENCE_SECTION_PATTERN = /^#\s*(work\s+)?experience/i;
+const CERTIFICATIONS_SECTION_PATTERN =
+  /^#\s*(certifications?|licenses?\s*(?:&|and)\s*certifications?)/i;
+const PROJECTS_SECTION_PATTERN =
+  /^#\s*(projects?|key\s+projects|selected\s+projects|project\s+highlights)/i;
+const HIGHLIGHTS_SECTION_PATTERN =
+  /^#\s*(highlights?|career\s+highlights|key\s+highlights|professional\s+highlights)/i;
+
 function replaceSectionContent(
   resumeText = '',
   headingPattern,
@@ -2341,6 +2351,15 @@ function enforceTargetedUpdate(type, originalResume, result = {}, context = {}) 
       designation: targetJobTitle
         ? `Headline now states ${targetJobTitle} to remove designation mismatch.`
         : 'Headline now reflects the target job title for ATS clarity.',
+      certifications: targetJobTitle
+        ? `Certifications foreground credentials recruiters expect for ${targetJobTitle}.`
+        : 'Certifications foreground credentials recruiters expect for this role.',
+      projects: targetJobTitle
+        ? `Projects spotlight initiatives that mirror ${targetJobTitle} responsibilities.`
+        : 'Projects spotlight initiatives that mirror the job description priorities.',
+      highlights: targetJobTitle
+        ? `Highlights now emphasise wins tied to ${targetJobTitle} success metrics.`
+        : 'Highlights now emphasise wins tied to the job description success metrics.',
     };
 
     const trackChange = (key, label, sectionResult = {}, reasons, options = {}) => {
@@ -2379,7 +2398,7 @@ function enforceTargetedUpdate(type, originalResume, result = {}, context = {}) 
       'summary',
       'Summary',
       applySectionUpdate(workingResume, baseResult.updatedResume, {
-        pattern: /^#\s*summary/i,
+        pattern: SUMMARY_SECTION_PATTERN,
         defaultLabel: 'Summary',
         insertIndex: 1,
       }),
@@ -2390,7 +2409,7 @@ function enforceTargetedUpdate(type, originalResume, result = {}, context = {}) 
       'skills',
       'Skills',
       applySectionUpdate(workingResume, baseResult.updatedResume, {
-        pattern: /^#\s*skills/i,
+        pattern: SKILLS_SECTION_PATTERN,
         defaultLabel: 'Skills',
         insertIndex: 2,
       }),
@@ -2401,10 +2420,43 @@ function enforceTargetedUpdate(type, originalResume, result = {}, context = {}) 
       'experience',
       'Work Experience',
       applySectionUpdate(workingResume, baseResult.updatedResume, {
-        pattern: /^#\s*(work\s+)?experience/i,
+        pattern: EXPERIENCE_SECTION_PATTERN,
         defaultLabel: 'Work Experience',
       }),
       defaultReasons.experience
+    );
+
+    trackChange(
+      'certifications',
+      'Certifications',
+      applySectionUpdate(workingResume, baseResult.updatedResume, {
+        pattern: CERTIFICATIONS_SECTION_PATTERN,
+        defaultLabel: 'Certifications',
+        insertIndex: 3,
+      }),
+      defaultReasons.certifications
+    );
+
+    trackChange(
+      'projects',
+      'Projects',
+      applySectionUpdate(workingResume, baseResult.updatedResume, {
+        pattern: PROJECTS_SECTION_PATTERN,
+        defaultLabel: 'Projects',
+        insertIndex: 3,
+      }),
+      defaultReasons.projects
+    );
+
+    trackChange(
+      'highlights',
+      'Highlights',
+      applySectionUpdate(workingResume, baseResult.updatedResume, {
+        pattern: HIGHLIGHTS_SECTION_PATTERN,
+        defaultLabel: 'Highlights',
+        insertIndex: 2,
+      }),
+      defaultReasons.highlights
     );
 
     trackChange(
@@ -2448,7 +2500,7 @@ function enforceTargetedUpdate(type, originalResume, result = {}, context = {}) 
 
   if (type === 'improve-summary') {
     const sectionResult = applySectionUpdate(safeOriginal, baseResult.updatedResume, {
-      pattern: /^#\s*summary/i,
+      pattern: SUMMARY_SECTION_PATTERN,
       defaultLabel: 'Summary',
       insertIndex: 1,
     });
@@ -2462,7 +2514,7 @@ function enforceTargetedUpdate(type, originalResume, result = {}, context = {}) 
 
   if (type === 'add-missing-skills') {
     const sectionResult = applySectionUpdate(safeOriginal, baseResult.updatedResume, {
-      pattern: /^#\s*skills/i,
+      pattern: SKILLS_SECTION_PATTERN,
       defaultLabel: 'Skills',
       insertIndex: 2,
     });
@@ -2476,8 +2528,50 @@ function enforceTargetedUpdate(type, originalResume, result = {}, context = {}) 
 
   if (type === 'align-experience') {
     const sectionResult = applySectionUpdate(safeOriginal, baseResult.updatedResume, {
-      pattern: /^#\s*(work\s+)?experience/i,
+      pattern: EXPERIENCE_SECTION_PATTERN,
       defaultLabel: 'Work Experience',
+    });
+    return {
+      ...baseResult,
+      ...sectionResult,
+      beforeExcerpt: sectionResult.beforeExcerpt || baseResult.beforeExcerpt,
+      afterExcerpt: sectionResult.afterExcerpt || baseResult.afterExcerpt,
+    };
+  }
+
+  if (type === 'improve-certifications') {
+    const sectionResult = applySectionUpdate(safeOriginal, baseResult.updatedResume, {
+      pattern: CERTIFICATIONS_SECTION_PATTERN,
+      defaultLabel: 'Certifications',
+      insertIndex: 3,
+    });
+    return {
+      ...baseResult,
+      ...sectionResult,
+      beforeExcerpt: sectionResult.beforeExcerpt || baseResult.beforeExcerpt,
+      afterExcerpt: sectionResult.afterExcerpt || baseResult.afterExcerpt,
+    };
+  }
+
+  if (type === 'improve-projects') {
+    const sectionResult = applySectionUpdate(safeOriginal, baseResult.updatedResume, {
+      pattern: PROJECTS_SECTION_PATTERN,
+      defaultLabel: 'Projects',
+      insertIndex: 3,
+    });
+    return {
+      ...baseResult,
+      ...sectionResult,
+      beforeExcerpt: sectionResult.beforeExcerpt || baseResult.beforeExcerpt,
+      afterExcerpt: sectionResult.afterExcerpt || baseResult.afterExcerpt,
+    };
+  }
+
+  if (type === 'improve-highlights') {
+    const sectionResult = applySectionUpdate(safeOriginal, baseResult.updatedResume, {
+      pattern: HIGHLIGHTS_SECTION_PATTERN,
+      defaultLabel: 'Highlights',
+      insertIndex: 2,
     });
     return {
       ...baseResult,
@@ -2514,7 +2608,7 @@ const IMPROVEMENT_CONFIG = {
     ],
   },
   'add-missing-skills': {
-    title: 'Add Missing Skills',
+    title: 'Improve Skills',
     focus: [
       'Blend the missing or underrepresented skills into both the Skills list and relevant experience bullets.',
       'Revise existing bullets so each new skill is backed by duties already present in the resume.',
@@ -2522,7 +2616,7 @@ const IMPROVEMENT_CONFIG = {
     ],
   },
   'change-designation': {
-    title: 'Change Designation',
+    title: 'Improve Designation',
     focus: [
       'Update the headline or latest role title to match the target job title while keeping chronology intact.',
       'Adjust surrounding bullets so they evidence the updated title with truthful scope and impact.',
@@ -2530,17 +2624,41 @@ const IMPROVEMENT_CONFIG = {
     ],
   },
   'align-experience': {
-    title: 'Align Experience',
+    title: 'Improve Experience',
     focus: [
       'Rewrite the most relevant experience bullets so they mirror the job description’s responsibilities and metrics.',
       'Highlight missing keywords or responsibilities from the JD using facts already in the resume.',
       'Keep bullet formatting, tense, and chronology consistent throughout the section.',
     ],
   },
+  'improve-certifications': {
+    title: 'Improve Certifications',
+    focus: [
+      'Prioritise certifications that validate the JD’s compliance or technical requirements.',
+      'Clarify issuer names and relevance without inventing new credentials.',
+      'Keep existing credential dates and order intact while surfacing the most role-aligned items first.',
+    ],
+  },
+  'improve-projects': {
+    title: 'Improve Projects',
+    focus: [
+      'Refocus project bullets on outcomes and responsibilities that match the job description.',
+      'Weave in JD keywords using project details already present in the resume.',
+      'Avoid adding new projects—revise the wording of existing ones to emphasise fit.',
+    ],
+  },
+  'improve-highlights': {
+    title: 'Improve Highlights',
+    focus: [
+      'Elevate the top-line wins so they mirror the target role’s success metrics.',
+      'Tie each highlight back to measurable impact already evidenced in the resume.',
+      'Retain the existing highlight count and ordering while tightening phrasing.',
+    ],
+  },
   'enhance-all': {
     title: 'Enhance All',
     focus: [
-      'Deliver the summary, skills, designation, and experience improvements in one cohesive pass.',
+      'Deliver the summary, skills, experience, designation, certifications, projects, and highlights improvements in one cohesive pass.',
       'Address missing skills and JD priorities everywhere they fit naturally in the resume.',
       'Ensure the final resume remains ATS-safe, truthful, and consistent in tone and formatting.',
     ],
@@ -2704,12 +2822,12 @@ function fallbackImprovement(type, context) {
   }
 
   if (type === 'improve-summary') {
-    const section = extractSectionContent(resumeText, /^#\s*summary/i);
+    const section = extractSectionContent(resumeText, SUMMARY_SECTION_PATTERN);
     const before = section.content.join('\n').trim();
     const summaryLine = `Forward-looking ${jobTitle || 'professional'} with strengths in ${
       fallbackSkillText || 'delivering measurable outcomes'
     } and a record of translating goals into results.`;
-    const updatedResume = replaceSectionContent(resumeText, /^#\s*summary/i, [summaryLine], {
+    const updatedResume = replaceSectionContent(resumeText, SUMMARY_SECTION_PATTERN, [summaryLine], {
       headingLabel: 'Summary',
       insertIndex: 1,
     });
@@ -2729,7 +2847,7 @@ function fallbackImprovement(type, context) {
         explanation: 'No missing skills detected—resume already covers the job keywords.',
       };
     }
-    const section = extractSectionContent(resumeText, /^#\s*skills/i);
+    const section = extractSectionContent(resumeText, SKILLS_SECTION_PATTERN);
     const before = section.content.join('\n').trim();
     const bullet = `- ${fallbackSkills.join(', ')}`;
     const existing = section.content.some((line) =>
@@ -2740,7 +2858,7 @@ function fallbackImprovement(type, context) {
       : [...section.content.filter(Boolean), bullet];
     const updatedResume = replaceSectionContent(
       resumeText,
-      /^#\s*skills/i,
+      SKILLS_SECTION_PATTERN,
       newContent,
       { headingLabel: 'Skills', insertIndex: 2 }
     );
@@ -2793,7 +2911,7 @@ function fallbackImprovement(type, context) {
   }
 
   if (type === 'align-experience') {
-    const section = extractSectionContent(resumeText, /^#\s*(work\s+)?experience/i);
+    const section = extractSectionContent(resumeText, EXPERIENCE_SECTION_PATTERN);
     const headingLabel = section.heading.replace(/^#\s*/, '') || 'Work Experience';
     const before = section.content.join('\n').trim();
     const focusPhrase = fallbackSkillText
@@ -2803,7 +2921,7 @@ function fallbackImprovement(type, context) {
     const newContent = [...section.content, bullet];
     const updatedResume = replaceSectionContent(
       resumeText,
-      /^#\s*(work\s+)?experience/i,
+      EXPERIENCE_SECTION_PATTERN,
       newContent,
       { headingLabel }
     );
@@ -2813,6 +2931,114 @@ function fallbackImprovement(type, context) {
       afterExcerpt: bullet,
       explanation: 'Added an accomplishment bullet that mirrors the job description focus.',
       confidence: 0.32,
+    };
+  }
+
+  if (type === 'improve-certifications') {
+    const certificationCandidates = dedupeCertificates([
+      ...(context.knownCertificates || []),
+      ...(context.manualCertificates || []),
+    ]);
+    if (!certificationCandidates.length) {
+      return {
+        ...baseResult,
+        explanation: 'No certifications supplied to reinforce for this role.',
+      };
+    }
+
+    const targetCertificate = certificationCandidates[0];
+    const certificateLabelParts = [targetCertificate.name].filter(Boolean);
+    if (targetCertificate.provider) {
+      certificateLabelParts.push(targetCertificate.provider);
+    }
+    const certificateLine = `- ${certificateLabelParts.join(' — ')}`;
+    const section = extractSectionContent(resumeText, CERTIFICATIONS_SECTION_PATTERN);
+    const headingLabel = deriveHeadingLabel(section.heading, 'Certifications');
+    const before = section.content.join('\n').trim();
+    const alreadyPresent = section.content.some((line) =>
+      targetCertificate.name && line.toLowerCase().includes(targetCertificate.name.toLowerCase())
+    );
+    const baseContent = section.content.filter((line) => typeof line === 'string');
+    const newContent = alreadyPresent
+      ? baseContent
+      : [...baseContent.filter(Boolean), certificateLine];
+    const sanitizedContent = newContent.length ? sanitizeSectionLines(newContent) : [];
+    const updatedResume = replaceSectionContent(
+      resumeText,
+      CERTIFICATIONS_SECTION_PATTERN,
+      sanitizedContent.length ? sanitizedContent : [certificateLine],
+      { headingLabel, insertIndex: 3 }
+    );
+    return {
+      updatedResume,
+      beforeExcerpt: before,
+      afterExcerpt: alreadyPresent ? before : certificateLine,
+      explanation: alreadyPresent
+        ? 'Certifications section already lists the supplied credential.'
+        : `Highlighted ${targetCertificate.name} so the credential is prominent for screeners.`,
+      confidence: alreadyPresent ? 0.26 : 0.32,
+    };
+  }
+
+  if (type === 'improve-projects') {
+    const section = extractSectionContent(resumeText, PROJECTS_SECTION_PATTERN);
+    const headingLabel = deriveHeadingLabel(section.heading, 'Projects');
+    const before = section.content.join('\n').trim();
+    const focusText = fallbackSkillText || jobTitle || 'role priorities';
+    const addition = `- Spotlighted projects that prove ${focusText} impact.`;
+    const alreadyPresent = section.content.some((line) =>
+      line.trim().toLowerCase() === addition.toLowerCase()
+    );
+    const baseContent = section.content.filter((line) => typeof line === 'string');
+    const newContent = alreadyPresent
+      ? baseContent
+      : [...baseContent.filter(Boolean), addition];
+    const sanitizedContent = newContent.length ? sanitizeSectionLines(newContent) : [];
+    const updatedResume = replaceSectionContent(
+      resumeText,
+      PROJECTS_SECTION_PATTERN,
+      sanitizedContent.length ? sanitizedContent : [addition],
+      { headingLabel, insertIndex: 3 }
+    );
+    return {
+      updatedResume,
+      beforeExcerpt: before,
+      afterExcerpt: alreadyPresent ? before : addition,
+      explanation: alreadyPresent
+        ? 'Projects section already emphasises the job-aligned initiatives.'
+        : 'Elevated project bullets to mirror the job description priorities.',
+      confidence: alreadyPresent ? 0.25 : 0.31,
+    };
+  }
+
+  if (type === 'improve-highlights') {
+    const section = extractSectionContent(resumeText, HIGHLIGHTS_SECTION_PATTERN);
+    const headingLabel = deriveHeadingLabel(section.heading, 'Highlights');
+    const before = section.content.join('\n').trim();
+    const focusText = fallbackSkillText || jobTitle || 'target role';
+    const addition = `- Highlighted wins that reinforce ${focusText} outcomes.`;
+    const alreadyPresent = section.content.some((line) =>
+      line.trim().toLowerCase() === addition.toLowerCase()
+    );
+    const baseContent = section.content.filter((line) => typeof line === 'string');
+    const newContent = alreadyPresent
+      ? baseContent
+      : [...baseContent.filter(Boolean), addition];
+    const sanitizedContent = newContent.length ? sanitizeSectionLines(newContent) : [];
+    const updatedResume = replaceSectionContent(
+      resumeText,
+      HIGHLIGHTS_SECTION_PATTERN,
+      sanitizedContent.length ? sanitizedContent : [addition],
+      { headingLabel, insertIndex: 2 }
+    );
+    return {
+      updatedResume,
+      beforeExcerpt: before,
+      afterExcerpt: alreadyPresent ? before : addition,
+      explanation: alreadyPresent
+        ? 'Highlights already underscore the job-aligned achievements.'
+        : 'Reinforced highlights so top wins echo the job metrics.',
+      confidence: alreadyPresent ? 0.25 : 0.31,
     };
   }
 
@@ -2826,13 +3052,26 @@ function fallbackImprovement(type, context) {
       ...context,
       resumeText: interim.updatedResume,
     });
-    const finalResult = fallbackImprovement('align-experience', {
+    interim = fallbackImprovement('align-experience', {
+      ...context,
+      resumeText: interim.updatedResume,
+    });
+    interim = fallbackImprovement('improve-certifications', {
+      ...context,
+      resumeText: interim.updatedResume,
+    });
+    interim = fallbackImprovement('improve-projects', {
+      ...context,
+      resumeText: interim.updatedResume,
+    });
+    const finalResult = fallbackImprovement('improve-highlights', {
       ...context,
       resumeText: interim.updatedResume,
     });
     return {
       ...finalResult,
-      explanation: 'Applied deterministic improvements for summary, skills, designation, and experience.',
+      explanation:
+        'Applied deterministic improvements for summary, skills, designation, experience, certifications, projects, and highlights.',
       confidence: 0.34,
     };
   }
@@ -7713,9 +7952,12 @@ async function handleImprovementRequest(type, req, res) {
       manualCertificates,
     });
     const sectionPatterns = {
-      'improve-summary': /^#\s*summary/i,
-      'add-missing-skills': /^#\s*skills/i,
-      'align-experience': /^#\s*(work\s+)?experience/i,
+      'improve-summary': SUMMARY_SECTION_PATTERN,
+      'add-missing-skills': SKILLS_SECTION_PATTERN,
+      'align-experience': EXPERIENCE_SECTION_PATTERN,
+      'improve-certifications': CERTIFICATIONS_SECTION_PATTERN,
+      'improve-projects': PROJECTS_SECTION_PATTERN,
+      'improve-highlights': HIGHLIGHTS_SECTION_PATTERN,
     };
     const excerptPattern = sectionPatterns[type];
     const normalizedBeforeExcerpt = excerptPattern
@@ -7871,6 +8113,9 @@ const improvementRoutes = [
   { path: '/api/add-missing-skills', type: 'add-missing-skills' },
   { path: '/api/change-designation', type: 'change-designation' },
   { path: '/api/align-experience', type: 'align-experience' },
+  { path: '/api/improve-certifications', type: 'improve-certifications' },
+  { path: '/api/improve-projects', type: 'improve-projects' },
+  { path: '/api/improve-highlights', type: 'improve-highlights' },
   { path: '/api/enhance-all', type: 'enhance-all' },
 ];
 

--- a/tests/enforceTargetedUpdate.test.js
+++ b/tests/enforceTargetedUpdate.test.js
@@ -66,7 +66,15 @@ describe('enforceTargetedUpdate', () => {
     expect(Array.isArray(result.changeDetails)).toBe(true);
     const sections = result.changeDetails.map((detail) => detail.section || detail.label);
     expect(sections).toEqual(
-      expect.arrayContaining(['Summary', 'Skills', 'Work Experience', 'Headline'])
+      expect.arrayContaining([
+        'Summary',
+        'Skills',
+        'Work Experience',
+        'Certifications',
+        'Projects',
+        'Highlights',
+        'Headline',
+      ])
     );
     result.changeDetails.forEach((detail) => {
       expect(Array.isArray(detail.reasons)).toBe(true);

--- a/tests/improvementRoutes.test.js
+++ b/tests/improvementRoutes.test.js
@@ -9,8 +9,14 @@ const baseResume = [
   'Original summary line focused on delivery.',
   '# Skills',
   '- JavaScript',
+  '# Projects',
+  '- Delivered analytics dashboard for leadership.',
+  '# Highlights',
+  '- Recognised for 20% adoption growth.',
   '# Experience',
   '- Built scalable services.',
+  '# Certifications',
+  '- AWS Certified Solutions Architect',
 ].join('\n');
 
 const jobDescription = [
@@ -79,6 +85,61 @@ describe('targeted improvement routes', () => {
         added: ['Refined summary that highlights leadership impact.'],
         removed: ['Original summary line focused on delivery.'],
         reason: ['Highlights leadership accomplishments.'],
+      })
+    );
+  });
+
+  it('returns a structured improvement summary for improve-certifications', async () => {
+    generateContentMock.mockResolvedValueOnce({
+      response: {
+        text: () =>
+          JSON.stringify({
+            updatedResume: baseResume.replace(
+              '- AWS Certified Solutions Architect',
+              '- AWS Certified Solutions Architect\n- Azure Administrator Associate'
+            ),
+            beforeExcerpt: '- AWS Certified Solutions Architect',
+            afterExcerpt: '- AWS Certified Solutions Architect\n- Azure Administrator Associate',
+            explanation: 'Elevated certifications for cloud leadership.',
+            confidence: 0.77,
+            changeDetails: [
+              {
+                section: 'Certifications',
+                before: '- AWS Certified Solutions Architect',
+                after: '- AWS Certified Solutions Architect\n- Azure Administrator Associate',
+                reasons: ['Elevated certifications for cloud leadership.'],
+              },
+            ],
+          }),
+      },
+    });
+
+    const response = await request(app).post('/api/improve-certifications').send({
+      jobId: 'job-789',
+      linkedinProfileUrl: 'https://linkedin.com/in/example',
+      resumeText: baseResume,
+      jobDescription,
+      knownCertificates: [{ name: 'AWS Certified Solutions Architect' }],
+      manualCertificates: [{ name: 'Azure Administrator Associate' }],
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        success: true,
+        type: 'improve-certifications',
+        beforeExcerpt: '- AWS Certified Solutions Architect',
+        afterExcerpt: '- AWS Certified Solutions Architect\n- Azure Administrator Associate',
+        confidence: expect.any(Number),
+      })
+    );
+    expect(Array.isArray(response.body.improvementSummary)).toBe(true);
+    expect(response.body.improvementSummary[0]).toEqual(
+      expect.objectContaining({
+        section: 'Certifications',
+        added: expect.arrayContaining(['Azure Administrator Associate']),
+        removed: expect.arrayContaining([]),
+        reason: ['Elevated certifications for cloud leadership.'],
       })
     );
   });

--- a/tests/improvements.e2e.test.js
+++ b/tests/improvements.e2e.test.js
@@ -8,8 +8,14 @@ const baseResume = [
   'Original summary line focused on delivery.',
   '# Skills',
   '- JavaScript',
+  '# Projects',
+  '- Delivered analytics dashboard for leadership.',
+  '# Highlights',
+  '- Recognised for 20% adoption growth.',
   '# Experience',
   '- Built scalable services.',
+  '# Certifications',
+  '- AWS Certified Solutions Architect',
 ].join('\n');
 
 const jobDescription = [
@@ -39,72 +45,252 @@ describe('targeted improvement endpoints (integration)', () => {
       {
         route: '/api/improve-summary',
         type: 'improve-summary',
-        expectation: {
-          summary: 'Refined summary spotlighting leadership wins.',
-          section: 'Summary',
-        },
+        section: 'Summary',
+        beforeExcerpt: 'Original summary line focused on delivery.',
+        afterExcerpt: 'Refined summary spotlighting leadership wins.',
+        explanation: 'Refined summary spotlighting leadership wins.',
+        mutations: [
+          {
+            target: 'Original summary line focused on delivery.',
+            value: 'Refined summary spotlighting leadership wins.',
+          },
+        ],
+        changeDetails: [
+          {
+            section: 'Summary',
+            before: '- Original summary line focused on delivery.',
+            after: '- Refined summary spotlighting leadership wins.',
+            reasons: ['Refined summary spotlighting leadership wins.'],
+          },
+        ],
       },
       {
         route: '/api/add-missing-skills',
         type: 'add-missing-skills',
-        expectation: {
-          summary: 'Added targeted skills including leadership and cloud.',
-          section: 'Skills',
-        },
+        section: 'Skills',
+        beforeExcerpt: '- JavaScript',
+        afterExcerpt: '- JavaScript\n- Leadership',
+        explanation: 'Added targeted skills including leadership and cloud.',
+        mutations: [
+          {
+            target: '- JavaScript',
+            value: '- JavaScript\n- Leadership',
+          },
+        ],
+        changeDetails: [
+          {
+            section: 'Skills',
+            before: '- JavaScript',
+            after: '- JavaScript\n- Leadership',
+            reasons: ['Added targeted skills including leadership and cloud.'],
+          },
+        ],
       },
       {
         route: '/api/change-designation',
         type: 'change-designation',
-        expectation: {
-          summary: 'Aligned title with target role.',
-          section: 'Designation',
-        },
+        section: 'Designation',
+        beforeExcerpt: 'Senior Software Engineer',
+        afterExcerpt: 'Lead Software Engineer',
+        explanation: 'Aligned title with target role.',
+        mutations: [
+          {
+            target: 'Senior Software Engineer',
+            value: 'Lead Software Engineer',
+          },
+        ],
+        changeDetails: [
+          {
+            section: 'Designation',
+            before: 'Senior Software Engineer',
+            after: 'Lead Software Engineer',
+            reasons: ['Aligned title with target role.'],
+          },
+        ],
       },
       {
         route: '/api/align-experience',
         type: 'align-experience',
-        expectation: {
-          summary: 'Expanded experience bullets for leadership initiatives.',
-          section: 'Experience',
-        },
+        section: 'Experience',
+        beforeExcerpt: '- Built scalable services.',
+        afterExcerpt: '- Built scalable services.\n- Expanded leadership initiatives.',
+        explanation: 'Expanded experience bullets for leadership initiatives.',
+        mutations: [
+          {
+            target: '- Built scalable services.',
+            value: '- Built scalable services.\n- Expanded leadership initiatives.',
+          },
+        ],
+        changeDetails: [
+          {
+            section: 'Experience',
+            before: '- Built scalable services.',
+            after: '- Built scalable services.\n- Expanded leadership initiatives.',
+            reasons: ['Expanded experience bullets for leadership initiatives.'],
+          },
+        ],
+      },
+      {
+        route: '/api/improve-certifications',
+        type: 'improve-certifications',
+        section: 'Certifications',
+        beforeExcerpt: '- AWS Certified Solutions Architect',
+        afterExcerpt: '- AWS Certified Solutions Architect\n- Azure Administrator Associate',
+        explanation: 'Elevated certifications for cloud leadership.',
+        mutations: [
+          {
+            target: '- AWS Certified Solutions Architect',
+            value: '- AWS Certified Solutions Architect\n- Azure Administrator Associate',
+          },
+        ],
+        changeDetails: [
+          {
+            section: 'Certifications',
+            before: '- AWS Certified Solutions Architect',
+            after: '- AWS Certified Solutions Architect\n- Azure Administrator Associate',
+            reasons: ['Elevated certifications for cloud leadership.'],
+          },
+        ],
+      },
+      {
+        route: '/api/improve-projects',
+        type: 'improve-projects',
+        section: 'Projects',
+        beforeExcerpt: '- Delivered analytics dashboard for leadership.',
+        afterExcerpt: '- Delivered analytics dashboard for leadership.\n- Added cloud migration case study.',
+        explanation: 'Spotlighted projects that match role priorities.',
+        mutations: [
+          {
+            target: '- Delivered analytics dashboard for leadership.',
+            value: '- Delivered analytics dashboard for leadership.\n- Added cloud migration case study.',
+          },
+        ],
+        changeDetails: [
+          {
+            section: 'Projects',
+            before: '- Delivered analytics dashboard for leadership.',
+            after: '- Delivered analytics dashboard for leadership.\n- Added cloud migration case study.',
+            reasons: ['Spotlighted projects that match role priorities.'],
+          },
+        ],
+      },
+      {
+        route: '/api/improve-highlights',
+        type: 'improve-highlights',
+        section: 'Highlights',
+        beforeExcerpt: '- Recognised for 20% adoption growth.',
+        afterExcerpt: '- Recognised for 20% adoption growth.\n- Highlighted delivery wins for JD.',
+        explanation: 'Reinforced highlights around JD success metrics.',
+        mutations: [
+          {
+            target: '- Recognised for 20% adoption growth.',
+            value: '- Recognised for 20% adoption growth.\n- Highlighted delivery wins for JD.',
+          },
+        ],
+        changeDetails: [
+          {
+            section: 'Highlights',
+            before: '- Recognised for 20% adoption growth.',
+            after: '- Recognised for 20% adoption growth.\n- Highlighted delivery wins for JD.',
+            reasons: ['Reinforced highlights around JD success metrics.'],
+          },
+        ],
       },
       {
         route: '/api/enhance-all',
         type: 'enhance-all',
-        expectation: {
-          summary: 'Applied holistic improvements across resume sections.',
-          section: '',
-        },
+        section: '',
+        beforeExcerpt: 'Original summary line focused on delivery.',
+        afterExcerpt: 'Applied holistic improvements across resume sections.',
+        explanation: 'Applied holistic improvements across resume sections.',
+        mutations: [
+          {
+            target: 'Original summary line focused on delivery.',
+            value: 'Applied holistic improvements across resume sections.',
+          },
+          {
+            target: '- JavaScript',
+            value: '- JavaScript\n- Leadership',
+          },
+          {
+            target: '- Delivered analytics dashboard for leadership.',
+            value: '- Delivered analytics dashboard for leadership.\n- Added cloud migration case study.',
+          },
+          {
+            target: '- Recognised for 20% adoption growth.',
+            value: '- Recognised for 20% adoption growth.\n- Highlighted delivery wins for JD.',
+          },
+          {
+            target: '- Built scalable services.',
+            value: '- Built scalable services.\n- Expanded leadership initiatives.',
+          },
+          {
+            target: '- AWS Certified Solutions Architect',
+            value: '- AWS Certified Solutions Architect\n- Azure Administrator Associate',
+          },
+        ],
+        changeDetails: [
+          {
+            section: 'Summary',
+            before: '- Original summary line focused on delivery.',
+            after: '- Applied holistic improvements across resume sections.',
+            reasons: ['Applied holistic improvements across resume sections.'],
+          },
+          {
+            section: 'Skills',
+            before: '- JavaScript',
+            after: '- JavaScript\n- Leadership',
+            reasons: ['Applied holistic improvements across resume sections.'],
+          },
+          {
+            section: 'Projects',
+            before: '- Delivered analytics dashboard for leadership.',
+            after: '- Delivered analytics dashboard for leadership.\n- Added cloud migration case study.',
+            reasons: ['Applied holistic improvements across resume sections.'],
+          },
+          {
+            section: 'Highlights',
+            before: '- Recognised for 20% adoption growth.',
+            after: '- Recognised for 20% adoption growth.\n- Highlighted delivery wins for JD.',
+            reasons: ['Applied holistic improvements across resume sections.'],
+          },
+          {
+            section: 'Work Experience',
+            before: '- Built scalable services.',
+            after: '- Built scalable services.\n- Expanded leadership initiatives.',
+            reasons: ['Applied holistic improvements across resume sections.'],
+          },
+          {
+            section: 'Certifications',
+            before: '- AWS Certified Solutions Architect',
+            after: '- AWS Certified Solutions Architect\n- Azure Administrator Associate',
+            reasons: ['Applied holistic improvements across resume sections.'],
+          },
+        ],
       },
     ];
 
-    aiResponses.forEach(({ expectation }) => {
-      const updated = baseResume
-        .replace('Original summary line focused on delivery.', expectation.summary)
-        .replace('Senior Software Engineer', 'Lead Software Engineer');
+    aiResponses.forEach(({ mutations = [], beforeExcerpt, afterExcerpt, explanation, changeDetails }) => {
+      const replacements = mutations.length
+        ? mutations
+        : [{ target: beforeExcerpt, value: afterExcerpt }];
+      const updated = replacements.reduce((text, mutation) => text.replace(mutation.target, mutation.value), baseResume);
       generateContentMock.mockResolvedValueOnce({
         response: {
           text: () =>
             JSON.stringify({
               updatedResume: updated,
-              beforeExcerpt: 'Original summary line focused on delivery.',
-              afterExcerpt: expectation.summary,
-              explanation: expectation.summary,
+              beforeExcerpt,
+              afterExcerpt,
+              explanation,
               confidence: 0.74,
-              changeDetails: [
-                {
-                  section: expectation.section || 'Summary',
-                  before: '- Original summary line focused on delivery.',
-                  after: `- ${expectation.summary}`,
-                  reasons: [expectation.summary],
-                },
-              ],
+              changeDetails,
             }),
         },
       });
     });
 
-    for (const { route, type, expectation } of aiResponses) {
+    for (const { route, type, section, explanation } of aiResponses) {
       const response = await request(app)
         .post(route)
         .send({
@@ -121,10 +307,12 @@ describe('targeted improvement endpoints (integration)', () => {
       expect(Array.isArray(response.body.improvementSummary)).toBe(true);
       expect(response.body.improvementSummary.length).toBeGreaterThan(0);
       const summaryEntry = response.body.improvementSummary[0];
-      if (expectation.section) {
-        expect(summaryEntry.section).toMatch(new RegExp(expectation.section, 'i'));
+      if (section) {
+        expect(summaryEntry.section).toMatch(new RegExp(section, 'i'));
       }
-      expect(summaryEntry.reason.join(' ')).toContain(expectation.summary.split(' ')[0]);
+      if (explanation) {
+        expect(summaryEntry.reason.join(' ')).toContain(explanation.split(' ')[0]);
+      }
     }
 
     expect(generateContentMock).toHaveBeenCalledTimes(aiResponses.length);

--- a/tests/targetedImprovements.test.js
+++ b/tests/targetedImprovements.test.js
@@ -1,6 +1,21 @@
 import { enforceTargetedUpdate } from '../server.js';
 
-const baseResume = `Alex Roe\n# Summary\nOriginal summary line.\n# Skills\n- JavaScript\n- Node.js\n# Experience\n- Built features for enterprise clients.`;
+const baseResume = [
+  'Alex Roe',
+  '# Summary',
+  'Original summary line.',
+  '# Skills',
+  '- JavaScript',
+  '- Node.js',
+  '# Projects',
+  '- Built analytics dashboard for leadership reviews.',
+  '# Highlights',
+  '- Recognised for improving deployment reliability.',
+  '# Experience',
+  '- Built features for enterprise clients.',
+  '# Certifications',
+  '- AWS Certified Developer – Associate',
+].join('\n');
 
 describe('enforceTargetedUpdate', () => {
   test('limits improve-summary updates to the Summary section', () => {
@@ -64,5 +79,60 @@ describe('enforceTargetedUpdate', () => {
     expect(result.updatedResume).toContain('Principal Software Engineer');
     expect(result.updatedResume).not.toContain('Updated summary that should not persist.');
     expect(result.updatedResume).toContain('Original summary line.');
+  });
+
+  test('limits improve-certifications updates to the Certifications section', () => {
+    const updatedResume = baseResume.replace(
+      '# Certifications\n- AWS Certified Developer – Associate',
+      '# Certifications\n- AWS Certified Developer – Associate\n- Azure Administrator Associate\n# Summary\nInjected summary change.'
+    );
+
+    const result = enforceTargetedUpdate(
+      'improve-certifications',
+      baseResume,
+      { updatedResume },
+      {}
+    );
+
+    expect(result.updatedResume).toContain('AWS Certified Developer – Associate');
+    expect(result.updatedResume).toContain('Azure Administrator Associate');
+    expect(result.updatedResume).toContain('Original summary line.');
+    expect(result.updatedResume).not.toContain('Injected summary change.');
+  });
+
+  test('limits improve-projects updates to the Projects section', () => {
+    const updatedResume = baseResume.replace(
+      '# Projects\n- Built analytics dashboard for leadership reviews.',
+      '# Projects\n- Built analytics dashboard for leadership reviews.\n- Added cloud migration case study.\n# Skills\n- Injected skill'
+    );
+
+    const result = enforceTargetedUpdate(
+      'improve-projects',
+      baseResume,
+      { updatedResume },
+      {}
+    );
+
+    expect(result.updatedResume).toContain('Added cloud migration case study.');
+    expect(result.updatedResume).toContain('- JavaScript');
+    expect(result.updatedResume).not.toContain('Injected skill');
+  });
+
+  test('limits improve-highlights updates to the Highlights section', () => {
+    const updatedResume = baseResume.replace(
+      '# Highlights\n- Recognised for improving deployment reliability.',
+      '# Highlights\n- Recognised for improving deployment reliability.\n- Highlighted delivery wins for JD.\n# Experience\n- Altered experience line.'
+    );
+
+    const result = enforceTargetedUpdate(
+      'improve-highlights',
+      baseResume,
+      { updatedResume },
+      {}
+    );
+
+    expect(result.updatedResume).toContain('Highlighted delivery wins for JD.');
+    expect(result.updatedResume).toContain('- Built features for enterprise clients.');
+    expect(result.updatedResume).not.toContain('Altered experience line.');
   });
 });


### PR DESCRIPTION
## Summary
- expose dedicated "Improve" actions for summary, skills, experience, designation, certifications, projects, and highlights in the client
- extend targeted improvement handling on the server for the new sections, including config, enforcement, fallbacks, and enhance-all updates
- broaden automated coverage to exercise the new improvement routes and enforcement rules

## Testing
- npm test -- --runInBand *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68df7ea21a1c832bb1a3d53edb54ef75