### PR TITLE
Enhance fallback experience rewrite for JD responsibilities

### DIFF
--- a/server.js
+++ b/server.js
@@ -3262,17 +3262,17 @@ function fallbackImprovement(type, context) {
     const headingLabel = section.heading.replace(/^#\s*/, '') || 'Work Experience';
     const baseContent = sanitizeSectionLines(section.content);
     const before = baseContent.join('\n').trim();
-    const focusDescriptor = (() => {
+    const responsibilityDescriptor = (() => {
       if (jobTitle && fallbackSkillText) {
-        return `${jobTitle} priorities across ${fallbackSkillText}`;
+        return `${jobTitle} responsibilities across ${fallbackSkillText}`;
       }
       if (jobTitle) {
         return `${jobTitle} responsibilities`;
       }
       if (fallbackSkillText) {
-        return `${fallbackSkillText} priorities`;
+        return `${fallbackSkillText} responsibilities`;
       }
-      return 'the job description priorities';
+      return 'key responsibilities from the job description';
     })();
     const updatedContent = [...baseContent];
     let firstBulletIndex = updatedContent.findIndex((line) => /^[-•*]/.test(line.trim()));
@@ -3284,20 +3284,35 @@ function fallbackImprovement(type, context) {
       const markerMatch = trimmed.match(/^([•*-])/);
       bulletMarker = markerMatch ? markerMatch[1] : '-';
       const body = trimmed.replace(/^([•*-])\s*/, '').replace(/\s*[.?!]+$/, '');
-      const rewrittenLine = `${bulletMarker} ${body} — emphasised ownership of ${focusDescriptor}.`;
+      const rewrittenLine = `${bulletMarker} ${body} — reframed to show ownership of ${responsibilityDescriptor}.`;
       updatedContent[firstBulletIndex] = rewrittenLine;
     } else {
-      const synthesizedLine = `${bulletMarker} Delivered on ${focusDescriptor} with measurable outcomes.`;
+      const synthesizedLine = `${bulletMarker} Delivered on ${responsibilityDescriptor} with measurable outcomes.`;
       updatedContent.push(synthesizedLine);
       firstBulletIndex = updatedContent.length - 1;
     }
 
-    const additionLine = `${bulletMarker} Partnered with stakeholders to deliver on ${focusDescriptor}, showcasing measurable outcomes.`;
+    const responsibilitiesLine = `${bulletMarker} Highlighted ${responsibilityDescriptor} so recruiters instantly see JD-aligned responsibilities.`;
+    const additionLine = `${bulletMarker} Delivered ${fallbackSkillText || 'priority'} initiatives to mirror JD responsibilities with measurable outcomes.`;
+    const responsibilitiesLineKey = responsibilitiesLine.trim().toLowerCase();
     const additionLineKey = additionLine.trim().toLowerCase();
+    const hasResponsibilities = updatedContent.some(
+      (line) => line && line.trim().toLowerCase() === responsibilitiesLineKey
+    );
     const hasAddition = updatedContent.some((line) => line && line.trim().toLowerCase() === additionLineKey);
+    let insertIndex = firstBulletIndex >= 0 ? firstBulletIndex + 1 : updatedContent.length;
+    let additionInsertIndex = insertIndex;
+    if (!hasResponsibilities) {
+      updatedContent.splice(insertIndex, 0, responsibilitiesLine);
+      additionInsertIndex = insertIndex + 1;
+    } else {
+      const existingIndex = updatedContent.findIndex(
+        (line) => line && line.trim().toLowerCase() === responsibilitiesLineKey
+      );
+      additionInsertIndex = existingIndex >= 0 ? existingIndex + 1 : insertIndex;
+    }
     if (!hasAddition) {
-      const insertIndex = firstBulletIndex >= 0 ? firstBulletIndex + 1 : updatedContent.length;
-      updatedContent.splice(insertIndex, 0, additionLine);
+      updatedContent.splice(additionInsertIndex, 0, additionLine);
     }
 
     const sanitizedContent = sanitizeSectionLines(updatedContent);
@@ -3314,7 +3329,9 @@ function fallbackImprovement(type, context) {
     const afterSet = new Set(afterLines.map((line) => line.toLowerCase()));
     const addedItems = afterLines.filter((line) => !beforeSet.has(line.toLowerCase()));
     const removedItems = beforeLines.filter((line) => !afterSet.has(line.toLowerCase()));
-    const explanation = `Rewrote experience bullets to highlight ownership of ${focusDescriptor}.`;
+    const explanation = jobTitle
+      ? `Rewrote experience bullets to surface ${jobTitle} responsibilities and highlight the JD-aligned additions.`
+      : 'Rewrote experience bullets to surface JD-aligned responsibilities and highlight the additions.';
     const changeDetails = [
       {
         key: 'experience',

--- a/tests/improvementRoutes.test.js
+++ b/tests/improvementRoutes.test.js
@@ -296,25 +296,29 @@ describe('targeted improvement routes', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.updatedResume).toContain(
-      'Built scalable services — emphasised ownership of Lead Software Engineer priorities across Leadership and Cloud Architecture.'
+      'Built scalable services — reframed to show ownership of Lead Software Engineer responsibilities across Leadership and Cloud Architecture.'
     );
     expect(response.body.updatedResume).toContain(
-      'Partnered with stakeholders to deliver on Lead Software Engineer priorities across Leadership and Cloud Architecture, showcasing measurable outcomes.'
+      'Highlighted Lead Software Engineer responsibilities across Leadership and Cloud Architecture so recruiters instantly see JD-aligned responsibilities.'
+    );
+    expect(response.body.updatedResume).toContain(
+      'Delivered Leadership and Cloud Architecture initiatives to mirror JD responsibilities with measurable outcomes.'
     );
     expect(response.body.explanation).toBe(
-      'Rewrote experience bullets to highlight ownership of Lead Software Engineer priorities across Leadership and Cloud Architecture.'
+      'Rewrote experience bullets to surface Lead Software Engineer responsibilities and highlight the JD-aligned additions.'
     );
     expect(Array.isArray(response.body.improvementSummary)).toBe(true);
     expect(response.body.improvementSummary[0]).toEqual(
       expect.objectContaining({
         section: 'Work Experience',
         added: expect.arrayContaining([
-          'Built scalable services — emphasised ownership of Lead Software Engineer priorities across Leadership and Cloud Architecture.',
-          'Partnered with stakeholders to deliver on Lead Software Engineer priorities across Leadership and Cloud Architecture, showcasing measurable outcomes.'
+          'Built scalable services — reframed to show ownership of Lead Software Engineer responsibilities across Leadership and Cloud Architecture.',
+          'Highlighted Lead Software Engineer responsibilities across Leadership and Cloud Architecture so recruiters instantly see JD-aligned responsibilities.',
+          'Delivered Leadership and Cloud Architecture initiatives to mirror JD responsibilities with measurable outcomes.'
         ]),
         removed: expect.arrayContaining(['Built scalable services.']),
         reason: expect.arrayContaining([
-          'Rewrote experience bullets to highlight ownership of Lead Software Engineer priorities across Leadership and Cloud Architecture.'
+          'Rewrote experience bullets to surface Lead Software Engineer responsibilities and highlight the JD-aligned additions.'
         ]),
       })
     );


### PR DESCRIPTION
## Summary
- refine the deterministic align-experience fallback to emphasise JD responsibilities and insert explicit change bullets
- update the align-experience integration test expectations to cover the new responsibility-focused messaging

## Testing
- npm test -- tests/improvementRoutes.test.js *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68e1f60a0dec832bad4b41a51b3610fd