### PR TITLE
Add QR code imagery to resume templates

### DIFF
--- a/templates/classic.html
+++ b/templates/classic.html
@@ -43,6 +43,41 @@
       margin-bottom: 32px;
     }
 
+    .masthead {
+      display: grid;
+      gap: 22px;
+    }
+
+    @media (min-width: 720px) {
+      .masthead {
+        grid-template-columns: 1fr auto;
+        align-items: center;
+      }
+    }
+
+    .identity {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 20px;
+      align-items: center;
+    }
+
+    .crest {
+      width: 72px;
+      height: 72px;
+      border-radius: 18px;
+      overflow: hidden;
+      box-shadow: 0 18px 32px rgba(31, 41, 51, 0.18);
+      border: 1px solid rgba(31, 41, 51, 0.08);
+    }
+
+    .crest img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
     header h1 {
       font-family: 'Playfair Display', 'Times New Roman', serif;
       font-size: 38px;
@@ -57,6 +92,40 @@
       letter-spacing: 0.12em;
       color: var(--muted);
       text-transform: uppercase;
+    }
+
+    .qr-card {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 14px;
+      align-items: center;
+      padding: 12px 18px;
+      border-radius: 16px;
+      background: linear-gradient(135deg, rgba(45, 90, 158, 0.12), rgba(45, 90, 158, 0.04));
+      border: 1px solid rgba(31, 41, 51, 0.12);
+      box-shadow: 0 16px 28px rgba(31, 41, 51, 0.12);
+    }
+
+    .qr-card img {
+      width: 72px;
+      height: 72px;
+      border-radius: 12px;
+      box-shadow: 0 10px 18px rgba(31, 41, 51, 0.18);
+    }
+
+    .qr-card strong {
+      display: block;
+      font-size: 0.95rem;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--accent);
+    }
+
+    .qr-card span {
+      display: block;
+      font-size: 0.85rem;
+      color: var(--muted);
+      letter-spacing: 0.04em;
     }
 
     .sections {
@@ -141,8 +210,32 @@
 <body>
   <main class="sheet">
     <header>
-      <h1>{{name}}</h1>
-      <p>Curriculum Vitae</p>
+      <div class="masthead">
+        <div class="identity">
+          <div class="crest">
+            {{#if avatar}}
+            <img src="{{avatar}}" alt="{{name}} monogram" />
+            {{else}}
+            <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMyZDVhOWUiLz4KICA8cGF0aCBkPSJNMjAgMjBoMjR2MThjMCA4LjgzNy03LjE2MyAxNi0xNiAxNnMtMTYtNy4xNjMtMTYtMTZWMjB6IiBmaWxsPSIjZjhmYWZjIiBvcGFjaXR5PSIwLjkiLz4KICA8cGF0aCBkPSJNMjQgMTZoMTZhNCA0IDAgMCAxIDQgNHYxMGwtMTIgNi0xMi02VjIwYTQgNCAwIDAgMSA0LTR6IiBmaWxsPSIjMWYyOTMzIiBvcGFjaXR5PSIwLjM1Ii8+CiAgPHBhdGggZD0iTTI0IDI0aDE2IiBzdHJva2U9IiMxZjI5MzMiIHN0cm9rZS13aWR0aD0iMyIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBvcGFjaXR5PSIwLjY1Ii8+CiAgPHBhdGggZD0iTTI0IDMwaDE2IiBzdHJva2U9IiMxZjI5MzMiIHN0cm9rZS13aWR0aD0iMyIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBvcGFjaXR5PSIwLjQiLz4KICA8cGF0aCBkPSJNMTYgMTJsLTIgNGMtMS42IDMuMi0yLjQgNi43LTIuNCAxMC4yQzExLjYgMzkuNyAyMSA0OCAzMiA0OHMyMC40LTguMyAyMC40LTIxLjhjMC0zLjUtMC44LTctMi40LTEwLjJsLTItNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjZjhmYWZjIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgb3BhY2l0eT0iMC42NSIvPgo8L3N2Zz4=" alt="Classic crest placeholder" />
+            {{/if}}
+          </div>
+          <div>
+            <h1>{{name}}</h1>
+            <p>Curriculum Vitae</p>
+          </div>
+        </div>
+        <div class="qr-card">
+          {{#if qrCode}}
+          <img src="{{qrCode}}" alt="QR code linking to {{name}}'s professional dossier" />
+          {{else}}
+          <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjggMTI4Ij4KICA8cmVjdCB3aWR0aD0iMTI4IiBoZWlnaHQ9IjEyOCIgcng9IjE4IiBmaWxsPSIjMGYxNzJhIi8+CiAgPGcgZmlsbD0iIzM4YmRmOCI+CiAgICA8cmVjdCB4PSIxNiIgeT0iMTYiIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIgcng9IjQiLz4KICAgIDxyZWN0IHg9IjgwIiB5PSIxNiIgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNCIvPgogICAgPHJlY3QgeD0iMTYiIHk9IjgwIiB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHJ4PSI0Ii8+CiAgICA8cmVjdCB4PSI4MCIgeT0iODAiIHdpZHRoPSIxMiIgaGVpZ2h0PSIxMiIvPgogICAgPHJlY3QgeD0iOTYiIHk9Ijk2IiB3aWR0aD0iMTYiIGhlaWdodD0iMTYiLz4KICAgIDxyZWN0IHg9IjY0IiB5PSI0OCIgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2Ii8+CiAgICA8cmVjdCB4PSI0OCIgeT0iNjQiIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIvPgogICAgPHJlY3QgeD0iNjQiIHk9IjgwIiB3aWR0aD0iMTYiIGhlaWdodD0iMTYiLz4KICAgIDxyZWN0IHg9IjgwIiB5PSI2NCIgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2Ii8+CiAgICA8cmVjdCB4PSIzMiIgeT0iNDgiIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIvPgogICAgPHJlY3QgeD0iNDgiIHk9IjMyIiB3aWR0aD0iMTYiIGhlaWdodD0iMTYiLz4KICA8L2c+Cjwvc3ZnPg==" alt="Static QR code placeholder" />
+          {{/if}}
+          <div>
+            <strong>Portfolio QR</strong>
+            <span>Scan to explore work samples and credentials.</span>
+          </div>
+        </div>
+      </div>
     </header>
     <div class="sections">
       {{#each sections}}

--- a/templates/modern.html
+++ b/templates/modern.html
@@ -61,8 +61,44 @@
       border: 1px solid rgba(148, 163, 184, 0.2);
       box-shadow: inset 0 0 0 1px rgba(226, 232, 240, 0.12);
       display: grid;
-      gap: 12px;
+      gap: clamp(18px, 2.6vw, 28px);
       text-align: left;
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    @media (min-width: 860px) {
+      .hero {
+        grid-template-columns: 1.3fr 1fr;
+        align-items: center;
+      }
+    }
+
+    .hero-copy {
+      display: grid;
+      gap: 14px;
+      position: relative;
+      z-index: 1;
+    }
+
+    .hero-tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 8px 14px;
+      border-radius: 999px;
+      background: rgba(15, 118, 110, 0.28);
+      color: #ecfeff;
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.18em;
+      font-weight: 600;
+      box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.28);
+    }
+
+    .hero-tag img {
+      width: 18px;
+      height: 18px;
+      display: inline-block;
     }
 
     .hero h1 {
@@ -76,8 +112,69 @@
     .hero p {
       margin: 0;
       color: var(--muted);
-      max-width: 40ch;
-      font-size: 1rem;
+      max-width: 45ch;
+      font-size: 1.02rem;
+    }
+
+    .hero-visual {
+      position: relative;
+      z-index: 1;
+      display: grid;
+      gap: 18px;
+      justify-items: center;
+    }
+
+    .hero-avatar {
+      width: clamp(140px, 24vw, 180px);
+      aspect-ratio: 1 / 1;
+      border-radius: 24px;
+      padding: 12px;
+      background: rgba(15, 23, 42, 0.55);
+      border: 1px solid rgba(148, 163, 184, 0.28);
+      box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.18), 0 18px 30px rgba(8, 47, 73, 0.4);
+      display: grid;
+      place-items: center;
+    }
+
+    .hero-avatar img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: 18px;
+      box-shadow: 0 8px 18px rgba(8, 47, 73, 0.35);
+    }
+
+    .hero-qr {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 12px;
+      align-items: center;
+      padding: 12px 16px;
+      border-radius: 16px;
+      background: rgba(15, 23, 42, 0.7);
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.12);
+    }
+
+    .hero-qr img {
+      width: 74px;
+      height: 74px;
+      border-radius: 12px;
+      box-shadow: 0 10px 22px rgba(8, 47, 73, 0.35);
+    }
+
+    .hero-qr strong {
+      display: block;
+      font-size: 0.95rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .hero-qr span {
+      display: block;
+      color: var(--muted);
+      font-size: 0.82rem;
+      letter-spacing: 0.04em;
     }
 
     .content-grid {
@@ -147,6 +244,16 @@
       text-transform: uppercase;
       letter-spacing: 0.08em;
       color: #f8fafc;
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .card-header .heading-icon {
+      width: 26px;
+      height: 26px;
+      border-radius: 8px;
+      box-shadow: 0 8px 14px rgba(8, 47, 73, 0.28);
     }
 
     .card-header .accent-line {
@@ -210,15 +317,44 @@
 <body>
   <div class="resume-shell">
     <header class="hero">
-      <h1>{{name}}</h1>
-      <p>Crafted with a modern product-design aesthetic for standout first impressions.</p>
+      <div class="hero-copy">
+        <span class="hero-tag">
+          <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+CiAgPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iOSIgZmlsbD0iIzBmMTcyYSIvPgogIDxwYXRoIGQ9Ik0xMCA5aDEyYTIgMiAwIDAgMSAyIDJ2MTJsLTgtMy04IDNWMTFhMiAyIDAgMCAxIDItMnoiIGZpbGw9IiMzOGJkZjgiLz4KICA8cGF0aCBkPSJNMTMgMTNoNiIgc3Ryb2tlPSIjMGVhNWU5IiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgogIDxwYXRoIGQ9Ik0xMyAxN2g2IiBzdHJva2U9IiNiYWU2ZmQiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBvcGFjaXR5PSIwLjgiLz4KPC9zdmc+" alt="Digital icon" />
+          Digital ready
+        </span>
+        <h1>{{name}}</h1>
+        <p>Crafted with a modern product-design aesthetic for standout first impressions.</p>
+      </div>
+      <div class="hero-visual">
+        <figure class="hero-avatar">
+          {{#if avatar}}
+          <img src="{{avatar}}" alt="Portrait of {{name}}" />
+          {{else}}
+          <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjAgMTIwIj4KICA8ZGVmcz4KICAgIDxsaW5lYXJHcmFkaWVudCBpZD0iZyIgeDE9IjAiIHkxPSIwIiB4Mj0iMSIgeTI9IjEiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjMzhiZGY4Ii8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iIzBlYTVlOSIvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPHJlY3Qgd2lkdGg9IjEyMCIgaGVpZ2h0PSIxMjAiIHJ4PSIyOCIgZmlsbD0iIzBmMTcyYSIvPgogIDxjaXJjbGUgY3g9IjYwIiBjeT0iNDgiIHI9IjI2IiBmaWxsPSJ1cmwoI2cpIi8+CiAgPHBhdGggZD0iTTI0IDEwOGM2LTIyIDI4LTM2IDM2LTM2czMwIDE0IDM2IDM2IiBmaWxsPSIjMWUyOTNiIi8+CiAgPHBhdGggZD0iTTI0IDEwOGM2LTIyIDI4LTM2IDM2LTM2czMwIDE0IDM2IDM2IiBmaWxsPSJub25lIiBzdHJva2U9IiMzOGJkZjgiIHN0cm9rZS13aWR0aD0iMyIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBvcGFjaXR5PSIwLjQiLz4KPC9zdmc+" alt="Abstract avatar placeholder" />
+          {{/if}}
+        </figure>
+        <div class="hero-qr">
+          {{#if qrCode}}
+          <img src="{{qrCode}}" alt="QR code linking to {{name}}'s professional profile" />
+          {{else}}
+          <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjggMTI4Ij4KICA8cmVjdCB3aWR0aD0iMTI4IiBoZWlnaHQ9IjEyOCIgcng9IjE4IiBmaWxsPSIjMGYxNzJhIi8+CiAgPGcgZmlsbD0iIzM4YmRmOCI+CiAgICA8cmVjdCB4PSIxNiIgeT0iMTYiIHdpZHRoPSIzMiIgaGVpZ2h0PSIzMiIgcng9IjQiLz4KICAgIDxyZWN0IHg9IjgwIiB5PSIxNiIgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNCIvPgogICAgPHJlY3QgeD0iMTYiIHk9IjgwIiB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHJ4PSI0Ii8+CiAgICA8cmVjdCB4PSI4MCIgeT0iODAiIHdpZHRoPSIxMiIgaGVpZ2h0PSIxMiIvPgogICAgPHJlY3QgeD0iOTYiIHk9Ijk2IiB3aWR0aD0iMTYiIGhlaWdodD0iMTYiLz4KICAgIDxyZWN0IHg9IjY0IiB5PSI0OCIgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2Ii8+CiAgICA8cmVjdCB4PSI0OCIgeT0iNjQiIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIvPgogICAgPHJlY3QgeD0iNjQiIHk9IjgwIiB3aWR0aD0iMTYiIGhlaWdodD0iMTYiLz4KICAgIDxyZWN0IHg9IjgwIiB5PSI2NCIgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2Ii8+CiAgICA8cmVjdCB4PSIzMiIgeT0iNDgiIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIvPgogICAgPHJlY3QgeD0iNDgiIHk9IjMyIiB3aWR0aD0iMTYiIGhlaWdodD0iMTYiLz4KICA8L2c+Cjwvc3ZnPg==" alt="Static QR code placeholder" />
+          {{/if}}
+          <div>
+            <strong>Scan for profile</strong>
+            <span>Instant access to interactive resume details.</span>
+          </div>
+        </div>
+      </div>
     </header>
     <main class="content-grid">
       {{#each sections}}
       <section class="card {{#if @first}}card--spotlight{{/if}}">
         {{#if heading}}
         <div class="card-header">
-          <h2>{{heading}}</h2>
+          <h2>
+            <img class="heading-icon" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+CiAgPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iOSIgZmlsbD0iIzBmMTcyYSIvPgogIDxwYXRoIGQ9Ik0xMCA5aDEyYTIgMiAwIDAgMSAyIDJ2MTJsLTgtMy04IDNWMTFhMiAyIDAgMCAxIDItMnoiIGZpbGw9IiMzOGJkZjgiLz4KICA8cGF0aCBkPSJNMTMgMTNoNiIgc3Ryb2tlPSIjMGVhNWU5IiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgogIDxwYXRoIGQ9Ik0xMyAxN2g2IiBzdHJva2U9IiNiYWU2ZmQiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBvcGFjaXR5PSIwLjgiLz4KPC9zdmc+" alt="Section icon" />
+            {{heading}}
+          </h2>
           <span class="accent-line"></span>
         </div>
         {{/if}}


### PR DESCRIPTION
## Summary
- enhance the modern template hero with embedded avatar, QR code placeholders, and section heading icons
- refresh the classic template masthead with a crest image, avatar fallback, and QR callout while preserving section layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dff8225110832b8cbc9c90812ee1f5