### PR TITLE
Remove default CloudFront load error message

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2180,7 +2180,7 @@ function App() {
         )
 
         if (!response.ok) {
-          let message = 'Unable to load the published CloudFront domain.'
+          let message = ''
           try {
             const errorPayload = await response.json()
             if (errorPayload && typeof errorPayload.message === 'string') {
@@ -2212,7 +2212,7 @@ function App() {
         }
         console.error('Failed to load published CloudFront metadata', err)
         setPublishedCloudfront(null)
-        setPublishedCloudfrontError('Unable to load the published CloudFront domain.')
+        setPublishedCloudfrontError('')
         setPublishedCloudfrontCopyStatus('')
       } finally {
         if (isSubscribed) {


### PR DESCRIPTION
## Summary
- stop defaulting to the "Unable to load the published CloudFront domain" error when the API call fails
- leave the CloudFront status panel blank unless the API provides a specific error message

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0ba5d6e68832b9e92a8c5f8c17a90