### PR TITLE
Ensure session-specific storage for original resume downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Because the configuration is loaded and cached once, the service reuses the same
 ### Privacy, GDPR, and data retention
 
 - DynamoDB inserts now hash candidate names, LinkedIn URLs, IP addresses, and user agents with SHA-256 (plus the optional `PII_HASH_SECRET` salt) before persisting them. The table retains browser, OS, and device metadata for aggregate analytics without storing raw personally identifiable information.
-- An EventBridge rule can invoke the Lambda on a schedule to remove generated sessions from S3 that are older than `SESSION_RETENTION_DAYS` (30 days by default). The scheduled handler deletes entire `<candidate>/cv/<ISO-date>/...` prefixes so no PDFs or logs linger past the retention window.
+- An EventBridge rule can invoke the Lambda on a schedule to remove generated sessions from S3 that are older than `SESSION_RETENTION_DAYS` (30 days by default). The scheduled handler deletes entire `<candidate>/cv/<ISO-date>/<session-id>/...` prefixes so no PDFs or logs linger past the retention window.
 
 Implementation snippet:
 
@@ -389,7 +389,7 @@ ownload URLs expire after one hour:
 
 `originalScore` represents the percentage match between the job description and the uploaded resume. `enhancedScore` is the best match achieved by the generated resumes. `table` details how each job skill matched, `addedSkills` shows skills newly matched in the enhanced resume, and `missingSkills` lists skills from the job description still absent.
 
-S3 keys follow the pattern `<candidate>/cv/<ISO-date>/generated/<subdir>/<file>.pdf`, where `<subdir>` is `cover_letter/` or `cv/` depending on the file type. The API now returns presigned download URLs along with an ISO 8601 timestamp (`expiresAt`) that indicates when each link will expire.
+S3 keys follow the pattern `<candidate>/cv/<ISO-date>/<session-id>/generated/<subdir>/<file>.pdf`, where `<subdir>` is `cover_letter/` or `cv/` depending on the file type. The original upload remains stored at `<candidate>/cv/<ISO-date>/<session-id>/<candidate>.pdf` to guarantee the untouched résumé is always available. The API now returns presigned download URLs along with an ISO 8601 timestamp (`expiresAt`) that indicates when each link will expire.
 
 ```
 jane_doe/cv/2025-01-15/

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -534,12 +534,12 @@ function getDownloadPresentation(file = {}) {
       return {
         label: 'Original CV Upload',
         description: 'Exact resume you submitted before any AI enhancements—keep this for applications that prefer the untouched version.',
-        badgeText: 'Original',
+        badgeText: 'Original CV',
         badgeStyle: 'bg-slate-100 text-slate-700 border-slate-200',
         buttonStyle: 'bg-slate-700 hover:bg-slate-800 focus:ring-slate-500',
         cardAccent: 'bg-gradient-to-br from-slate-50 via-white to-white',
         cardBorder: 'border-slate-200',
-        linkLabel: 'Download original file',
+        linkLabel: 'Download original PDF',
         category: 'resume',
         autoPreviewPriority: 4
       }
@@ -547,12 +547,12 @@ function getDownloadPresentation(file = {}) {
       return {
         label: 'Enhanced CV Version 1',
         description: 'Primary rewrite balanced for ATS scoring and recruiter readability with the strongest keyword alignment.',
-        badgeText: 'Enhanced',
+        badgeText: 'Enhanced CV',
         badgeStyle: 'bg-emerald-100 text-emerald-700 border-emerald-200',
         buttonStyle: 'bg-emerald-600 hover:bg-emerald-700 focus:ring-emerald-500',
         cardAccent: 'bg-gradient-to-br from-emerald-50 via-white to-white',
         cardBorder: 'border-emerald-200',
-        linkLabel: 'Download PDF',
+        linkLabel: 'Download enhanced PDF',
         category: 'resume',
         autoPreviewPriority: 0
       }
@@ -560,12 +560,12 @@ function getDownloadPresentation(file = {}) {
       return {
         label: 'Enhanced CV Version 2',
         description: 'Alternate layout that spotlights impact metrics and leadership achievements for different screening preferences.',
-        badgeText: 'Enhanced Alt',
+        badgeText: 'Enhanced CV Alt',
         badgeStyle: 'bg-emerald-100 text-emerald-700 border-emerald-200',
         buttonStyle: 'bg-emerald-600 hover:bg-emerald-700 focus:ring-emerald-500',
         cardAccent: 'bg-gradient-to-br from-emerald-50 via-white to-white',
         cardBorder: 'border-emerald-200',
-        linkLabel: 'Download PDF',
+        linkLabel: 'Download enhanced PDF',
         category: 'resume',
         autoPreviewPriority: 1
       }

--- a/tests/purgeExpiredSessions.test.js
+++ b/tests/purgeExpiredSessions.test.js
@@ -8,8 +8,10 @@ describe('purgeExpiredSessions', () => {
     const { serverModule, mocks } = await setupTestServer();
     const oldDate = '2023-01-01';
     const freshDate = '2024-01-15';
-    const sessionPrefix = `candidate/cv/${oldDate}/`;
-    const freshPrefix = `candidate/cv/${freshDate}/`;
+    const sessionId = 'session-abc123';
+    const freshSessionId = 'session-fresh456';
+    const sessionPrefix = `candidate/cv/${oldDate}/${sessionId}/`;
+    const freshPrefix = `candidate/cv/${freshDate}/${freshSessionId}/`;
 
     const listedObjects = [
       buildS3Object(`${sessionPrefix}candidate.pdf`),


### PR DESCRIPTION
## Summary
- store original resume uploads under session-specific prefixes so they are never overwritten and expose helpers to derive the same prefix during retention and regeneration
- update the retention job and documentation to understand the new session-aware S3 key layout
- clarify download button copy so users can distinguish original versus enhanced CV files at a glance

## Testing
- npm test -- --runInBand *(fails: test environment lacks @babel/preset-env)*

------
https://chatgpt.com/codex/tasks/task_e_68e00c8ca7a8832b966ebb4e1757e797