### PR TITLE
Call enhanced generation in process CV flow

### DIFF
--- a/server.js
+++ b/server.js
@@ -12594,6 +12594,51 @@ app.post(
       });
     }
 
+    let enhancedResponse = null;
+    try {
+      enhancedResponse = await generateEnhancedDocumentsResponse({
+        res,
+        s3,
+        dynamo,
+        tableName,
+        bucket,
+        logKey,
+        jobId,
+        requestId,
+        logContext,
+        resumeText: text,
+        originalResumeTextInput: originalResumeText,
+        jobDescription,
+        jobSkills,
+        resumeSkills,
+        originalMatch,
+        linkedinProfileUrl,
+        linkedinData,
+        credlyProfileUrl,
+        credlyCertifications,
+        credlyStatus,
+        manualCertificates,
+        templateContextInput,
+        templateParamConfig,
+        applicantName,
+        sanitizedName,
+        anonymizedLinkedIn,
+        originalUploadKey,
+        selection,
+        geminiApiKey: secrets.GEMINI_API_KEY,
+        changeLogEntries: [],
+      });
+    } catch (generationErr) {
+      logStructured('warn', 'process_cv_generation_failed', {
+        ...logContext,
+        error: serializeError(generationErr),
+      });
+    }
+
+    if (enhancedResponse) {
+      return res.json(enhancedResponse);
+    }
+
     const fallbackResponse = {
       success: true,
       requestId,


### PR DESCRIPTION
## Summary
- invoke `generateEnhancedDocumentsResponse` from the `/api/process-cv` handler after scoring so the primary flow produces generated resumes and cover letters when possible
- log and gracefully fall back to the legacy response if enhanced generation is unavailable or fails

## Testing
- npm test -- tests/server.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e015717edc832baa0014740e7baaaa