### PR TITLE
Fix TemplateSelector test IDs

### DIFF
--- a/client/src/components/__tests__/TemplateSelector.test.jsx
+++ b/client/src/components/__tests__/TemplateSelector.test.jsx
@@ -19,10 +19,12 @@ describe('TemplateSelector', () => {
       />
     )
 
-    const selectedBadge = within(screen.getByTestId('template-option-modern')).getByText(/selected/i)
+    const selectedBadge = within(
+      screen.getByTestId('template-selector-option-modern')
+    ).getByText(/selected/i)
     expect(selectedBadge).toBeInTheDocument()
     expect(
-      within(screen.getByTestId('template-option-professional')).queryByText(/selected/i)
+      within(screen.getByTestId('template-selector-option-professional')).queryByText(/selected/i)
     ).not.toBeInTheDocument()
 
     rerender(
@@ -33,7 +35,9 @@ describe('TemplateSelector', () => {
       />
     )
 
-    const newlySelectedBadge = within(screen.getByTestId('template-option-professional')).getByText(/selected/i)
+    const newlySelectedBadge = within(
+      screen.getByTestId('template-selector-option-professional')
+    ).getByText(/selected/i)
     expect(newlySelectedBadge).toBeInTheDocument()
   })
 
@@ -47,7 +51,7 @@ describe('TemplateSelector', () => {
       />
     )
 
-    const optionButton = screen.getByTestId('template-option-professional')
+    const optionButton = screen.getByTestId('template-selector-option-professional')
     fireEvent.click(optionButton)
 
     expect(handleSelect).toHaveBeenCalledWith('professional')
@@ -64,7 +68,7 @@ describe('TemplateSelector', () => {
       />
     )
 
-    const optionButton = screen.getByTestId('template-option-professional')
+    const optionButton = screen.getByTestId('template-selector-option-professional')
     expect(optionButton).toBeDisabled()
     fireEvent.click(optionButton)
     expect(handleSelect).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary
- update TemplateSelector unit tests to use the current data-testid values

## Testing
- npm test -- TemplateSelector *(fails: missing jest-environment-jsdom in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b121b0a4832bbfda3e3ba8d3b1bc