### PR TITLE
Store resume versions and metadata in AWS

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -10,7 +10,16 @@ async function streamToString(stream) {
   });
 }
 
-export async function logEvent({ s3, bucket, key, jobId, event, level = 'info', message }) {
+export async function logEvent({
+  s3,
+  bucket,
+  key,
+  jobId,
+  event,
+  level = 'info',
+  message,
+  metadata,
+}) {
   const entry = {
     timestamp: new Date().toISOString(),
     jobId,
@@ -18,6 +27,9 @@ export async function logEvent({ s3, bucket, key, jobId, event, level = 'info', 
     level
   };
   if (message) entry.message = message;
+  if (metadata && typeof metadata === 'object' && Object.keys(metadata).length) {
+    entry.metadata = metadata;
+  }
 
   let existing = '';
   try {

--- a/tests/awsStorage.integration.test.js
+++ b/tests/awsStorage.integration.test.js
@@ -97,6 +97,9 @@ describe('AWS integrations for /api/process-cv', () => {
     expect(mocks.logEventMock).toHaveBeenCalledWith(
       expect.objectContaining({ event: 'completed' })
     );
+    expect(mocks.logEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ event: 'generation_text_artifacts_uploaded' })
+    );
   });
 
   test('surfaces initial upload errors and records failure log', async () => {

--- a/tests/utils/testServer.js
+++ b/tests/utils/testServer.js
@@ -88,6 +88,17 @@ export async function setupTestServer({
             const [, fallback = ''] = inner.split(',').map((part) => part.trim());
             return resolveValue(fallback);
           }
+          if (token.startsWith('list_append(')) {
+            const inner = token.slice('list_append('.length, -1);
+            const [leftRaw = '', rightRaw = ''] = inner
+              .split(',')
+              .map((segment) => segment.trim());
+            const leftValue = resolveAssignmentValue(leftRaw);
+            const rightValue = resolveValue(rightRaw);
+            const leftList = Array.isArray(leftValue?.L) ? leftValue.L : [];
+            const rightList = Array.isArray(rightValue?.L) ? rightValue.L : [];
+            return { L: [...leftList, ...rightList].map((entry) => cloneAttrMap(entry)) };
+          }
           return resolveValue(token);
         };
 


### PR DESCRIPTION
## Summary
- upload original resume text, enhanced versions, and change-log JSON artifacts to S3 alongside generated PDFs
- write detailed activity metadata (device, location, templates, artifact keys) into DynamoDB when artifacts are saved
- allow logEvent to persist structured metadata and update tests/mocks for the expanded storage flow

## Testing
- `npm test -- server.test.js`
- `npm test -- awsStorage.integration.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e08b755a34832b92d7fa9614f9dbb7