### PR TITLE
Honor pre-enhancement CV template choices

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -490,37 +490,25 @@ const jobFitToneStyles = {
 
 const TEMPLATE_ALIASES = {}
 
-const COVER_TEMPLATE_IDS = ['cover_modern', 'cover_lumina', 'cover_midnight', 'cover_classic']
+const COVER_TEMPLATE_IDS = ['cover_modern', 'cover_classic']
 
 const COVER_TEMPLATE_ALIASES = {
   modern: 'cover_modern',
   classic: 'cover_classic',
-  lumina: 'cover_lumina',
-  midnight: 'cover_midnight',
   'cover-modern': 'cover_modern',
   'cover-classic': 'cover_classic',
-  'cover-lumina': 'cover_lumina',
-  'cover-midnight': 'cover_midnight',
   'modern-cover': 'cover_modern',
   'classic-cover': 'cover_classic',
-  'lumina-cover': 'cover_lumina',
-  'midnight-cover': 'cover_midnight',
   'cover modern': 'cover_modern',
   'cover classic': 'cover_classic',
-  'cover lumina': 'cover_lumina',
-  'cover midnight': 'cover_midnight',
   covermodern: 'cover_modern',
   coverclassic: 'cover_classic',
-  coverlumina: 'cover_lumina',
-  covermidnight: 'cover_midnight'
+  covermidnight: 'cover_classic'
 }
 
 const CLASSIC_STYLE_TEMPLATE_IDS = new Set(['classic', 'professional', 'ucmo'])
 
-const RESUME_TO_COVER_TEMPLATE = {
-  lumina: 'cover_lumina',
-  midnight: 'cover_midnight'
-}
+const RESUME_TO_COVER_TEMPLATE = {}
 
 const DEFAULT_COVER_TEMPLATE = 'cover_modern'
 
@@ -678,34 +666,9 @@ const BASE_TEMPLATE_OPTIONS = [
     description: 'Sleek two-column layout with clean dividers and ATS-safe spacing.'
   },
   {
-    id: 'lumina',
-    name: 'Lumina Spectrum',
-    description: 'Vibrant gradient storytelling with confident header hierarchy.'
-  },
-  {
-    id: 'midnight',
-    name: 'Midnight Glass',
-    description: 'Dark mode glassmorphism with luminous accent highlights.'
-  },
-  {
-    id: 'ucmo',
-    name: 'Crimson Heritage',
-    description: 'Classic serif typography with deep crimson accents inspired by university letterhead design.'
-  },
-  {
     id: 'professional',
     name: 'Professional Edge',
     description: 'Refined business styling with signature accents for leadership roles.'
-  },
-  {
-    id: 'classic',
-    name: 'Classic Heritage',
-    description: 'Timeless serif typography with elegant section framing.'
-  },
-  {
-    id: 'creative',
-    name: 'Creative Spotlight',
-    description: 'Gradient-rich storytelling layout with bold highlights.'
   },
   {
     id: 'vibrant',
@@ -721,6 +684,21 @@ const BASE_TEMPLATE_OPTIONS = [
     id: '2025',
     name: 'Future Vision 2025',
     description: 'Futuristic grid layout with crisp typography and subtle neon cues.'
+  },
+  {
+    id: 'ucmo',
+    name: 'Crimson Heritage',
+    description: 'Classic serif typography with deep crimson accents inspired by university letterhead design.'
+  },
+  {
+    id: 'classic',
+    name: 'Classic Heritage',
+    description: 'Timeless serif typography with elegant section framing.'
+  },
+  {
+    id: 'creative',
+    name: 'Creative Spotlight',
+    description: 'Gradient-rich storytelling layout with bold highlights.'
   }
 ]
 
@@ -729,21 +707,13 @@ const COVER_TEMPLATE_DETAILS = {
     name: 'Modern Cover Letter',
     description: 'Gradient header with confident typography and clean paragraph rhythm.'
   },
-  cover_lumina: {
-    name: 'Lumina Cover Letter',
-    description: 'Iridescent gradients with open white space for a storytelling tone.'
-  },
-  cover_midnight: {
-    name: 'Midnight Cover Letter',
-    description: 'Noir glassmorphism with electric accents and calm serif body text.'
-  },
   cover_classic: {
     name: 'Classic Cover Letter',
     description: 'Elegant serif presentation with letterhead-inspired spacing and signature close.'
   }
 }
 
