### PR TITLE
Ensure designation improvements use requested job title

### DIFF
--- a/server.js
+++ b/server.js
@@ -10726,7 +10726,7 @@ async function handleImprovementRequest(type, req, res) {
     const jobTitleInput = typeof payload.jobTitle === 'string' ? payload.jobTitle.trim() : '';
     const updatedDesignationTitle =
       type === 'change-designation' || type === 'enhance-all'
-        ? extractDesignationLine(updatedResumeText) || jobTitleInput || baselineDesignationTitle
+        ? jobTitleInput || extractDesignationLine(updatedResumeText) || baselineDesignationTitle
         : sectionContext.key === 'designation' && sectionContext.afterText
           ? sectionContext.afterText
           : baselineDesignationTitle;


### PR DESCRIPTION
## Summary
- prioritize the requested job title when computing the modified designation for change-designation and enhance-all improvements

## Testing
- npm test -- tests/improvements.e2e.test.js *(fails: missing @babel/preset-env in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ec674f48832bb119e56db36dadc2