### PR TITLE
Add post-improvement rescoring with selection probability deltas

### DIFF
--- a/tests/improvementRoutes.test.js
+++ b/tests/improvementRoutes.test.js
@@ -87,6 +87,36 @@ describe('targeted improvement routes', () => {
         reason: ['Highlights leadership accomplishments.'],
       })
     );
+    expect(response.body.rescore).toEqual(
+      expect.objectContaining({
+        section: expect.objectContaining({
+          key: expect.any(String),
+          label: expect.any(String),
+          before: expect.objectContaining({ score: expect.any(Number) }),
+          after: expect.objectContaining({ score: expect.any(Number) }),
+          delta: expect.objectContaining({ score: expect.any(Number) }),
+        }),
+        overall: expect.objectContaining({
+          before: expect.objectContaining({
+            score: expect.any(Number),
+            atsSubScores: expect.any(Array),
+          }),
+          after: expect.objectContaining({
+            score: expect.any(Number),
+            atsSubScores: expect.any(Array),
+          }),
+          delta: expect.objectContaining({ score: expect.any(Number) }),
+        }),
+        selectionProbability: expect.objectContaining({
+          before: expect.any(Number),
+          after: expect.any(Number),
+          delta: expect.any(Number),
+        }),
+      })
+    );
+    expect(typeof response.body.selectionProbabilityBefore).toBe('number');
+    expect(typeof response.body.selectionProbabilityAfter).toBe('number');
+    expect(typeof response.body.selectionProbabilityDelta).toBe('number');
   });
 
   it('returns a structured improvement summary for improve-certifications', async () => {
@@ -140,6 +170,33 @@ describe('targeted improvement routes', () => {
         added: expect.arrayContaining(['Azure Administrator Associate']),
         removed: expect.arrayContaining([]),
         reason: ['Elevated certifications for cloud leadership.'],
+      })
+    );
+    expect(response.body.rescore).toEqual(
+      expect.objectContaining({
+        section: expect.objectContaining({
+          key: expect.any(String),
+          label: expect.any(String),
+          before: expect.objectContaining({ score: expect.any(Number) }),
+          after: expect.objectContaining({ score: expect.any(Number) }),
+          delta: expect.objectContaining({ score: expect.any(Number) }),
+        }),
+        overall: expect.objectContaining({
+          before: expect.objectContaining({
+            score: expect.any(Number),
+            atsSubScores: expect.any(Array),
+          }),
+          after: expect.objectContaining({
+            score: expect.any(Number),
+            atsSubScores: expect.any(Array),
+          }),
+          delta: expect.objectContaining({ score: expect.any(Number) }),
+        }),
+        selectionProbability: expect.objectContaining({
+          before: expect.any(Number),
+          after: expect.any(Number),
+          delta: expect.any(Number),
+        }),
       })
     );
   });

--- a/tests/improvements.e2e.test.js
+++ b/tests/improvements.e2e.test.js
@@ -313,6 +313,36 @@ describe('targeted improvement endpoints (integration)', () => {
       if (explanation) {
         expect(summaryEntry.reason.join(' ')).toContain(explanation.split(' ')[0]);
       }
+      expect(response.body.rescore).toEqual(
+        expect.objectContaining({
+          section: expect.objectContaining({
+            key: expect.any(String),
+            label: expect.any(String),
+            before: expect.objectContaining({ score: expect.any(Number) }),
+            after: expect.objectContaining({ score: expect.any(Number) }),
+            delta: expect.objectContaining({ score: expect.any(Number) }),
+          }),
+          overall: expect.objectContaining({
+            before: expect.objectContaining({
+              score: expect.any(Number),
+              atsSubScores: expect.any(Array),
+            }),
+            after: expect.objectContaining({
+              score: expect.any(Number),
+              atsSubScores: expect.any(Array),
+            }),
+            delta: expect.objectContaining({ score: expect.any(Number) }),
+          }),
+          selectionProbability: expect.objectContaining({
+            before: expect.any(Number),
+            after: expect.any(Number),
+            delta: expect.any(Number),
+          }),
+        })
+      );
+      expect(typeof response.body.selectionProbabilityBefore).toBe('number');
+      expect(typeof response.body.selectionProbabilityAfter).toBe('number');
+      expect(typeof response.body.selectionProbabilityDelta).toBe('number');
     }
 
     expect(generateContentMock).toHaveBeenCalledTimes(aiResponses.length);


### PR DESCRIPTION
## Summary
- add helpers to identify targeted sections and extract designation headlines when rescoring improvements
- compute section and overall ATS metrics plus selection probability deltas after each improvement and return them in the API response
- extend improvement route tests to verify the new rescore payload structure and selection probability fields

## Testing
- npm test -- improvementRoutes.test.js *(fails: missing @babel/preset-env in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df924ef190832b942dbfc30158728d