### PR TITLE
Avoid empty class attributes in UCMO template

### DIFF
--- a/templates/ucmo.html
+++ b/templates/ucmo.html
@@ -62,14 +62,14 @@
     <h1>{{name}}</h1>
   </header>
   {{#each sections}}
-  <section class="{{sectionClass}}">
+  <section{{#if sectionClass}} class="{{sectionClass}}"{{/if}}>
     {{#if heading}}
-    <h2 class="{{headingClass}}">{{heading}}</h2>
+    <h2{{#if headingClass}} class="{{headingClass}}"{{/if}}>{{heading}}</h2>
     {{/if}}
     {{#if items}}
-      <ul class="{{listClass}}">
+      <ul{{#if listClass}} class="{{listClass}}"{{/if}}>
         {{#each items}}
-          <li class="{{../itemClass}}">{{{this}}}</li>
+          <li{{#if ../itemClass}} class="{{../itemClass}}"{{/if}}>{{{this}}}</li>
         {{/each}}
       </ul>
     {{/if}}

--- a/tests/templates/__snapshots__/ucmo.test.js.snap
+++ b/tests/templates/__snapshots__/ucmo.test.js.snap
@@ -42,6 +42,13 @@ exports[`ucmo template renders with contact bar and logo: html 1`] = `
     .tab { display:inline-block; width:1.5em; }
     .tab + p { margin-top: 0; }
     strong { font-weight: 700; }
+
+    .section-item--contact,
+    .section-item--summary,
+    .section-item--skills,
+    .section-item--certifications {
+      margin-left: 0;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- avoid emitting empty class attributes in the UCMO template so optional styling hooks are only rendered when present
- update the template snapshot with the new margin overrides for contact-oriented sections

## Testing
- npm test -- tests/templates/ucmo.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1268f9f70832bab93a22a5a4b5314