### PR TITLE
Enforce Dynamo state transitions between scoring and enhancement

### DIFF
--- a/server.js
+++ b/server.js
@@ -10797,6 +10797,8 @@ async function generateEnhancedDocumentsResponse({
       ':status': { S: 'completed' },
       ':generatedAt': { S: nowIso },
       ':jobId': { S: jobId },
+      ':statusScored': { S: 'scored' },
+      ':statusCompleted': { S: 'completed' },
     };
 
     const assignKey = (field, placeholder, value) => {
@@ -10818,7 +10820,8 @@ async function generateEnhancedDocumentsResponse({
           UpdateExpression: `SET ${updateExpressionParts.join(', ')}`,
           ExpressionAttributeNames: expressionAttributeNames,
           ExpressionAttributeValues: expressionAttributeValues,
-          ConditionExpression: 'jobId = :jobId',
+          ConditionExpression:
+            'jobId = :jobId AND (#status = :statusScored OR #status = :statusCompleted)',
         })
       );
       await logEvent({
@@ -12570,9 +12573,11 @@ app.post(
             },
             ':score': { N: String(scoringUpdate.normalizedScore) },
             ':jobId': { S: jobId },
+            ':statusUploaded': { S: 'uploaded' },
           },
           ExpressionAttributeNames: { '#status': 'status' },
-          ConditionExpression: 'jobId = :jobId',
+          ConditionExpression:
+            'jobId = :jobId AND (#status = :statusUploaded OR #status = :status OR attribute_not_exists(#status))',
         })
       );
       await logEvent({

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -288,9 +288,14 @@ describe('/api/process-cv', () => {
       ([cmd]) => cmd.__type === 'UpdateItemCommand'
     );
     expect(updateCall).toBeTruthy();
-    expect(updateCall[0].input.ConditionExpression).toBe('jobId = :jobId');
+    expect(updateCall[0].input.ConditionExpression).toBe(
+      'jobId = :jobId AND (#status = :statusUploaded OR #status = :status OR attribute_not_exists(#status))'
+    );
     expect(updateCall[0].input.ExpressionAttributeValues[':status'].S).toBe(
       'scored'
+    );
+    expect(updateCall[0].input.ExpressionAttributeValues[':statusUploaded'].S).toBe(
+      'uploaded'
     );
     expect(updateCall[0].input.ExpressionAttributeNames['#status']).toBe(
       'status'


### PR DESCRIPTION
## Summary
- require scoring updates to only transition sessions from uploaded to scored states
- gate enhancement completion updates on existing scored/completed records to keep the workflow linear
- update server tests to reflect the stricter DynamoDB condition expression

## Testing
- `npm test -- --runTestsByPath tests/server.test.js` *(fails: missing @babel/preset-env in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e00f4ef2cc832b9e7b4cdfc7337336