### PR TITLE
Add template history tracking and UI summary

### DIFF
--- a/client/src/__tests__/AppTemplateSelection.test.jsx
+++ b/client/src/__tests__/AppTemplateSelection.test.jsx
@@ -29,4 +29,18 @@ describe('TemplateSelector', () => {
     fireEvent.click(professionalButton)
     expect(handleSelect).toHaveBeenCalledWith('professional')
   })
+
+  it('shows a history summary when provided', () => {
+    render(
+      <TemplateSelector
+        options={options}
+        selectedTemplate="modern"
+        historySummary="Professional, Modern, and Classic"
+      />
+    )
+
+    expect(
+      screen.getByText(/You tried Professional, Modern, and Classic/i)
+    ).toBeInTheDocument()
+  })
 })

--- a/client/src/components/TemplateSelector.jsx
+++ b/client/src/components/TemplateSelector.jsx
@@ -1,4 +1,10 @@
-function TemplateSelector({ options = [], selectedTemplate, onSelect, disabled = false }) {
+function TemplateSelector({
+  options = [],
+  selectedTemplate,
+  onSelect,
+  disabled = false,
+  historySummary = ''
+}) {
   if (!options.length) return null
 
   return (
@@ -11,6 +17,11 @@ function TemplateSelector({ options = [], selectedTemplate, onSelect, disabled =
           Enhanced CVs and tailored cover letters will follow this selected design.
         </p>
       </div>
+      {historySummary && (
+        <p className="text-xs text-purple-500">
+          You tried {historySummary}
+        </p>
+      )}
       <div
         id="template-selector"
         role="radiogroup"


### PR DESCRIPTION
## Summary
- track template history selections on the client and persist them through the template context
- surface a "You tried …" history summary in the template selector UI
- normalize and return template history from the server so it survives uploads and downloads

## Testing
- npm test -- AppTemplateSelection.test.jsx *(fails: missing jest-environment-jsdom / @babel/preset-env in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e08efcf5e0832bb59dcd6704556d7b