### PR TITLE
Add integration assertions for improvement asset URLs

### DIFF
--- a/tests/improvements.e2e.test.js
+++ b/tests/improvements.e2e.test.js
@@ -343,6 +343,24 @@ describe('targeted improvement endpoints (integration)', () => {
       expect(typeof response.body.selectionProbabilityBefore).toBe('number');
       expect(typeof response.body.selectionProbabilityAfter).toBe('number');
       expect(typeof response.body.selectionProbabilityDelta).toBe('number');
+      expect(response.body.urlExpiresInSeconds).toBe(3600);
+      expect(Array.isArray(response.body.urls)).toBe(true);
+      const assetTypes = response.body.urls.map((entry) => entry.type).sort();
+      expect(assetTypes).toEqual([
+        'cover_letter1',
+        'cover_letter2',
+        'original_upload',
+        'version1',
+        'version2',
+      ]);
+      response.body.urls.forEach((entry) => {
+        expect(entry).toEqual(
+          expect.objectContaining({
+            type: expect.any(String),
+            url: expect.stringMatching(/\.pdf\?X-Amz-Signature=[^&]+&X-Amz-Expires=3600$/),
+          })
+        );
+      });
     }
 
     expect(generateContentMock).toHaveBeenCalledTimes(aiResponses.length);


### PR DESCRIPTION
## Summary
- extend the targeted improvements integration test to assert every endpoint returns presigned PDF URLs
- verify each response includes labelled asset types and one-hour expirations for cover letters and CV variants

## Testing
- npm test -- --runTestsByPath tests/improvements.e2e.test.js *(fails: missing @babel/preset-env preset in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e10577b24c832ba33bf34bbfc091f3