### PR TITLE
Add before/after ATS metrics to dashboard

### DIFF
--- a/client/src/components/__tests__/ATSScoreCard.test.jsx
+++ b/client/src/components/__tests__/ATSScoreCard.test.jsx
@@ -16,12 +16,14 @@ describe('ATSScoreCard', () => {
     render(<ATSScoreCard metric={baseMetric} accentClass="from-indigo-500 to-purple-500" />)
 
     expect(screen.getByText('Keyword Match')).toBeInTheDocument()
+    expect(screen.getByText('ATS Score Before')).toBeInTheDocument()
+    expect(screen.getByText('ATS Score After')).toBeInTheDocument()
+    expect(screen.getByTestId('metric-score-before')).toHaveTextContent('82')
     expect(screen.getByTestId('metric-score')).toHaveTextContent('82')
     expect(screen.getByTestId('rating-badge')).toHaveTextContent('EXCELLENT')
     expect(screen.getByTestId('metric-tip')).toHaveTextContent(
       /leadership verbs/i
     )
-    expect(screen.getByText('%')).toBeInTheDocument()
     expect(screen.getByText('Tip')).toBeInTheDocument()
   })
 
@@ -39,7 +41,8 @@ describe('ATSScoreCard', () => {
 
     expect(screen.getByTestId('rating-badge')).toHaveTextContent('NEEDS IMPROVEMENT')
     expect(screen.getByTestId('metric-score')).toHaveTextContent('N/A')
-    expect(screen.queryByText('%')).not.toBeInTheDocument()
+    expect(screen.getByTestId('metric-score-before')).toHaveTextContent('N/A')
+    expect(screen.queryAllByText('%')).toHaveLength(0)
     expect(screen.queryByTestId('metric-tip')).not.toBeInTheDocument()
   })
 })

--- a/client/src/components/__tests__/ATSScoreDashboard.test.jsx
+++ b/client/src/components/__tests__/ATSScoreDashboard.test.jsx
@@ -38,6 +38,11 @@ describe('ATSScoreDashboard', () => {
     }
   ]
 
