### PR TITLE
Align designation improvements with target job title

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4442,13 +4442,25 @@ function App() {
     setError('')
     try {
       const requestUrl = buildApiUrl(API_BASE_URL, `/api/${type}`)
+      const selectionTargetTitle =
+        typeof selectionInsights?.designation?.targetTitle === 'string'
+          ? selectionInsights.designation.targetTitle.trim()
+          : ''
+      const matchModifiedTitle =
+        typeof match?.modifiedTitle === 'string' ? match.modifiedTitle.trim() : ''
+      const matchOriginalTitle =
+        typeof match?.originalTitle === 'string' ? match.originalTitle.trim() : ''
+      const targetJobTitle = selectionTargetTitle || matchModifiedTitle || matchOriginalTitle
+      const currentResumeTitle = matchModifiedTitle || matchOriginalTitle
+
       const payload = {
         jobId,
         linkedinProfileUrl: profileUrl.trim(),
         resumeText,
         jobDescription: jobDescriptionText,
-        jobTitle: match?.modifiedTitle || match?.originalTitle || '',
-        currentTitle: match?.modifiedTitle || match?.originalTitle || '',
+        jobTitle: targetJobTitle,
+        currentTitle: currentResumeTitle,
+        originalTitle: matchOriginalTitle,
         jobSkills,
         resumeSkills,
         missingSkills: match?.missingSkills || [],


### PR DESCRIPTION
## Summary
- send the target designation from selection insights when requesting improvements so the backend can align the headline with the JD
- ensure designation updates always add change details and surface the JD title when generating improvement responses
- fall back to the JD title when extracting the updated designation after running an improvement

## Testing
- npm test -- tests/improvements.e2e.test.js *(fails: Cannot find package '@babel/preset-env' imported from babel-virtual-resolve-base.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ea80b92c832babcbfee5f0cf1f2e