### PR TITLE
Surface active CloudFront domain in app and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,13 @@ After `sam deploy` completes it prints the `AppBaseUrl`, `ApiBaseUrl`, and `Clou
 npm run print:cloudfront-url -- <stack-name>
 ```
 
-The script uses your configured AWS credentials/region to read the `CloudFrontUrl` output from the specified stack and prints the full distribution URL (for example, `https://d123456abcdef8.cloudfront.net`). The production endpoint for the application is:
+The script uses your configured AWS credentials/region to read the `CloudFrontUrl` output from the specified stack and prints the full distribution URL (for example, `https://d123456abcdef8.cloudfront.net`).
+
+> **Active CloudFront domain:** `https://d3exampleabcdef8.cloudfront.net`
+
+The React portal now surfaces this value in the hero card so onboarding teams can copy or open the canonical entry point without digging through CloudFormation outputs or JSON helpers.
+
+The REST API remains available directly via API Gateway if you need to integrate programmatically:
 
 ```
 https://<api-id>.execute-api.<region>.amazonaws.com/<stage>
@@ -184,6 +190,8 @@ npm run publish:cloudfront-url -- <stack-name>
 - The script always issues a `/*` invalidation for the previously published distribution, even when the stack reuses the same distribution id, so caches are busted after every deploy.
 
 The recorded CloudFront URL is the entry point shared with users; redirect any legacy bookmarks to this domain to keep traffic on the latest deployment.
+
+The portal reads `/api/published-cloudfront` on load and renders the active domain with copy/open controls. This gives support teams and new joiners a self-serve place to confirm the production endpoint while candidates continue straight into the resume workflow.
 
 Once the metadata is published, the API exposes two helper endpoints:
 

--- a/docs/cloudfront-url.md
+++ b/docs/cloudfront-url.md
@@ -11,6 +11,13 @@ The **canonical production CloudFront domain** for ResumeForge lives in [`config
 }
 ```
 
+## Active domain snapshot
+
+- **Production CloudFront URL:** [`https://d3exampleabcdef8.cloudfront.net`](https://d3exampleabcdef8.cloudfront.net)
+- **Published:** 28 May 2024, 00:00 UTC
+
+The ResumeForge portal queries `/api/published-cloudfront` on load and renders this domain in the hero card with copy/open actions. Share that card (or this document) with new joiners so they can grab the right URL without installing the CLI helpers first.
+
 ## Updating the published URL
 
 1. Deploy the CloudFormation/SAM stack.

--- a/docs/user-journey.md
+++ b/docs/user-journey.md
@@ -2,6 +2,8 @@
 
 This guide walks a candidate through ResumeForge end to end so every action has a clearly defined outcome.
 
+> **Start here:** [`https://d3exampleabcdef8.cloudfront.net`](https://d3exampleabcdef8.cloudfront.net) is the active CloudFront entry point. Share this link with candidates so they always land on the latest deployment.
+
 ## 1. Upload a résumé
 - **What to do:** Drag-and-drop or browse for a PDF, DOC, or DOCX résumé.
 - **Behind the scenes:** The file is streamed straight to S3 and a DynamoDB session is created with hashed personal data. The portal immediately validates the file type and page structure.


### PR DESCRIPTION
## Summary
- surface the published CloudFront domain in the React portal and add copy/open affordances fed by `/api/published-cloudfront`
- add helpers for formatting and fetching the active CloudFront metadata on load
- document the current distribution URL in the README and onboarding docs so new joiners can find it quickly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0922e4428832b99622f621a6d73c6