### PR TITLE
Handle nested download metadata in normalizeOutputFiles

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2619,7 +2619,10 @@ function App() {
         return
       }
 
-      const outputFilesValue = normalizeOutputFiles(data.urls)
+      const outputFilesValue = normalizeOutputFiles(data.urls, {
+        defaultExpiresAt: data?.urlExpiresAt,
+        defaultExpiresInSeconds: data?.urlExpiresInSeconds,
+      })
       setOutputFiles(outputFilesValue)
       const { drafts: analysisCoverLetterDrafts, originals: analysisCoverLetterOriginals } =
         deriveCoverLetterStateFromFiles(outputFilesValue)
@@ -2833,7 +2836,10 @@ function App() {
       : []
     setScoreBreakdown(scoreBreakdownValue)
 
-    const outputFilesValue = normalizeOutputFiles(snapshot.outputFiles)
+    const outputFilesValue = normalizeOutputFiles(snapshot.outputFiles, {
+      defaultExpiresAt: snapshot?.urlExpiresAt,
+      defaultExpiresInSeconds: snapshot?.urlExpiresInSeconds,
+    })
     setOutputFiles(outputFilesValue)
 
     const snapshotCoverDrafts =
@@ -3768,7 +3774,10 @@ function App() {
       }
 
       const data = await response.json()
-      const urlsValue = normalizeOutputFiles(data.urls)
+      const urlsValue = normalizeOutputFiles(data.urls, {
+        defaultExpiresAt: data?.urlExpiresAt,
+        defaultExpiresInSeconds: data?.urlExpiresInSeconds,
+      })
       setOutputFiles(urlsValue)
       const { drafts: generatedCoverLetterDrafts, originals: generatedCoverLetterOriginals } =
         deriveCoverLetterStateFromFiles(urlsValue)

--- a/client/src/utils/normalizeOutputFiles.js
+++ b/client/src/utils/normalizeOutputFiles.js
@@ -1,13 +1,64 @@
 const URL_KEYS = ['url', 'downloadUrl', 'href', 'link', 'signedUrl']
+const EXPIRES_AT_KEYS = [
+  'expiresAt',
+  'expiryAt',
+  'expiry',
+  'expires_at',
+  'expiry_at',
+  'expiresISO',
+  'expiryISO',
+  'expiresAtIso',
+  'expiresAtISO',
+  'expiryIso',
+  'expiryISO'
+]
+const EXPIRES_IN_KEYS = [
+  'expiresInSeconds',
+  'expiresIn',
+  'expiryInSeconds',
+  'expirySeconds',
+  'expires_in_seconds',
+  'expires_in',
+  'expiry_in_seconds',
+  'expiry_in'
+]
+const EXPIRES_EPOCH_KEYS = [
+  'expiresAtEpoch',
+  'expiryAtEpoch',
+  'expiryEpoch',
+  'expiresEpoch',
+  'expiresAtTimestamp',
+  'expiryTimestamp',
+  'expiryEpochSeconds',
+  'expiresEpochSeconds',
+  'expires_at_epoch',
+  'expiry_at_epoch'
+]
+const EXPIRES_MS_KEYS = [
+  'expiresAtMs',
+  'expiryAtMs',
+  'expiryMs',
+  'expiresMs',
+  'expires_at_ms',
+  'expiry_at_ms'
+]
 
 function pickFirstString(source = {}, keys = []) {
   for (const key of keys) {
-    const value = source?.[key]
-    if (typeof value === 'string' && value.trim()) {
-      return value.trim()
+    if (source && typeof source === 'object' && key in source) {
+      const value = source[key]
+      if (typeof value === 'string' && value.trim()) {
+        return value.trim()
+      }
     }
   }
   return ''
+}
+
+function toFiniteNumber(value) {
+  if (value == null) return null
+  const number = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(number) ? number : null
 }
 
 function normaliseExpiresAt(value) {
@@ -19,9 +70,173 @@ function normaliseExpiresAt(value) {
     return new Date(value).toISOString()
   }
   if (typeof value === 'string') {
-    return value.trim() || undefined
+    const trimmed = value.trim()
+    return trimmed || undefined
   }
   return undefined
+}
+
+function resolveEpoch(value) {
+  const finite = toFiniteNumber(value)
+  if (finite == null) return undefined
+  const milliseconds = Math.abs(finite) < 1e12 ? finite * 1000 : finite
+  return new Date(milliseconds).toISOString()
+}
+
+function resolveExpiresAt(entry, options = {}, visited = new Set()) {
+  if (!entry || typeof entry !== 'object') {
+    return normaliseExpiresAt(entry)
+  }
+  if (visited.has(entry)) {
+    return undefined
+  }
+  visited.add(entry)
+
+  const directIso = pickFirstString(entry, EXPIRES_AT_KEYS)
+  if (directIso) {
+    const normalized = normaliseExpiresAt(directIso)
+    if (normalized) {
+      return normalized
+    }
+  }
+
+  for (const key of EXPIRES_MS_KEYS) {
+    if (key in entry) {
+      const normalized = resolveEpoch(entry[key])
+      if (normalized) {
+        return normalized
+      }
+    }
+  }
+
+  for (const key of EXPIRES_EPOCH_KEYS) {
+    if (key in entry) {
+      const normalized = resolveEpoch(entry[key])
+      if (normalized) {
+        return normalized
+      }
+    }
+  }
+
+  for (const key of EXPIRES_IN_KEYS) {
+    if (key in entry) {
+      const seconds = toFiniteNumber(entry[key])
+      if (seconds != null) {
+        return new Date(Date.now() + seconds * 1000).toISOString()
+      }
+    }
+  }
+
+  const nestedSources = [
+    entry.download,
+    entry.asset,
+    entry.document,
+    entry.file,
+    entry.link,
+    entry.payload,
+    entry.value
+  ]
+
+  nestedSources.push(
+    ...(Array.isArray(entry.urls) ? entry.urls : []),
+    ...(Array.isArray(entry.links) ? entry.links : [])
+  )
+
+  if (entry.urls && typeof entry.urls === 'object') {
+    nestedSources.push(...Object.values(entry.urls))
+  }
+
+  if (entry.links && typeof entry.links === 'object') {
+    nestedSources.push(...Object.values(entry.links))
+  }
+
+  for (const nested of nestedSources) {
+    if (!nested) continue
+    const nestedExpiry = resolveExpiresAt(nested, options, visited)
+    if (nestedExpiry) {
+      return nestedExpiry
+    }
+  }
+
+  if (options.defaultExpiresAt) {
+    const normalized = normaliseExpiresAt(options.defaultExpiresAt)
+    if (normalized) {
+      return normalized
+    }
+  }
+
+  if (options.defaultExpiresInSeconds != null) {
+    const seconds = toFiniteNumber(options.defaultExpiresInSeconds)
+    if (seconds != null) {
+      return new Date(Date.now() + seconds * 1000).toISOString()
+    }
+  }
+
+  return undefined
+}
+
+function isLikelyUrl(value) {
+  if (typeof value !== 'string') return false
+  const trimmed = value.trim()
+  return /^https?:\/\//i.test(trimmed)
+}
+
+function extractUrl(entry, visited = new Set()) {
+  if (!entry) return ''
+  if (typeof entry === 'string') {
+    const trimmed = entry.trim()
+    return trimmed && isLikelyUrl(trimmed) ? trimmed : ''
+  }
+  if (typeof entry !== 'object') {
+    return ''
+  }
+  if (visited.has(entry)) {
+    return ''
+  }
+  visited.add(entry)
+
+  const direct = pickFirstString(entry, URL_KEYS)
+  if (direct && isLikelyUrl(direct)) {
+    return direct
+  }
+
+  const nestedSources = [
+    entry.download,
+    entry.asset,
+    entry.document,
+    entry.file,
+    entry.payload,
+    entry.value
+  ]
+
+  nestedSources.push(
+    ...(Array.isArray(entry.urls) ? entry.urls : []),
+    ...(Array.isArray(entry.links) ? entry.links : [])
+  )
+
+  if (entry.urls && typeof entry.urls === 'object') {
+    nestedSources.push(...Object.values(entry.urls))
+  }
+
+  if (entry.links && typeof entry.links === 'object') {
+    nestedSources.push(...Object.values(entry.links))
+  }
+
+  for (const nested of nestedSources) {
+    if (!nested) continue
+    const nestedUrl = extractUrl(nested, visited)
+    if (nestedUrl) {
+      return nestedUrl
+    }
+  }
+
+  for (const value of Object.values(entry)) {
+    if (typeof value === 'string' && isLikelyUrl(value)) {
+      return value.trim()
+    }
+  }
+
+  return ''
 }
 
 function deriveType(entry = {}, fallbackType = '', index = 0) {
@@ -34,7 +249,7 @@ function deriveType(entry = {}, fallbackType = '', index = 0) {
   return `file_${index + 1}`
 }
 
-function normaliseOutputFileEntry(entry, index = 0, fallbackType = '') {
+function normaliseOutputFileEntry(entry, index = 0, fallbackType = '', options = {}) {
   if (!entry) return null
   if (typeof entry === 'string') {
     const trimmed = entry.trim()
@@ -48,7 +263,7 @@ function normaliseOutputFileEntry(entry, index = 0, fallbackType = '') {
     return null
   }
 
-  const url = pickFirstString(entry, URL_KEYS)
+  const url = extractUrl(entry)
   if (!url) {
     return null
   }
@@ -58,11 +273,15 @@ function normaliseOutputFileEntry(entry, index = 0, fallbackType = '') {
     url,
   }
 
-  const expiresAt = normaliseExpiresAt(entry.expiresAt)
+  const expiresAt = resolveExpiresAt(entry, options)
   if (expiresAt) {
     normalized.expiresAt = expiresAt
   } else if ('expiresAt' in normalized) {
     delete normalized.expiresAt
+  }
+
+  if (typeof normalized.text !== 'string' && typeof entry?.download?.text === 'string') {
+    normalized.text = entry.download.text
   }
 
   normalized.type = deriveType(entry, fallbackType, index)
@@ -70,7 +289,7 @@ function normaliseOutputFileEntry(entry, index = 0, fallbackType = '') {
   return normalized
 }
 
-export function normalizeOutputFiles(rawInput) {
+export function normalizeOutputFiles(rawInput, options = {}) {
   if (!rawInput) {
     return []
   }
@@ -79,7 +298,7 @@ export function normalizeOutputFiles(rawInput) {
 
   if (Array.isArray(rawInput)) {
     rawInput.forEach((entry, index) => {
-      const normalizedEntry = normaliseOutputFileEntry(entry, index)
+      const normalizedEntry = normaliseOutputFileEntry(entry, index, '', options)
       if (normalizedEntry) {
         normalized.push(normalizedEntry)
       }
@@ -100,7 +319,7 @@ export function normalizeOutputFiles(rawInput) {
 
   if (typeof rawInput === 'object') {
     Object.entries(rawInput).forEach(([key, value], index) => {
-      const normalizedEntry = normaliseOutputFileEntry(value, index, key)
+      const normalizedEntry = normaliseOutputFileEntry(value, index, key, options)
       if (normalizedEntry) {
         if (!normalizedEntry.type && typeof key === 'string' && key.trim()) {
           normalizedEntry.type = key.trim()

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
       "devDependencies": {
         "@babel/core": "^7.24.5",
         "@babel/preset-env": "^7.28.3",
-        "@babel/preset-react": "^7.24.5",
+        "@babel/preset-react": "^7.27.1",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.1",
         "babel-jest": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@babel/core": "^7.24.5",
     "@babel/preset-env": "^7.28.3",
-    "@babel/preset-react": "^7.24.5",
+    "@babel/preset-react": "^7.27.1",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
     "babel-jest": "^29.7.0",

--- a/tests/client/normalizeOutputFiles.test.js
+++ b/tests/client/normalizeOutputFiles.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals'
+import { normalizeOutputFiles } from '../../client/src/utils/normalizeOutputFiles.js'
+
+describe('normalizeOutputFiles', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2025-01-01T00:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('extracts nested download URLs and derives expiry from seconds', () => {
+    const input = [
+      {
+        type: 'version1',
+        download: {
+          href: ' https://cdn.example.com/enhanced.pdf ',
+          expiresInSeconds: 1800,
+        },
+      },
+    ]
+
+    const result = normalizeOutputFiles(input)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe('version1')
+    expect(result[0].url).toBe('https://cdn.example.com/enhanced.pdf')
+    expect(result[0].expiresAt).toBe('2025-01-01T00:30:00.000Z')
+  })
+
+  it('reads expiry timestamps nested inside link metadata', () => {
+    const input = {
+      cover_letter1: {
+        name: 'cover_letter1',
+        download: {
+          link: 'https://cdn.example.com/cover.pdf',
+          expiresAtEpoch: 1767225600,
+        },
+      },
+      invalid: {
+        download: {},
+      },
+    }
+
+    const result = normalizeOutputFiles(input)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe('cover_letter1')
+    expect(result[0].url).toBe('https://cdn.example.com/cover.pdf')
+    expect(result[0].expiresAt).toBe('2026-01-01T00:00:00.000Z')
+  })
+
+  it('applies default expiry when response omits timestamps', () => {
+    const input = [
+      {
+        type: 'version2',
+        url: 'https://cdn.example.com/enhanced-alt.pdf',
+      },
+    ]
+
+    const result = normalizeOutputFiles(input, { defaultExpiresInSeconds: 3600 })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].expiresAt).toBe('2025-01-01T01:00:00.000Z')
+  })
+})


### PR DESCRIPTION
## Summary
- expand the download normalisation helper to extract URLs and expiry timestamps from nested API payloads and honour global expiry hints
- update the React dashboard to pass API-level expiry metadata so download buttons always get valid links and labels
- add unit coverage for the new parsing logic and refresh the Babel preset dependency used by Jest

## Testing
- npm test -- --runTestsByPath tests/client/normalizeOutputFiles.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e10801addc832b993abb795710b99f