### PR TITLE
Handle missing AI response text in JSON extraction

### DIFF
--- a/server.js
+++ b/server.js
@@ -8296,6 +8296,9 @@ function extractCertifications(source) {
 }
 
 function extractJsonBlock(text) {
+  if (typeof text !== 'string') {
+    return null;
+  }
   const fenced = text.match(/```json[\s\S]*?```/i);
   if (fenced) {
     text = fenced[0].replace(/```json|```/gi, '');


### PR DESCRIPTION
## Summary
- add a guard in `extractJsonBlock` so undefined AI responses no longer throw when matched for JSON

## Testing
- npm test -- tests/uploadFlow.e2e.test.js *(fails: Cannot find package '@babel/preset-env' in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e01fb06f3c832ba381e8cabc804974