### PR TITLE
Ensure resume variant enhancements use placeholder tokens

### DIFF
--- a/server.js
+++ b/server.js
@@ -8947,7 +8947,14 @@ function createResumeVariants({
       : {}),
   });
 
-  return { version1: version1Text, version2: version2Text, placeholders: placeholderMap };
+  const version1Tokenized = injectEnhancementTokens(version1Text, placeholderMap);
+  const version2Tokenized = injectEnhancementTokens(version2Text, placeholderMap);
+
+  return {
+    version1: version1Tokenized,
+    version2: version2Tokenized,
+    placeholders: placeholderMap,
+  };
 }
 
 async function verifyResume(


### PR DESCRIPTION
## Summary
- ensure resume variant generation reinjects enhancement tokens into variant text before returning it

## Testing
- npm test -- --runTestsByPath tests/createResumeVariants.test.js *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68dff50498f8832baed20b2269fedf2a