### PR TITLE
Expose full CV template selection in portal

### DIFF
--- a/templates/portal.html
+++ b/templates/portal.html
@@ -220,14 +220,18 @@
         </label>
         <label>
           Preferred CV template (optional)
-          <select name="template">
+          <select name="template" id="cv-template-select">
             <option value="">Let ResumeForge decide</option>
-            <option value="modern">Modern</option>
-            <option value="ucmo">Classic</option>
-            <option value="professional">Professional</option>
-            <option value="vibrant">Vibrant</option>
-            <option value="2025">Futuristic</option>
+            <option value="modern">Modern Minimal</option>
+            <option value="professional">Professional Edge</option>
+            <option value="vibrant">Vibrant Fusion</option>
+            <option value="ats">ATS Optimized</option>
+            <option value="2025">Future Vision 2025</option>
+            <option value="ucmo">Crimson Heritage</option>
+            <option value="classic">Classic Heritage</option>
+            <option value="creative">Creative Spotlight</option>
           </select>
+          <input type="hidden" name="templateId" id="cv-template-id" />
         </label>
         <label>
           Preferred cover letter template (optional)
@@ -255,6 +259,19 @@
       const links = document.getElementById('links');
       const metrics = document.getElementById('metrics');
       const scoreGrid = document.getElementById('score-grid');
+      const templateSelect = form.querySelector('#cv-template-select');
+      const templateIdField = form.querySelector('#cv-template-id');
+
+      const syncTemplateId = () => {
+        if (!templateIdField) return;
+        const value = templateSelect && templateSelect.value ? templateSelect.value.trim() : '';
+        templateIdField.value = value;
+      };
+
+      if (templateSelect && templateIdField) {
+        syncTemplateId();
+        templateSelect.addEventListener('change', syncTemplateId);
+      }
 
       form.addEventListener('submit', async (event) => {
         event.preventDefault();
@@ -265,6 +282,7 @@
         metrics.innerHTML = '';
         scoreGrid.innerHTML = '';
 
+        syncTemplateId();
         const formData = new FormData(form);
         const submitButton = form.querySelector('button[type="submit"]');
         const originalText = submitButton.textContent;

--- a/tests/rootRoute.test.js
+++ b/tests/rootRoute.test.js
@@ -9,6 +9,13 @@ describe('serverless bootstrap', () => {
     expect(response.type).toMatch(/html/);
     expect(response.text).toContain('<title>ResumeForge Portal</title>');
     expect(response.text).toContain('id="portal-form"');
+    expect(response.text).toContain('option value="modern"');
+    expect(response.text).toContain('option value="professional"');
+    expect(response.text).toContain('option value="vibrant"');
+    expect(response.text).toContain('option value="ats"');
+    expect(response.text).toContain('option value="2025"');
+    expect(response.text).toContain('option value="ucmo"');
+    expect(response.text).toContain('name="templateId"');
   });
 
   it('handles API Gateway proxy events without socket errors', async () => {


### PR DESCRIPTION
## Summary
- expose the full set of resume templates (Modern, Professional, Vibrant, ATS, 2025, UCMO, Classic, Creative) in the server-rendered portal so users can choose a layout before enhancement
- add a hidden templateId field that stays in sync with the selected option to help the backend honour the chosen layout
- extend the root route smoke test to verify the new options and hidden field are present

## Testing
- npm test *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68e10e5e8f18832bbe0b0913c8d1a10b