### PR TITLE
Refine resume generation to merge template fields

### DIFF
--- a/tests/geminiPrompts.unit.test.js
+++ b/tests/geminiPrompts.unit.test.js
@@ -14,7 +14,11 @@ const generativeModelMock = {
   })
 };
 
-const { collectSectionText, rewriteSectionsWithGemini } = await import('../server.js');
+const {
+  collectSectionText,
+  rewriteSectionsWithGemini,
+  sanitizeGeneratedText,
+} = await import('../server.js');
 
 describe('rewriteSectionsWithGemini prompt construction', () => {
   beforeEach(() => {
@@ -47,7 +51,8 @@ describe('rewriteSectionsWithGemini prompt construction', () => {
       'Exciting job description here',
       ['JavaScript', 'AWS'],
       generativeModelMock,
-      { skipRequiredSections: true }
+      { skipRequiredSections: true },
+      resume
     );
 
     expect(generativeModelMock.generateContent).toHaveBeenCalledTimes(1);
@@ -75,10 +80,11 @@ describe('rewriteSectionsWithGemini prompt construction', () => {
       'Job description',
       [],
       null,
-      { skipRequiredSections: true }
+      { skipRequiredSections: true },
+      resume
     );
 
-    expect(result.text).toContain('Jane Doe');
+    expect(result.text).toBe(sanitizeGeneratedText(resume, { skipRequiredSections: true }));
     expect(result.project).toBe('');
     expect(result.modifiedTitle).toBe('');
     expect(result.addedSkills).toEqual([]);

--- a/tests/geminiSections.test.js
+++ b/tests/geminiSections.test.js
@@ -36,13 +36,14 @@ describe('rewriteSectionsWithGemini', () => {
       },
     });
     const generativeModel = { generateContent: generateContentMock };
-    const { text, modifiedTitle, addedSkills } = await rewriteSectionsWithGemini(
+    const { text, modifiedTitle, addedSkills, sanitizedFallbackUsed } = await rewriteSectionsWithGemini(
       'John Doe',
       sections,
       'JD text',
       ['Leadership', 'Skill C'],
       generativeModel,
-      { skipRequiredSections: true }
+      { skipRequiredSections: true },
+      resumeText
     );
     expect(generativeModel.generateContent).toHaveBeenCalled();
     expect(text).toContain('Polished summary');
@@ -55,6 +56,7 @@ describe('rewriteSectionsWithGemini', () => {
     expect(text).toContain('Updated Title');
     expect(modifiedTitle).toBe('Updated Title');
     expect(addedSkills).toEqual(['Skill C']);
+    expect(sanitizedFallbackUsed).toBe(false);
   });
 
   test('falls back to sanitized resume when Gemini returns plain text', async () => {
@@ -74,13 +76,15 @@ describe('rewriteSectionsWithGemini', () => {
       'Job description text',
       ['Communication'],
       generativeModel,
-      options
+      options,
+      resumeText
     );
 
     expect(generativeModel.generateContent).toHaveBeenCalledTimes(1);
-    expect(result.text).toBe(sanitizeGeneratedText('Jane Doe', options));
+    expect(result.text).toBe(sanitizeGeneratedText(resumeText, options));
     expect(result.project).toBe('');
     expect(result.modifiedTitle).toBe('');
     expect(result.addedSkills).toEqual([]);
+    expect(result.sanitizedFallbackUsed).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add helpers to normalize Gemini responses into structured resume sections and merge them with extracted resume data
- update `rewriteSectionsWithGemini` to consume the base resume text, reuse template-driven sanitization, and return merged content
- adjust Gemini-focused unit tests to cover the new structured fallback behaviour

## Testing
- npm test -- --runTestsByPath tests/geminiSections.test.js tests/geminiPrompts.unit.test.js *(fails: missing @babel/preset-env)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcd73e778832bb668603d50cfbe65