### PR TITLE
Surface actionable ATS score card tips

### DIFF
--- a/client/src/components/ATSScoreCard.jsx
+++ b/client/src/components/ATSScoreCard.jsx
@@ -1,4 +1,5 @@
 import InfoTooltip from './InfoTooltip.jsx'
+import { buildMetricTip } from '../utils/actionableAdvice.js'
 
 const badgeThemes = {
   EXCELLENT:
@@ -105,7 +106,12 @@ function ATSScoreCard({ metric, accentClass = defaultAccent, improvement }) {
     ? normalizeLabel(metric.beforeRatingLabel)
     : null
   const deltaText = metric?.deltaText || formatScoreDelta(beforeScore, afterScore)
-  const tip = metric?.tip ?? metric?.tips?.[0] ?? ''
+  const explicitTip = typeof metric?.tip === 'string' ? metric.tip.trim() : ''
+  const listTips = Array.isArray(metric?.tips)
+    ? metric.tips.map((entry) => (typeof entry === 'string' ? entry.trim() : '')).filter(Boolean)
+    : []
+  const fallbackTip = buildMetricTip(metric)
+  const tip = explicitTip || listTips[0] || fallbackTip || ''
   const category = metric?.category ?? 'Metric'
   const metricDescription = describeMetric(metric)
 

--- a/client/src/components/__tests__/ATSScoreCard.test.jsx
+++ b/client/src/components/__tests__/ATSScoreCard.test.jsx
@@ -43,6 +43,8 @@ describe('ATSScoreCard', () => {
     expect(screen.getByTestId('metric-score')).toHaveTextContent('N/A')
     expect(screen.getByTestId('metric-score-before')).toHaveTextContent('N/A')
     expect(screen.queryAllByText('%')).toHaveLength(0)
-    expect(screen.queryByTestId('metric-tip')).not.toBeInTheDocument()
+    expect(screen.getByTestId('metric-tip')).toHaveTextContent(
+      /Keep mirroring the JD skill keywords in upcoming drafts/i
+    )
   })
 })


### PR DESCRIPTION
## Summary
- ensure ATS score cards import the shared advice helper to generate actionable tips when explicit copy is missing
- normalise provided tip strings so empty entries fall back to the helper-generated guidance
- update the component test to expect the skills guidance fallback when no direct tip is supplied

## Testing
- npm test -- --runTestsByPath client/src/components/__tests__/ATSScoreCard.test.jsx *(fails: environment lacks jest-environment-jsdom package)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e4492364832b905c8b1c06942601