### PR TITLE
Ensure presigned download URLs for generated documents

### DIFF
--- a/tests/processCv.e2e.test.js
+++ b/tests/processCv.e2e.test.js
@@ -21,9 +21,17 @@ describe('end-to-end CV processing', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(true);
-    expect(response.body.urlExpiresInSeconds).toBe(0);
+    expect(response.body.urlExpiresInSeconds).toBe(3600);
     expect(Array.isArray(response.body.urls)).toBe(true);
-    expect(response.body.urls).toHaveLength(0);
+    expect(response.body.urls).toHaveLength(5);
+    response.body.urls.forEach((entry) => {
+      expect(entry).toEqual(
+        expect.objectContaining({
+          type: expect.any(String),
+          url: expect.stringContaining('https://'),
+        })
+      );
+    });
     expect(typeof response.body.applicantName).toBe('string');
     expect(typeof response.body.originalScore).toBe('number');
     expect(typeof response.body.enhancedScore).toBe('number');


### PR DESCRIPTION
## Summary
- always generate presigned download URLs for CV and cover letter artifacts, and expose an injectable S3 client for testing
- run improvement routes through the document generation pipeline so they return presigned URLs alongside existing metadata
- update end-to-end and route tests to expect presigned links and to mock S3 interactions

## Testing
- npm test -- improvementRoutes
- npm test -- processCv.e2e

------
https://chatgpt.com/codex/tasks/task_e_68e0f7611184832b888e6144b5bb7895