### PR TITLE
Align resume template sections with canonical presentation

### DIFF
--- a/templates/2025.html
+++ b/templates/2025.html
@@ -21,19 +21,21 @@
       </header>
       <main class="resume-grid">
         {{#each sections}}
-        <section class="resume-section {{#if @first}}span-2{{/if}}">
+        <section class="resume-section {{#if @first}}span-2{{/if}} {{sectionClass}}">
           {{#if heading}}
           <div class="section-header">
-            <h2>{{heading}}</h2>
+            <h2 class="section-title {{headingClass}}">{{heading}}</h2>
             <span class="section-accent"></span>
           </div>
           {{/if}}
           {{#if items}}
-          <ul class="section-list">
+          <ul class="section-list {{listClass}}">
             {{#each items}}
-            <li class="section-item">
-              <span class="bullet">◆</span>
-              <span class="item-content">{{{this}}}</span>
+            <li class="section-item {{../itemClass}}">
+              {{#if ../showMarkers}}
+              <span class="bullet {{../markerClass}}">◆</span>
+              {{/if}}
+              <span class="item-content {{../textClass}}">{{{this}}}</span>
             </li>
             {{/each}}
           </ul>

--- a/templates/ats.html
+++ b/templates/ats.html
@@ -71,6 +71,21 @@
       white-space: pre-wrap;
     }
 
+    .section-list--contact,
+    .section-list--summary,
+    .section-list--skills,
+    .section-list--certifications {
+      list-style: none;
+      padding-left: 0;
+    }
+
+    .section-item--contact,
+    .section-item--summary,
+    .section-item--skills,
+    .section-item--certifications {
+      padding-left: 0;
+    }
+
     li strong {
       color: #111827;
     }
@@ -99,14 +114,14 @@
       <p>ATS Optimized Resume</p>
     </header>
     {{#each sections}}
-    <section>
+    <section class="{{sectionClass}}">
       {{#if heading}}
-      <h2>{{heading}}</h2>
+      <h2 class="{{headingClass}}">{{heading}}</h2>
       {{/if}}
       {{#if items}}
-      <ul>
+      <ul class="{{listClass}}">
         {{#each items}}
-        <li>{{{this}}}</li>
+        <li class="{{../itemClass}}">{{{this}}}</li>
         {{/each}}
       </ul>
       {{/if}}

--- a/templates/classic.html
+++ b/templates/classic.html
@@ -185,6 +185,21 @@
       font-size: 18px;
     }
 
+    .section-item--contact,
+    .section-item--summary,
+    .section-item--skills,
+    .section-item--certifications {
+      padding-left: 0;
+    }
+
+    .section-item--contact::before,
+    .section-item--summary::before,
+    .section-item--skills::before,
+    .section-item--certifications::before {
+      content: '';
+      display: none;
+    }
+
     strong {
       color: var(--ink);
       font-weight: 700;
@@ -239,14 +254,14 @@
     </header>
     <div class="sections">
       {{#each sections}}
-      <section>
+      <section class="{{sectionClass}}">
         {{#if heading}}
-        <h2>{{heading}}</h2>
+        <h2 class="{{headingClass}}">{{heading}}</h2>
         {{/if}}
         {{#if items}}
-        <ul>
+        <ul class="{{listClass}}">
           {{#each items}}
-          <li>{{{this}}}</li>
+          <li class="{{../itemClass}}">{{{this}}}</li>
           {{/each}}
         </ul>
         {{/if}}

--- a/templates/creative.html
+++ b/templates/creative.html
@@ -99,6 +99,13 @@
       line-height: 1.6;
     }
 
+    .section-item--contact,
+    .section-item--summary,
+    .section-item--skills,
+    .section-item--certifications {
+      grid-template-columns: 1fr;
+    }
+
     .marker {
       width: 1.2em;
       height: 1.2em;
@@ -141,16 +148,18 @@
     </header>
     <div class="sections">
       {{#each sections}}
-      <section>
+      <section class="{{sectionClass}}">
         {{#if heading}}
-        <h2>{{heading}}</h2>
+        <h2 class="{{headingClass}}">{{heading}}</h2>
         {{/if}}
         {{#if items}}
-        <ul>
+        <ul class="section-list {{listClass}}">
           {{#each items}}
-          <li>
-            <span class="marker">◆</span>
-            <span>{{{this}}}</span>
+          <li class="section-item {{../itemClass}}">
+            {{#if ../showMarkers}}
+            <span class="marker {{../markerClass}}">◆</span>
+            {{/if}}
+            <span class="section-text {{../textClass}}">{{{this}}}</span>
           </li>
           {{/each}}
         </ul>

--- a/templates/modern.html
+++ b/templates/modern.html
@@ -173,6 +173,13 @@
       line-height: 1.55;
     }
 
+    .section-item--contact,
+    .section-item--summary,
+    .section-item--skills,
+    .section-item--certifications {
+      grid-template-columns: 1fr;
+    }
+
     .marker {
       width: 1.1em;
       height: 1.1em;
@@ -215,19 +222,21 @@
     </header>
     <main class="content-grid">
       {{#each sections}}
-      <section class="card {{#if @first}}card--spotlight{{/if}}">
+      <section class="card {{#if @first}}card--spotlight{{/if}} {{sectionClass}}">
         {{#if heading}}
         <div class="card-header">
-          <h2>{{heading}}</h2>
+          <h2 class="card-title {{headingClass}}">{{heading}}</h2>
           <span class="accent-line"></span>
         </div>
         {{/if}}
         {{#if items}}
-        <ul>
+        <ul class="section-list {{listClass}}">
           {{#each items}}
-          <li>
-            <span class="marker">◆</span>
-            <span class="content">{{{this}}}</span>
+          <li class="section-item {{../itemClass}}">
+            {{#if ../showMarkers}}
+            <span class="marker {{../markerClass}}">◆</span>
+            {{/if}}
+            <span class="content {{../textClass}}">{{{this}}}</span>
           </li>
           {{/each}}
         </ul>

--- a/templates/professional.html
+++ b/templates/professional.html
@@ -144,6 +144,13 @@
       color: var(--text);
     }
 
+    .section-item--contact,
+    .section-item--summary,
+    .section-item--skills,
+    .section-item--certifications {
+      grid-template-columns: 1fr;
+    }
+
     .dot {
       width: 0.9rem;
       height: 0.9rem;
@@ -181,19 +188,21 @@
     </header>
     <main class="sections">
       {{#each sections}}
-      <section class="section-card {{#if @first}}section-card--wide{{/if}}">
+      <section class="section-card {{#if @first}}section-card--wide{{/if}} {{sectionClass}}">
         {{#if heading}}
         <div class="section-header">
-          <h2>{{heading}}</h2>
+          <h2 class="section-title {{headingClass}}">{{heading}}</h2>
           <span class="rule"></span>
         </div>
         {{/if}}
         {{#if items}}
-        <ul>
+        <ul class="section-list {{listClass}}">
           {{#each items}}
-          <li>
-            <span class="dot"></span>
-            <span class="item-text">{{{this}}}</span>
+          <li class="section-item {{../itemClass}}">
+            {{#if ../showMarkers}}
+            <span class="dot {{../markerClass}}"></span>
+            {{/if}}
+            <span class="item-text {{../textClass}}">{{{this}}}</span>
           </li>
           {{/each}}
         </ul>

--- a/templates/ucmo.html
+++ b/templates/ucmo.html
@@ -39,6 +39,13 @@
     .tab { display:inline-block; width:1.5em; }
     .tab + p { margin-top: 0; }
     strong { font-weight: 700; }
+
+    .section-item--contact,
+    .section-item--summary,
+    .section-item--skills,
+    .section-item--certifications {
+      margin-left: 0;
+    }
   </style>
 </head>
 <body>
@@ -55,14 +62,14 @@
     <h1>{{name}}</h1>
   </header>
   {{#each sections}}
-  <section>
+  <section class="{{sectionClass}}">
     {{#if heading}}
-    <h2>{{heading}}</h2>
+    <h2 class="{{headingClass}}">{{heading}}</h2>
     {{/if}}
     {{#if items}}
-      <ul>
+      <ul class="{{listClass}}">
         {{#each items}}
-          <li>{{{this}}}</li>
+          <li class="{{../itemClass}}">{{{this}}}</li>
         {{/each}}
       </ul>
     {{/if}}

--- a/templates/vibrant.html
+++ b/templates/vibrant.html
@@ -36,6 +36,13 @@
     .tab { display:inline-block; width:1.5em; }
     .tab + p { margin-top: 0; }
     strong { font-weight: 700; }
+
+    .section-item--contact,
+    .section-item--summary,
+    .section-item--skills,
+    .section-item--certifications {
+      margin-left: 0;
+    }
   </style>
 </head>
 <body>
@@ -43,12 +50,12 @@
     <h1>{{name}}</h1>
   </header>
   {{#each sections}}
-  <section>
-    {{#if heading}}<h2>{{heading}}</h2>{{/if}}
+  <section class="{{sectionClass}}">
+    {{#if heading}}<h2 class="{{headingClass}}">{{heading}}</h2>{{/if}}
     {{#if items}}
-      <ul>
+      <ul class="{{listClass}}">
         {{#each items}}
-          <li>{{{this}}}</li>
+          <li class="{{../itemClass}}">{{{this}}}</li>
         {{/each}}
       </ul>
     {{/if}}

--- a/tests/templateSections.test.js
+++ b/tests/templateSections.test.js
@@ -25,15 +25,30 @@ describe('buildTemplateSectionContext', () => {
     const data = parseContent(input);
     const context = buildTemplateSectionContext(data.sections);
 
+    expect(context.sections.map((sec) => sec.key).slice(0, 6)).toEqual([
+      'contact',
+      'summary',
+      'experience',
+      'education',
+      'skills',
+      'certifications'
+    ]);
+
     const summarySection = context.sections.find((sec) => sec.key === 'summary');
     expect(summarySection).toBeDefined();
     expect(summarySection.htmlItems[0]).not.toContain('class="bullet"');
+    expect(summarySection.showMarkers).toBe(false);
+    expect(summarySection.sectionClass).toContain('section--summary');
+    expect(summarySection.markerClass).toContain('marker');
 
     const experienceSection = context.sections.find((sec) => sec.key === 'experience');
     expect(experienceSection.htmlItems[0]).toContain('class="bullet"');
+    expect(experienceSection.showMarkers).toBe(true);
+    expect(experienceSection.markerClass).toContain('marker--experience');
 
     const educationSection = context.sections.find((sec) => sec.key === 'education');
     expect(educationSection.htmlItems[0]).toContain('class="edu-bullet"');
+    expect(educationSection.markerClass).toContain('marker--education');
 
     expect(context.buckets.skills).toHaveLength(1);
     expect(context.buckets.certifications).toHaveLength(1);


### PR DESCRIPTION
## Summary
- add a canonical section order and presentation metadata to the template merge logic so contact, summary, experience, education, skills, and certifications are consistently grouped
- expose the new metadata to Handlebars and update the resume templates to apply the canonical classes, markers, and list styling while avoiding extra bullets for narrative sections
- extend the template section unit test to cover the canonical ordering and marker presentation flags

## Testing
- npm test -- --runTestsByPath tests/templateSections.test.js *(fails: Cannot find package '@babel/preset-env' in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e11a102c44832bb5c390013c895879