### PR TITLE
Fix DynamoDB GetItemCommand mocks in tests

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -43,6 +43,7 @@ jest.unstable_mockModule('@aws-sdk/client-dynamodb', () => ({
   DynamoDBClient: jest.fn(() => ({ send: mockDynamoSend })),
   CreateTableCommand: jest.fn((input) => ({ input, __type: 'CreateTableCommand' })),
   DescribeTableCommand: jest.fn((input) => ({ input, __type: 'DescribeTableCommand' })),
+  GetItemCommand: jest.fn((input) => ({ input, __type: 'GetItemCommand' })),
   PutItemCommand: jest.fn((input) => ({ input, __type: 'PutItemCommand' })),
   UpdateItemCommand: jest.fn((input) => ({ input, __type: 'UpdateItemCommand' })),
   ScanCommand: jest.fn((input) => ({ input, __type: 'ScanCommand' })),

--- a/tests/utils/testServer.js
+++ b/tests/utils/testServer.js
@@ -76,6 +76,7 @@ export async function setupTestServer({
     DynamoDBClient: jest.fn(() => ({ send: mockDynamoSend })),
     CreateTableCommand: jest.fn((input) => ({ input, __type: 'CreateTableCommand' })),
     DescribeTableCommand: jest.fn((input) => ({ input, __type: 'DescribeTableCommand' })),
+    GetItemCommand: jest.fn((input) => ({ input, __type: 'GetItemCommand' })),
     PutItemCommand: jest.fn((input) => ({ input, __type: 'PutItemCommand' })),
     UpdateItemCommand: jest.fn((input) => ({ input, __type: 'UpdateItemCommand' })),
     ScanCommand: jest.fn((input) => ({ input, __type: 'ScanCommand' })),


### PR DESCRIPTION
## Summary
- add GetItemCommand mocks for DynamoDB in server-focused test suites so generation flows can load job context without runtime errors

## Testing
- npm test -- uploadFlow.e2e.test.js *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68e0225619bc832b9cc25d3901b9485e