+  const baselineMetrics = metrics.map((metric) => ({
+    ...metric,
+    score: Math.max(metric.score - 8, 0)
+  }))
+
   const baseMatch = {
     originalScore: 48,
     enhancedScore: 76,
@@ -51,10 +56,12 @@ describe('ATSScoreDashboard', () => {
       missingSkills: ['SQL', 'Roadmap execution'],
       addedSkills: ['Stakeholder communication']
     }
-    render(<ATSScoreDashboard metrics={metrics} match={match} />)
+    render(<ATSScoreDashboard metrics={metrics} baselineMetrics={baselineMetrics} match={match} />)
 
     const cards = screen.getAllByTestId('ats-score-card')
     expect(cards).toHaveLength(metrics.length)
+    expect(screen.getAllByText('ATS Score Before')).not.toHaveLength(0)
+    expect(screen.getAllByText('ATS Score After')).not.toHaveLength(0)
     expect(screen.getByLabelText('match comparison')).toBeInTheDocument()
     expect(screen.getByTestId('original-score')).toHaveTextContent('48')
     expect(screen.getByTestId('enhanced-score')).toHaveTextContent('76')
@@ -79,10 +86,18 @@ describe('ATSScoreDashboard', () => {
       missingSkills: ['SQL', 'Roadmap execution'],
       addedSkills: ['Stakeholder communication']
     }
-    const { rerender } = render(<ATSScoreDashboard metrics={metrics} match={match} />)
+    const { rerender } = render(
+      <ATSScoreDashboard metrics={metrics} baselineMetrics={baselineMetrics} match={match} />
+    )
 
     const updatedMatch = { ...match, enhancedScore: 90 }
-    rerender(<ATSScoreDashboard metrics={metrics} match={updatedMatch} />)
+    rerender(
+      <ATSScoreDashboard
+        metrics={metrics}
+        baselineMetrics={baselineMetrics}
+        match={updatedMatch}
+      />
+    )
 
     expect(screen.getByTestId('enhanced-score')).toHaveTextContent('90')
     const deltaBadge = screen.getByTestId('match-delta')
@@ -99,7 +114,7 @@ describe('ATSScoreDashboard', () => {
       addedSkills: ['Cross-functional leadership', 'Go-to-market strategy']
     }
 
-    render(<ATSScoreDashboard metrics={metrics} match={match} />)
+    render(<ATSScoreDashboard metrics={metrics} baselineMetrics={baselineMetrics} match={match} />)
 
     expect(screen.getByTestId('original-match-status')).toHaveTextContent('Match')
     expect(screen.getByTestId('enhanced-match-status')).toHaveTextContent('Match')
@@ -129,7 +144,7 @@ describe('ATSScoreDashboard', () => {
       ]
     }
 
-    render(<ATSScoreDashboard metrics={metrics} match={match} />)
+    render(<ATSScoreDashboard metrics={metrics} baselineMetrics={baselineMetrics} match={match} />)
 
     const recap = screen.getByTestId('improvement-recap-card')
     expect(recap).toBeInTheDocument()
@@ -148,7 +163,7 @@ describe('ATSScoreDashboard', () => {
 
   it('handles absent tips gracefully', () => {
     const minimalMetrics = [{ category: 'Structure', score: 50, ratingLabel: 'Fair' }]
-    render(<ATSScoreDashboard metrics={minimalMetrics} />)
+    render(<ATSScoreDashboard metrics={minimalMetrics} baselineMetrics={baselineMetrics} />)
 
     const card = screen.getByTestId('ats-score-card')
     expect(card).toBeInTheDocument()

--- a/client/src/components/__tests__/__snapshots__/ATSScoreCard.test.jsx.snap
+++ b/client/src/components/__tests__/__snapshots__/ATSScoreCard.test.jsx.snap
@@ -75,24 +75,71 @@ exports[`ATSScoreCard matches the gradient snapshot for consistency 1`] = `
         </div>
       </header>
       <div
-        class="flex flex-wrap items-end gap-x-3 gap-y-1"
+        class="space-y-4"
       >
-        <p
-          class="text-6xl font-black leading-none drop-shadow-md md:text-7xl"
-          data-testid="metric-score"
+        <div
+          class="grid grid-cols-1 gap-3 sm:grid-cols-2"
         >
-          82
-        </p>
-        <span
-          class="text-2xl font-semibold uppercase tracking-[0.3em] text-white/80"
-        >
-          %
-        </span>
-        <span
-          class="text-xs font-semibold uppercase tracking-[0.45em] text-white"
-        >
-          Score
-        </span>
+          <div
+            class="rounded-2xl border border-white/20 bg-white/10 p-4 shadow-inner"
+          >
+            <p
+              class="text-[10px] font-semibold uppercase tracking-[0.35em] text-white/70"
+            >
+              ATS Score Before
+            </p>
+            <div
+              class="mt-2 flex items-baseline gap-2"
+              data-testid="metric-score-before"
+            >
+              <span
+                class="text-4xl font-black leading-none text-white/95 md:text-5xl"
+              >
+                82
+              </span>
+              <span
+                class="text-sm font-semibold uppercase tracking-[0.3em] text-white/80"
+              >
+                %
+              </span>
+            </div>
+            <span
+              class="mt-3 inline-flex w-fit rounded-full bg-white/15 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-white/80"
+            >
+              EXCELLENT
+            </span>
+          </div>
+          <div
+            class="relative rounded-2xl border border-white/10 bg-white/15 p-4 shadow-inner"
+          >
+            <p
+              class="text-[10px] font-semibold uppercase tracking-[0.35em] text-white/80"
+            >
+              ATS Score After
+            </p>
+            <div
+              class="mt-2 flex items-baseline gap-2"
+              data-testid="metric-score"
+            >
+              <span
+                class="text-5xl font-black leading-none text-white md:text-6xl"
+              >
+                82
+              </span>
+              <span
+                class="text-base font-semibold uppercase tracking-[0.3em] text-white/80"
+              >
+                %
+              </span>
+            </div>
+            <span
+              class="mt-3 inline-flex w-fit rounded-full px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-white"
+              data-testid="rating-badge"
+            >
+              EXCELLENT
+            </span>
+          </div>
+        </div>
       </div>
       <div
         class="mt-auto space-y-3"

--- a/server.js
+++ b/server.js
@@ -12028,6 +12028,7 @@ async function generateEnhancedDocumentsResponse({
     jobText: jobDescription,
   });
   const finalAtsScores = scoreBreakdownToArray(finalScoreBreakdown);
+  const baselineAtsScores = scoreBreakdownToArray(baselineScoreBreakdown);
 
   const selectionInsights = buildSelectionInsights({
     jobTitle: versionsContext.jobTitle,
@@ -12073,6 +12074,8 @@ async function generateEnhancedDocumentsResponse({
     modifiedTitle: modifiedTitle || applicantTitle,
     scoreBreakdown: finalScoreBreakdown,
     atsSubScores: finalAtsScores,
+    atsSubScoresBefore: baselineAtsScores,
+    atsSubScoresAfter: finalAtsScores,
     resumeText: combinedProfile,
     originalResumeText: originalResumeTextInput || resumeText,
     jobDescriptionText: jobDescription,
@@ -12087,6 +12090,7 @@ async function generateEnhancedDocumentsResponse({
     manualCertificates,
     selectionProbability: selectionInsights?.probability ?? null,
     selectionProbabilityBefore: selectionInsights?.before?.probability ?? null,
+    selectionProbabilityAfter: selectionInsights?.after?.probability ?? selectionInsights?.probability ?? null,
     selectionInsights,
     changeLog: normalizedChangeLogEntries,
     templateContext: {

--- a/tests/processCv.e2e.test.js
+++ b/tests/processCv.e2e.test.js
@@ -39,6 +39,8 @@ describe('end-to-end CV processing', () => {
     expect(Array.isArray(response.body.missingSkills)).toBe(true);
     expect(typeof response.body.scoreBreakdown).toBe('object');
     expect(Array.isArray(response.body.atsSubScores)).toBe(true);
+    expect(Array.isArray(response.body.atsSubScoresBefore)).toBe(true);
+    expect(response.body.atsSubScoresBefore.length).toBeGreaterThan(0);
     expect(response.body.selectionInsights).toEqual(
       expect.objectContaining({
         flags: expect.any(Array),
@@ -46,6 +48,10 @@ describe('end-to-end CV processing', () => {
       })
     );
     expect(typeof response.body.selectionProbabilityBefore).toBe('number');
+    const selectionProbabilityAfter = response.body.selectionProbabilityAfter;
+    expect(
+      selectionProbabilityAfter === null || typeof selectionProbabilityAfter === 'number'
+    ).toBe(true);
     const probability = response.body.selectionInsights.probability;
     expect(probability === null || typeof probability === 'number').toBe(true);
     expect(response.body.selectionInsights.before).toEqual(


### PR DESCRIPTION
## Summary
- return baseline ATS subscores and explicit selection-after probabilities from the API
- display ATS Score Before/After and Selection % Before/After side-by-side in the dashboard
- refresh component tests and snapshots for the new comparison layout and API contract

## Testing
- npm test -- --runInBand *(fails: missing @babel/preset-env in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e14493fa0c832bbe78136a2d0f5054