-const COVER_TEMPLATE_ORDER = ['cover_modern', 'cover_lumina', 'cover_midnight', 'cover_classic']
+const COVER_TEMPLATE_ORDER = ['cover_modern', 'cover_classic']
 
 const COVER_TEMPLATE_OPTIONS = COVER_TEMPLATE_ORDER.filter((id) => COVER_TEMPLATE_DETAILS[id]).map(
   (id) => ({

--- a/client/src/components/TemplatePreview.jsx
+++ b/client/src/components/TemplatePreview.jsx
@@ -41,22 +41,6 @@ const RESUME_TEMPLATE_PREVIEWS = {
     highlight: 'bg-purple-500/25',
     chip: 'bg-orange-100 text-orange-700'
   },
-  lumina: {
-    accent: 'from-fuchsia-500 via-rose-500 to-amber-400',
-    container: 'border-rose-200 bg-white',
-    sidebar: 'bg-gradient-to-b from-fuchsia-600/90 to-amber-500/80',
-    line: 'bg-rose-200/80',
-    highlight: 'bg-rose-100 text-rose-700',
-    chip: 'bg-rose-100 text-rose-700'
-  },
-  midnight: {
-    accent: 'from-slate-900 via-indigo-900 to-blue-900',
-    container: 'border-slate-800 bg-slate-950 text-slate-100',
-    sidebar: 'bg-gradient-to-b from-slate-950/95 to-indigo-900/85',
-    line: 'bg-slate-700/70',
-    highlight: 'bg-indigo-500/20 text-indigo-100',
-    chip: 'bg-slate-800 text-indigo-200'
-  },
   ucmo: {
     accent: 'from-rose-900 via-rose-700 to-rose-500',
     container: 'border-rose-300 bg-rose-50',
@@ -97,20 +81,6 @@ const COVER_TEMPLATE_PREVIEWS = {
     line: 'bg-amber-200/80',
     highlight: 'bg-amber-500/15 text-amber-900',
     badge: 'bg-amber-100 text-amber-700'
-  },
-  cover_lumina: {
-    header: 'bg-gradient-to-r from-fuchsia-500 via-rose-500 to-amber-400 text-white',
-    border: 'border-rose-200 bg-white',
-    line: 'bg-rose-200/80',
-    highlight: 'bg-rose-100 text-rose-700',
-    badge: 'bg-rose-100 text-rose-700'
-  },
-  cover_midnight: {
-    header: 'bg-gradient-to-r from-slate-950 via-indigo-900 to-blue-900 text-slate-100',
-    border: 'border-slate-800 bg-slate-950 text-slate-100',
-    line: 'bg-slate-700/70',
-    highlight: 'bg-indigo-500/20 text-indigo-100',
-    badge: 'bg-slate-800 text-indigo-200'
   }
 }
 

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -288,20 +288,13 @@ describe('generatePdf and parsing', () => {
     expect(CL_TEMPLATES).toContain(coverTemplate2);
   });
 
-  test('providing one template still includes ucmo', () => {
-    const { template1, template2, coverTemplate1, coverTemplate2 } = selectTemplates({
-      template1: CV_TEMPLATES[0],
-      coverTemplate1: CL_TEMPLATES[0]
-    });
-    expect([template1, template2]).toContain('ucmo');
-    const other = template1 === 'ucmo' ? template2 : template1;
-    expect(other).toBe(CV_TEMPLATES[0]);
-    expect(CV_TEMPLATE_GROUPS[other]).not.toBe(CV_TEMPLATE_GROUPS['ucmo']);
-    expect(coverTemplate1).toBe(CL_TEMPLATES[0]);
-    expect(coverTemplate2).not.toBe(coverTemplate1);
-    expect(CV_TEMPLATES).toContain(template1);
+  test('explicit template preference becomes primary', () => {
+    const preferred = CV_TEMPLATES.find((tpl) => tpl !== 'ucmo') || CV_TEMPLATES[0];
+    const { template1, template2 } = selectTemplates({ preferredTemplate: preferred });
+    expect(template1).toBe(preferred);
+    expect(template2).not.toBe(preferred);
     expect(CV_TEMPLATES).toContain(template2);
-    expect(CL_TEMPLATES).toContain(coverTemplate2);
+    expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(CV_TEMPLATE_GROUPS[template2]);
   });
 
   test('script tags render as text', () => {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -547,7 +547,7 @@ describe('/api/process-cv', () => {
     });
   });
 
-  test('uses provided template and ucmo', async () => {
+  test('uses provided templates in preferred order', async () => {
     generateContentMock.mockReset();
     generateContentMock.mockResolvedValue({
       response: { text: () => JSON.stringify({ cover_letter1: 'cl1', cover_letter2: 'cl2' }) }
@@ -564,8 +564,8 @@ describe('/api/process-cv', () => {
 
     const calls = serverModule.generatePdf.mock.calls;
     const resumeCalls = calls.filter(([, , opts]) => opts && opts.resumeExperience);
-    expect(resumeCalls[0][1]).toBe('ucmo');
-    expect(resumeCalls[1][1]).toBe('modern');
+    expect(resumeCalls[0][1]).toBe('modern');
+    expect(resumeCalls[1][1]).toBe('professional');
   });
 
   test('uses templates array', async () => {


### PR DESCRIPTION
## Summary
- align the front-end template selector with supported resume and cover layouts
- ensure the backend `selectTemplates` logic preserves the user’s preferred CV style when generating documents
- refresh template-related tests to reflect the new prioritisation rules

## Testing
- CI=1 npm test -- tests/selectTemplatesGroup.test.js tests/generatePdf.test.js tests/server.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e10b524238832bbc28ce8e76cb8c63