### PR TITLE
Fix deploy workflow YAML syntax error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -274,13 +274,7 @@ jobs:
             # the sequences before normalizing whitespace so detection works even when
             # colors are enabled.
             deploy_err_stripped=$(printf '%s\n' "$deploy_err" | \
-              python <<'PY'
-import re
-import sys
-
-ansi_escape = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
-sys.stdout.write(ansi_escape.sub('', sys.stdin.read()))
-PY
+              python -c "import re, sys; ansi_escape = re.compile(r'\\x1B\\[[0-?]*[ -/]*[@-~]'); sys.stdout.write(ansi_escape.sub('', sys.stdin.read()))"
             )
 
             deploy_err_normalized=$(printf '%s\n' "$deploy_err_stripped" | tr '\r\n' '  ' | tr -s ' ')


### PR DESCRIPTION
## Summary
- replace the inline Python heredoc in the deploy workflow with a `python -c` invocation so the step remains properly indented within the YAML literal block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0000ca424832b961c69aa97f5466c