### PR TITLE
Ensure AI enhancements use token placeholders

### DIFF
--- a/tests/createResumeVariants.test.js
+++ b/tests/createResumeVariants.test.js
@@ -1,0 +1,55 @@
+import { createResumeVariants } from '../server.js';
+
+describe('createResumeVariants', () => {
+  test('enhancements rely on tokens mapped to placeholders', () => {
+    const baseText = [
+      'Jane Doe',
+      '# Summary',
+      '- Delivered award-winning platforms.',
+      '# Work Experience',
+      '- Senior Engineer at Acme Corp: Increased uptime by 20%.',
+      '# Skills',
+      '- JavaScript'
+    ].join('\n');
+
+    const { version1, version2, placeholders } = createResumeVariants({
+      baseText,
+      projectText: 'Built a scalable AI matching engine with AWS Lambda and DynamoDB.',
+      modifiedTitle: 'Principal Engineer',
+      skillsToInclude: ['GraphQL'],
+      baseSkills: ['Leadership'],
+      sanitizeOptions: { skipRequiredSections: true }
+    });
+
+    const tokenPattern = /\{\{RF_ENH_[A-Z0-9_]+\}\}/g;
+    const version1Tokens = version1.match(tokenPattern) || [];
+    const version2Tokens = version2.match(tokenPattern) || [];
+    const allTokens = Array.from(new Set([...version1Tokens, ...version2Tokens]));
+
+    expect(version1Tokens.length).toBeGreaterThanOrEqual(3);
+    allTokens.forEach((token) => {
+      expect(placeholders[token]).toBeDefined();
+    });
+
+    const workToken = version1Tokens.find((token) => token.includes('WORK_EXPERIENCE'));
+    expect(workToken).toBeDefined();
+    expect(placeholders[workToken]).toBe(
+      'Principal Engineer at Acme Corp: Increased uptime by 20%.'
+    );
+
+    const projectToken = version1Tokens.find((token) => token.includes('PROJECTS'));
+    expect(projectToken).toBeDefined();
+    expect(placeholders[projectToken]).toBe(
+      'Built a scalable AI matching engine with AWS Lambda and DynamoDB.'
+    );
+
+    const skillTokens = allTokens.filter((token) => token.includes('SKILLS'));
+    const skillValues = skillTokens.map((token) => placeholders[token]);
+    expect(skillValues).toEqual(
+      expect.arrayContaining(['Leadership', 'GraphQL'])
+    );
+
+    const graphQlToken = version2Tokens.find((token) => placeholders[token] === 'GraphQL');
+    expect(graphQlToken).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared helper to register enhancement placeholders and reuse it when adding Gemini-driven resume updates
- ensure resume variant generation records placeholder mappings and feeds them back into the overall enhancement token map
- add coverage verifying createResumeVariants outputs use token placeholders tied to their generated content

## Testing
- npm test -- createResumeVariants *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68dfee3ca030832b9c7ac02374655176