### PR TITLE
Fix change set conflict detection when sam deploy outputs color codes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -267,7 +267,23 @@ jobs:
             fi
 
             deploy_err=$(cat "$tmp_deploy_log")
-            deploy_err_normalized=$(printf '%s\n' "$deploy_err" | tr '\r\n' '  ' | tr -s ' ')
+
+            # sam deploy may emit ANSI color codes when running in a TTY. These escape
+            # sequences prevent the grep patterns below from matching reliably (for
+            # example, the word "ChangeSet" may appear as "\x1b[0mChangeSet"). Strip
+            # the sequences before normalizing whitespace so detection works even when
+            # colors are enabled.
+            deploy_err_stripped=$(printf '%s\n' "$deploy_err" | \
+              python <<'PY'
+import re
+import sys
+
+ansi_escape = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
+sys.stdout.write(ansi_escape.sub('', sys.stdin.read()))
+PY
+            )
+
+            deploy_err_normalized=$(printf '%s\n' "$deploy_err_stripped" | tr '\r\n' '  ' | tr -s ' ')
             if printf '%s\n' "$deploy_err_normalized" | grep -Eqi "is in (CREATE|UPDATE|DELETE)_IN_PROGRESS state (and )?can[[:space:]]*not be updated"; then
               if [ "$deploy_attempt" -eq "$max_deploy_attempts" ]; then
                 echo "Stack remained busy after $max_deploy_attempts attempts. Aborting deployment." >&2
@@ -300,7 +316,7 @@ jobs:
             : >"$tmp_err"
             if printf '%s\n' "$deploy_err_normalized" | grep -Eqi 'AlreadyExistsException' && \
                printf '%s\n' "$deploy_err_normalized" | grep -Eqi 'ChangeSet [^ ]* cannot be created due to a mismatch with existing attribute Description'; then
-              change_set_name=$(printf '%s\n' "$deploy_err" | sed -n "s/.*ChangeSet[[:space:]]\([^[:space:]]*\)[[:space:]].*/\1/p" | head -n1)
+              change_set_name=$(printf '%s\n' "$deploy_err_stripped" | sed -n "s/.*ChangeSet[[:space:]]\([^[:space:]]*\)[[:space:]].*/\1/p" | head -n1)
 
               if [ -z "$change_set_name" ]; then
                 echo "sam deploy reported an AlreadyExistsException but the change set name could not be determined." >&2


### PR DESCRIPTION
## Summary
- strip ANSI escape sequences from the captured `sam deploy` output before parsing it for known failure modes
- continue using the sanitized output when extracting the change set name so conflicting change sets can be removed automatically

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dffe2363d8832bb89062d8470aeb22