### PR TITLE
Expose ATS before/after scoring across API and dashboard

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2875,22 +2875,35 @@ function App() {
           ? `Projected ${probabilityMeaning.toLowerCase()} probability (${probabilityValue}%) that this resume will be shortlisted for the JD.`
           : null)
 
-      const enhancedScoreResponse =
-        typeof data.enhancedScore === 'number'
-          ? data.enhancedScore
+      const atsScoreAfterResponse =
+        typeof data.atsScoreAfter === 'number'
+          ? data.atsScoreAfter
+          : typeof data.enhancedScore === 'number'
+            ? data.enhancedScore
+            : typeof data.originalScore === 'number'
+              ? data.originalScore
+              : null
+      const atsScoreBeforeResponse =
+        typeof data.atsScoreBefore === 'number'
+          ? data.atsScoreBefore
           : typeof data.originalScore === 'number'
             ? data.originalScore
-            : null
+            : atsScoreAfterResponse ?? null
 
       const matchPayload = {
         table: Array.isArray(data.table) ? data.table : [],
         addedSkills: Array.isArray(data.addedSkills) ? data.addedSkills : [],
         missingSkills: Array.isArray(data.missingSkills) ? data.missingSkills : [],
+        atsScoreBefore: atsScoreBeforeResponse ?? 0,
+        atsScoreAfter: atsScoreAfterResponse ?? 0,
         originalScore:
-          typeof data.originalScore === 'number'
-            ? data.originalScore
-            : enhancedScoreResponse ?? 0,
-        enhancedScore: enhancedScoreResponse ?? 0,
+          typeof atsScoreBeforeResponse === 'number'
+            ? atsScoreBeforeResponse
+            : 0,
+        enhancedScore:
+          typeof atsScoreAfterResponse === 'number'
+            ? atsScoreAfterResponse
+            : 0,
         originalTitle: data.originalTitle || '',
         modifiedTitle: data.modifiedTitle || '',
         selectionProbability: probabilityValue,
@@ -3514,11 +3527,15 @@ function App() {
 
       const id = suggestion.id
       const updatedResumeDraft = suggestion.updatedResume || resumeText
-      const baselineScore = Number.isFinite(match?.enhancedScore)
-        ? match.enhancedScore
-        : Number.isFinite(match?.originalScore)
-          ? match.originalScore
-          : null
+      const baselineScore = Number.isFinite(match?.atsScoreAfter)
+        ? match.atsScoreAfter
+        : Number.isFinite(match?.enhancedScore)
+          ? match.enhancedScore
+          : Number.isFinite(match?.atsScoreBefore)
+            ? match.atsScoreBefore
+            : Number.isFinite(match?.originalScore)
+              ? match.originalScore
+              : null
       const previousMissingSkills = Array.isArray(match?.missingSkills) ? match.missingSkills : []
       const changeLogEntry = buildChangeLogEntry(suggestion)
       const historySnapshot = {
@@ -4685,7 +4702,10 @@ function App() {
                 </tbody>
               </table>
               <p className="text-purple-800 font-medium">
-                {formatMatchMessage(match.originalScore, match.enhancedScore)}
+                {formatMatchMessage(
+                  typeof match.atsScoreBefore === 'number' ? match.atsScoreBefore : match.originalScore,
+                  typeof match.atsScoreAfter === 'number' ? match.atsScoreAfter : match.enhancedScore
+                )}
               </p>
               <div className="text-sm text-purple-700 space-y-1">
                 <p>

--- a/client/src/components/ATSScoreDashboard.jsx
+++ b/client/src/components/ATSScoreDashboard.jsx
@@ -179,12 +179,23 @@ function ATSScoreDashboard({
     }
   })
 
-  const originalScoreValue = clampScore(match?.originalScore)
-  const enhancedScoreValue = clampScore(match?.enhancedScore)
+  const originalScoreValue = clampScore(
+    typeof match?.atsScoreBefore === 'number'
+      ? match.atsScoreBefore
+      : match?.originalScore
+  )
+  const enhancedScoreValue = clampScore(
+    typeof match?.atsScoreAfter === 'number'
+      ? match.atsScoreAfter
+      : match?.enhancedScore
+  )
   const matchDelta =
     originalScoreValue !== null && enhancedScoreValue !== null
       ? formatDelta(originalScoreValue, enhancedScoreValue)
-      : formatDelta(match?.originalScore, match?.enhancedScore)
+      : formatDelta(
+          typeof match?.atsScoreBefore === 'number' ? match.atsScoreBefore : match?.originalScore,
+          typeof match?.atsScoreAfter === 'number' ? match.atsScoreAfter : match?.enhancedScore
+        )
   const selectionProbabilityBeforeValue =
     typeof match?.selectionProbabilityBefore === 'number'
       ? match.selectionProbabilityBefore
@@ -235,13 +246,13 @@ function ATSScoreDashboard({
   const scoreBands = hasComparableScores
     ? [
         {
-          label: 'Original',
+          label: 'ATS Score Before',
           value: originalScoreValue,
           tone: 'bg-indigo-500',
           textTone: 'text-indigo-700'
         },
         {
-          label: 'Enhanced',
+          label: 'ATS Score After',
           value: enhancedScoreValue,
           tone: 'bg-emerald-500',
           textTone: 'text-emerald-700'
@@ -382,16 +393,16 @@ function ATSScoreDashboard({
         >
           <div className="rounded-3xl border border-indigo-100 bg-white/80 p-6 shadow-lg backdrop-blur">
             <div className="flex items-center justify-between gap-3">
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-indigo-500">Original Match</p>
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-indigo-500">ATS Score Before</p>
               <InfoTooltip
                 variant="light"
                 align="right"
-                label="How is the original match score calculated?"
+                label="How is the ATS score before calculated?"
                 content={originalScoreDescription}
               />
             </div>
             <p className="mt-3 text-5xl font-black text-indigo-700" data-testid="original-score">
-              {match.originalScore ?? '—'}%
+              {typeof originalScoreValue === 'number' ? `${originalScoreValue}%` : '—'}
             </p>
             <p className="mt-2 text-sm text-indigo-600/90" data-testid="original-title">
               {match.originalTitle || 'Initial resume title unavailable.'}
@@ -412,15 +423,15 @@ function ATSScoreDashboard({
             <div className="flex items-start justify-between gap-3">
               <div className="flex items-start gap-2">
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-600">Enhanced Match</p>
+                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-600">ATS Score After</p>
                   <p className="mt-3 text-5xl font-black text-emerald-700" data-testid="enhanced-score">
-                    {match.enhancedScore ?? '—'}%
+                    {typeof enhancedScoreValue === 'number' ? `${enhancedScoreValue}%` : '—'}
                   </p>
                 </div>
                 <InfoTooltip
                   variant="light"
                   align="left"
-                  label="How is the enhanced match score calculated?"
+                  label="How is the ATS score after calculated?"
                   content={enhancedScoreDescription}
                 />
               </div>
@@ -471,7 +482,11 @@ function ATSScoreDashboard({
                   )}
                 </div>
               </div>
-              <div className="mt-4 space-y-4" role="img" aria-label={`Original score ${originalScoreValue}%, enhanced score ${enhancedScoreValue}%`}>
+              <div
+                className="mt-4 space-y-4"
+                role="img"
+                aria-label={`ATS score before ${originalScoreValue}%, ATS score after ${enhancedScoreValue}%`}
+              >
                 {scoreBands.map(({ label, value, tone, textTone }) => (
                   <div key={label} className="space-y-2">
                     <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.3em] text-slate-600">

--- a/client/src/components/__tests__/ATSScoreDashboard.test.jsx
+++ b/client/src/components/__tests__/ATSScoreDashboard.test.jsx
@@ -46,6 +46,8 @@ describe('ATSScoreDashboard', () => {
   const baseMatch = {
     originalScore: 48,
     enhancedScore: 76,
+    atsScoreBefore: 48,
+    atsScoreAfter: 76,
     originalTitle: 'Product Manager',
     modifiedTitle: 'Senior Product Manager'
   }
@@ -63,12 +65,12 @@ describe('ATSScoreDashboard', () => {
     expect(screen.getAllByText('ATS Score Before')).not.toHaveLength(0)
     expect(screen.getAllByText('ATS Score After')).not.toHaveLength(0)
     expect(screen.getByLabelText('match comparison')).toBeInTheDocument()
-    expect(screen.getByTestId('original-score')).toHaveTextContent('48')
-    expect(screen.getByTestId('enhanced-score')).toHaveTextContent('76')
+    expect(screen.getByTestId('original-score')).toHaveTextContent('48%')
+    expect(screen.getByTestId('enhanced-score')).toHaveTextContent('76%')
     const chart = screen.getByTestId('score-comparison-chart')
     expect(chart).toBeInTheDocument()
-    expect(within(chart).getByText('Original')).toBeInTheDocument()
-    expect(within(chart).getByText('Enhanced')).toBeInTheDocument()
+    expect(within(chart).getByText('ATS Score Before')).toBeInTheDocument()
+    expect(within(chart).getByText('ATS Score After')).toBeInTheDocument()
     expect(screen.getByTestId('dashboard-live-indicator')).toBeInTheDocument()
     expect(screen.getByTestId('original-match-status')).toHaveTextContent('Mismatch')
     expect(screen.getByTestId('enhanced-match-status')).toHaveTextContent('Mismatch')
@@ -90,7 +92,7 @@ describe('ATSScoreDashboard', () => {
       <ATSScoreDashboard metrics={metrics} baselineMetrics={baselineMetrics} match={match} />
     )
 
-    const updatedMatch = { ...match, enhancedScore: 90 }
+    const updatedMatch = { ...match, enhancedScore: 90, atsScoreAfter: 90 }
     rerender(
       <ATSScoreDashboard
         metrics={metrics}

--- a/server.js
+++ b/server.js
@@ -12032,6 +12032,11 @@ async function generateEnhancedDocumentsResponse({
 
   await logEvent({ s3, bucket, key: logKey, jobId, event: 'completed' });
 
+  const atsScoreBefore = Number.isFinite(originalMatchResult.score)
+    ? originalMatchResult.score
+    : bestMatch.score;
+  const atsScoreAfter = bestMatch.score;
+
   return {
     success: true,
     requestId,
@@ -12039,10 +12044,10 @@ async function generateEnhancedDocumentsResponse({
     urlExpiresInSeconds: urls.length > 0 ? URL_EXPIRATION_SECONDS : 0,
     urls,
     applicantName,
-    originalScore: Number.isFinite(originalMatchResult.score)
-      ? originalMatchResult.score
-      : bestMatch.score,
-    enhancedScore: bestMatch.score,
+    originalScore: atsScoreBefore,
+    enhancedScore: atsScoreAfter,
+    atsScoreBefore,
+    atsScoreAfter,
     table: bestMatch.table,
     addedSkills,
     missingSkills: bestMatch.newSkills,

--- a/tests/processCv.e2e.test.js
+++ b/tests/processCv.e2e.test.js
@@ -35,6 +35,10 @@ describe('end-to-end CV processing', () => {
     expect(typeof response.body.applicantName).toBe('string');
     expect(typeof response.body.originalScore).toBe('number');
     expect(typeof response.body.enhancedScore).toBe('number');
+    expect(typeof response.body.atsScoreBefore).toBe('number');
+    expect(typeof response.body.atsScoreAfter).toBe('number');
+    expect(response.body.atsScoreBefore).toBe(response.body.originalScore);
+    expect(response.body.atsScoreAfter).toBe(response.body.enhancedScore);
     expect(Array.isArray(response.body.addedSkills)).toBe(true);
     expect(Array.isArray(response.body.missingSkills)).toBe(true);
     expect(typeof response.body.scoreBreakdown).toBe('object');

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -235,6 +235,10 @@ describe('/api/process-cv', () => {
     expect(res2.body.urls).toHaveLength(5);
     expect(typeof res2.body.originalScore).toBe('number');
     expect(typeof res2.body.enhancedScore).toBe('number');
+    expect(typeof res2.body.atsScoreBefore).toBe('number');
+    expect(typeof res2.body.atsScoreAfter).toBe('number');
+    expect(res2.body.atsScoreBefore).toBe(res2.body.originalScore);
+    expect(res2.body.atsScoreAfter).toBe(res2.body.enhancedScore);
     expect(res2.body.applicantName).toBeTruthy();
     const sanitized = res2.body.applicantName
       .trim()

--- a/tests/uploadFlow.e2e.test.js
+++ b/tests/uploadFlow.e2e.test.js
@@ -63,6 +63,8 @@ describe('upload to download flow (e2e)', () => {
     expect(uploadResponse.body.jobId.length).toBeGreaterThan(10);
     expect(typeof uploadResponse.body.originalScore).toBe('number');
     expect(typeof uploadResponse.body.enhancedScore).toBe('number');
+    expect(typeof uploadResponse.body.atsScoreBefore).toBe('number');
+    expect(typeof uploadResponse.body.atsScoreAfter).toBe('number');
 
     const uploadTypes = extractTypes(uploadResponse.body.urls);
     expect(uploadTypes).toEqual(
@@ -122,7 +124,10 @@ describe('upload to download flow (e2e)', () => {
       jobSkills,
       resumeSkills,
       baseline: {
-        originalScore: uploadResponse.body.originalScore,
+        originalScore:
+          typeof uploadResponse.body.atsScoreBefore === 'number'
+            ? uploadResponse.body.atsScoreBefore
+            : uploadResponse.body.originalScore,
         missingSkills: uploadResponse.body.missingSkills || missingSkills,
         table: uploadResponse.body.table || [],
       },


### PR DESCRIPTION
## Summary
- return explicit atsScoreBefore and atsScoreAfter fields from the scoring pipeline so both values are available to clients
- surface the new ATS Score Before/After labels and values in the dashboard alongside the existing selection probability cards
- refresh client and server tests to assert the new fields and updated UI copy

## Testing
- npm test -- --runTestsByPath client/src/components/__tests__/ATSScoreDashboard.test.jsx tests/processCv.e2e.test.js tests/server.test.js tests/uploadFlow.e2e.test.js *(fails: jest-environment-jsdom and @babel/preset-env are unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e14f0cfcf0832b8526148343ab306e