### PR TITLE
Align designation improvements with dashboard tracking

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3796,6 +3796,37 @@ function App() {
         )
       )
 
+      const normalizedOriginalTitle =
+        typeof suggestion.originalTitle === 'string' ? suggestion.originalTitle.trim() : ''
+      const normalizedModifiedTitle =
+        typeof suggestion.modifiedTitle === 'string' ? suggestion.modifiedTitle.trim() : ''
+
+      if (normalizedOriginalTitle || normalizedModifiedTitle) {
+        setMatch((prev) => {
+          const base = prev ? { ...prev } : {}
+          const currentOriginal = typeof prev?.originalTitle === 'string' ? prev.originalTitle : ''
+          const currentModified = typeof prev?.modifiedTitle === 'string' ? prev.modifiedTitle : ''
+
+          const shouldUpdateOriginal =
+            normalizedOriginalTitle && normalizedOriginalTitle !== currentOriginal
+          const shouldUpdateModified =
+            normalizedModifiedTitle && normalizedModifiedTitle !== currentModified
+
+          if (!shouldUpdateOriginal && !shouldUpdateModified) {
+            return prev
+          }
+
+          if (shouldUpdateOriginal) {
+            base.originalTitle = normalizedOriginalTitle
+          }
+          if (shouldUpdateModified) {
+            base.modifiedTitle = normalizedModifiedTitle
+          }
+
+          return base
+        })
+      }
+
       if (updatedResumeDraft) {
         setResumeText(updatedResumeDraft)
       }
@@ -3911,6 +3942,7 @@ function App() {
       setChangeLog,
       setError,
       setImprovementResults,
+      setMatch,
       setResumeText
     ]
   )
@@ -4465,6 +4497,8 @@ function App() {
         const meaningfulBase = explanation && !/^applied deterministic improvements/i.test(explanation)
         explanation = meaningfulBase ? `${explanation} ${enhanceAllSummary}` : enhanceAllSummary
       }
+      const originalTitle = typeof data.originalTitle === 'string' ? data.originalTitle.trim() : ''
+      const modifiedTitle = typeof data.modifiedTitle === 'string' ? data.modifiedTitle.trim() : ''
       const suggestion = {
         id: `${type}-${Date.now()}`,
         type,
@@ -4476,6 +4510,8 @@ function App() {
         updatedResume: data.updatedResume || resumeText,
         confidence: typeof data.confidence === 'number' ? data.confidence : 0.6,
         accepted: null,
+        originalTitle,
+        modifiedTitle,
         improvementSummary,
         rescoreSummary: normalizeRescoreSummary(data.rescore),
         scoreDelta: null,

--- a/server.js
+++ b/server.js
@@ -10940,6 +10940,8 @@ async function handleImprovementRequest(type, req, res) {
       confidence: result.confidence,
       updatedResume: result.updatedResume,
       missingSkills,
+      originalTitle: baselineDesignationTitle || '',
+      modifiedTitle: updatedDesignationTitle || '',
       improvementSummary: buildImprovementSummary(
         normalizedBeforeExcerpt,
         normalizedAfterExcerpt,

--- a/tests/improvements.e2e.test.js
+++ b/tests/improvements.e2e.test.js
@@ -302,6 +302,14 @@ describe('targeted improvement endpoints (integration)', () => {
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(response.body.type).toBe(type);
+      expect(typeof response.body.originalTitle).toBe('string');
+      expect(typeof response.body.modifiedTitle).toBe('string');
+      expect(response.body.originalTitle).toBe(basePayload.currentTitle);
+      if (type === 'change-designation' || type === 'enhance-all') {
+        expect(response.body.modifiedTitle).toBe(basePayload.jobTitle);
+      } else {
+        expect(response.body.modifiedTitle).toBe(response.body.originalTitle);
+      }
       expect(typeof response.body.confidence).toBe('number');
       expect(Array.isArray(response.body.missingSkills)).toBe(true);
       expect(Array.isArray(response.body.improvementSummary)).toBe(true);


### PR DESCRIPTION
## Summary
- return the original and modified titles from targeted improvement responses so the UI can highlight designation updates
- persist designation changes in client state when improvements are applied to surface the new title across the dashboard
- extend the improvement integration test to cover the new designation fields

## Testing
- npm test -- --runTestsByPath tests/improvements.e2e.test.js *(fails: missing @babel/preset-env in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e8d0fd4c832b8feae2c8e4b552e4