### PR TITLE
Wait for stack to settle before retrying deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -409,6 +409,23 @@ jobs:
                 fi
               fi
 
+              : >"$tmp_err"
+              if stack_status=$(aws cloudformation describe-stacks \
+                  --stack-name "$STACK_NAME" \
+                  --query "Stacks[0].StackStatus" \
+                  --output text 2>"$tmp_err"); then
+                stack_status=$(wait_for_terminal_stack_status "$stack_status")
+                echo "Stack reached terminal status after deleting obsolete change set: $stack_status"
+              else
+                describe_err=$(cat "$tmp_err")
+                if echo "$describe_err" | grep -qi "does not exist"; then
+                  echo "Stack '$STACK_NAME' no longer exists after deleting change set. Proceeding with retry."
+                else
+                  echo "$describe_err" >&2
+                  exit 1
+                fi
+              fi
+
               deploy_attempt=$((deploy_attempt + 1))
               sleep 15
               continue


### PR DESCRIPTION
## Summary
- wait for the CloudFormation stack to reach a terminal status after deleting an obsolete change set before retrying the deployment

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e096c06878832bbf4c3805e268e231