### PR TITLE
Fix presentation resolution order in template context builder

### DIFF
--- a/server.js
+++ b/server.js
@@ -5739,6 +5739,7 @@ function buildTemplateSectionContext(sections = [], enhancementTokenMap = {}) {
     const heading = normalizeHeading(section.heading || '');
     const key = canonicalSectionKey(heading);
     const tokensList = Array.isArray(section.items) ? section.items : [];
+    const presentation = resolveTemplatePresentation(key);
     const htmlItems = tokensList.map((tokens) =>
       renderSectionTokensToHtml(tokens, {
         sectionKey: key,
@@ -5746,7 +5747,6 @@ function buildTemplateSectionContext(sections = [], enhancementTokenMap = {}) {
         presentation,
       })
     );
-    const presentation = resolveTemplatePresentation(key);
     const entry = {
       heading,
       key,


### PR DESCRIPTION
## Summary
- resolve template presentation before rendering section token HTML to avoid temporal dead zone errors during PDF generation

## Testing
- npm test -- generatePdf *(fails: Cannot find package '@babel/preset-env' imported from babel-virtual-resolve-base.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e11ed5f6ec832ba5925ee850751c40