### PR TITLE
Populate templates with extracted resume contact details

### DIFF
--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -662,6 +662,33 @@ describe('generatePdf and parsing', () => {
     setChromiumLauncher(null);
   });
 
+  test('ucmo template auto-populates extracted contact fields', async () => {
+    const input = [
+      'Jane Candidate',
+      'Email: jane@example.com',
+      'Phone: 555-123-4567',
+      'Springfield, MO',
+      'LinkedIn: linkedin.com/in/jane',
+      '# Experience',
+      '- Led initiatives',
+      '# Education',
+      '- BSc, Computer Science'
+    ].join('\n');
+    const setContent = jest.fn();
+    const pdf = jest.fn().mockResolvedValue(Buffer.from('%PDF-1.4'));
+    const close = jest.fn();
+    const newPage = jest.fn().mockResolvedValue({ setContent, pdf });
+    setChromiumLauncher(async () => ({ newPage, close }));
+    await generatePdf(input, 'ucmo');
+    setChromiumLauncher(null);
+    expect(setContent).toHaveBeenCalled();
+    const html = setContent.mock.calls[0][0];
+    expect(html).toContain('555-123-4567');
+    expect(html).toContain('jane@example.com');
+    expect(html).toContain('Springfield, MO');
+    expect(html).toContain('linkedin.com/in/jane');
+  });
+
   test('PDFKit fallback produces consistent line spacing for bullet lists', async () => {
     const input = 'Jane Doe\n- First line\n- Second line';
     const fallbackPdf = await generatePdf(input, 'modern');

--- a/tests/templates/ucmo.test.js
+++ b/tests/templates/ucmo.test.js
@@ -1,4 +1,9 @@
-import { parseContent, generatePdf, setChromiumLauncher } from '../../server.js';
+import {
+  parseContent,
+  generatePdf,
+  setChromiumLauncher,
+  extractContactDetails
+} from '../../server.js';
 import Handlebars from '../../lib/handlebars.js';
 import fs from 'fs/promises';
 import path from 'path';
@@ -25,15 +30,26 @@ function tokensToHtml(tokens) {
 }
 
 test('ucmo template renders with contact bar and logo', async () => {
-  const input = 'Jane Doe\n# Experience\n- Built things\n# Education\n- BSc Stuff';
-  const data = parseContent(input);
+  const input = [
+    'Jane Doe',
+    'Email: jane@example.com',
+    'Phone: 555-555-5555',
+    'Warrensburg, MO',
+    'LinkedIn: linkedin.com/in/jane',
+    '# Experience',
+    '- Built things',
+    '# Education',
+    '- BSc Stuff'
+  ].join('\n');
+  const contact = extractContactDetails(input);
+  const data = parseContent(input, { contactLines: contact.contactLines });
   const tplSrc = await fs.readFile(path.resolve('templates', 'ucmo.html'), 'utf8');
   const htmlData = {
     ...data,
-    phone: '555-555-5555',
-    email: 'jane@example.com',
-    cityState: 'Warrensburg, MO',
-    linkedin: 'linkedin.com/in/jane',
+    phone: contact.phone,
+    email: contact.email,
+    cityState: contact.cityState,
+    linkedin: contact.linkedin,
     sections: data.sections.map((sec) => ({
       ...sec,
       items: sec.items.map(tokensToHtml)


### PR DESCRIPTION
## Summary
- extend resume contact extraction to capture location details and deduplicate contact lines
- feed extracted contact fields into PDF generation so HTML and PDF templates receive phone, email, LinkedIn, and location data
- update template and PDF tests to rely on the automated extraction logic and verify contact details appear in the rendered output

## Testing
- `npm test` *(fails: missing optional dependency @babel/preset-env in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcfed2fe4832ba86065038201aa7e