### PR TITLE
Update ATS score card snapshot

### DIFF
--- a/client/src/components/__tests__/__snapshots__/ATSScoreCard.test.jsx.snap
+++ b/client/src/components/__tests__/__snapshots__/ATSScoreCard.test.jsx.snap
@@ -103,11 +103,6 @@ exports[`ATSScoreCard matches the gradient snapshot for consistency 1`] = `
                 %
               </span>
             </div>
-            <span
-              class="mt-3 inline-flex w-fit rounded-full bg-white/15 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.35em] text-white/80"
-            >
-              EXCELLENT
-            </span>
           </div>
           <div
             class="relative rounded-2xl border border-white/10 bg-white/15 p-4 shadow-inner"


### PR DESCRIPTION
## Summary
- update the ATS score card snapshot to match the current markup that omits the pre-improvement badge

## Testing
- npm test *(fails: local environment cannot resolve @babel/preset-env while collecting coverage)*

------
https://chatgpt.com/codex/tasks/task_e_68e14d301634832b92aab95e0645a8b1