### PR TITLE
Add resume revert controls and history-aware downloads

### DIFF
--- a/client/src/deriveDeltaSummary.js
+++ b/client/src/deriveDeltaSummary.js
@@ -140,6 +140,9 @@ export function deriveDeltaSummary({
 
   const changeLogEntries = Array.isArray(changeLog) ? changeLog : []
   changeLogEntries.forEach((entry) => {
+    if (entry?.reverted) {
+      return
+    }
     const entryType = normalizeText(entry?.type)
     const entryAdded = normalizeStringList(entry?.addedItems)
     const entryRemoved = normalizeStringList(entry?.removedItems)


### PR DESCRIPTION
## Summary
- track accepted improvement history so users can undo changes and download prior resume drafts on demand
- surface undo/download controls in the change log and persist revert metadata to the server when possible
- ignore reverted change log entries when deriving delta summaries to reflect the active resume state

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e005077eac832b9487ee5d4cc308ed