### PR TITLE
Fix e2e flow by improving Dynamo mock and artifact metadata

### DIFF
--- a/server.js
+++ b/server.js
@@ -10756,8 +10756,10 @@ async function generateEnhancedDocumentsResponse({
         Date.now() + URL_EXPIRATION_SECONDS * 1000
       ).toISOString();
       const urlEntry = { type: name, url: signedUrl, expiresAt };
-      if (isCoverLetter) {
-        urlEntry.text = entry?.text || '';
+      if (entry?.text) {
+        urlEntry.text = entry.text;
+      } else if (name !== 'original_upload') {
+        urlEntry.text = '';
       }
       urls.push(urlEntry);
     }


### PR DESCRIPTION
## Summary
- add an in-memory DynamoDB mock implementation in the test server helper so job context persists across requests during tests
- ensure generated document URLs always include text payloads to satisfy downstream assertions

## Testing
- node --experimental-vm-modules node_modules/jest/bin/jest.js tests/uploadFlow.e2e.test.js --runInBand --testTimeout=20000

------
https://chatgpt.com/codex/tasks/task_e_68e02421b57c832bbad8d89f65b2a7c3