### PR TITLE
Add resume template selector to fallback portal view

### DIFF
--- a/server.js
+++ b/server.js
@@ -260,10 +260,17 @@ const FALLBACK_CLIENT_INDEX_HTML = `<!DOCTYPE html>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>ResumeForge Portal</title>
     <style>
+      :root {
+        color-scheme: light;
+      }
       body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; padding: 2rem; background: #f7fafc; color: #1a202c; }
-      main { max-width: 640px; margin: 0 auto; background: white; border-radius: 12px; padding: 2rem; box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08); }
+      main { max-width: 720px; margin: 0 auto; background: white; border-radius: 12px; padding: 2.25rem; box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08); }
       h1 { margin-top: 0; font-size: 2rem; }
       p { line-height: 1.6; }
+      form { margin-top: 2rem; display: grid; gap: 1rem; }
+      label { font-weight: 600; }
+      select, button { font: inherit; padding: 0.75rem 1rem; border-radius: 10px; border: 1px solid #cbd5f5; }
+      button { cursor: pointer; background: #2563eb; color: white; border: none; font-weight: 600; }
       .cta { margin-top: 1.5rem; display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.75rem 1.5rem; background: #2563eb; color: white; border-radius: 9999px; text-decoration: none; font-weight: 600; }
     </style>
   </head>
@@ -272,6 +279,19 @@ const FALLBACK_CLIENT_INDEX_HTML = `<!DOCTYPE html>
       <h1>ResumeForge Portal</h1>
       <p>The client application build assets are currently unavailable. This is a lightweight fallback view to keep the service responsive while the full interface is rebuilt.</p>
       <p>You can regenerate the production UI by running <code>npm run build:client</code>. Until then, API endpoints remain available.</p>
+      <form aria-label="Template selection">
+        <label for="templateId">Choose a resume template</label>
+        <select id="templateId" name="templateId">
+          <option value="modern">Modern</option>
+          <option value="professional">Professional</option>
+          <option value="vibrant">Vibrant</option>
+          <option value="ats">ATS</option>
+          <option value="2025">2025</option>
+          <option value="ucmo">UCMO</option>
+        </select>
+        <p style="margin: 0; font-size: 0.95rem; color: #4a5568;">Template downloads are temporarily disabled in fallback mode.</p>
+        <button type="button" disabled title="Build the client app to enable downloads">Download preview (unavailable)</button>
+      </form>
       <a class="cta" href="https://github.com/" rel="noreferrer">Return to dashboard</a>
     </main>
   </body>


### PR DESCRIPTION
## Summary
- add a template selection form to the fallback portal HTML so options remain available when the client build is missing
- refresh the fallback layout and styling to accommodate the selector and disabled download button

## Testing
- npm test -- --runTestsByPath tests/rootRoute.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e113430a70832bbd98c3b33d12278f