### PR TITLE
Fix Gemini rewrite to return resolved text

### DIFF
--- a/server.js
+++ b/server.js
@@ -3834,8 +3834,9 @@ async function rewriteSectionsWithGemini(
     basePlaceholderMap
   );
   const fallbackResult = {
-    text: sanitizedBaseText,
+    text: fallbackResolved,
     resolvedText: fallbackResolved,
+    tokenizedText: sanitizedBaseText,
     project: '',
     modifiedTitle: '',
     addedSkills: [],
@@ -3892,21 +3893,21 @@ async function rewriteSectionsWithGemini(
       const mergedData = mergeResumeDataSections(baseResumeData, resumeData);
       const mergedText = resumeDataToText(mergedData);
       const cleaned = sanitizeGeneratedText(mergedText, normalizeOptions);
-      const resolvedText = resolveEnhancementTokens(
-        cleaned,
-        mergedData?.placeholders || {}
-      );
+      const placeholders = mergedData?.placeholders || {};
+      const resolvedText = resolveEnhancementTokens(cleaned, placeholders);
+      const outputText = resolvedText || cleaned;
       const addedSkills = Array.isArray(parsed.addedSkills)
         ? parsed.addedSkills.filter((skill) => typeof skill === 'string' && skill.trim())
         : [];
       return {
-        text: cleaned,
-        resolvedText,
+        text: outputText,
+        resolvedText: outputText,
+        tokenizedText: cleaned,
         project: parsed.projectSnippet || parsed.project || '',
         modifiedTitle: parsed.latestRoleTitle || '',
         addedSkills,
         sanitizedFallbackUsed: false,
-        placeholders: mergedData.placeholders || {},
+        placeholders,
       };
     }
   } catch {


### PR DESCRIPTION
## Summary
- ensure `rewriteSectionsWithGemini` resolves Gemini placeholders before returning resume text
- preserve the sanitized placeholder text separately via a new `tokenizedText` field for both Gemini output and the fallback

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dfe3ac9bf0832b92f045950a2192c2