### PR TITLE
feat: surface category changelog reasons

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -23,6 +23,7 @@ import { createCoverLetterPdf } from './utils/createCoverLetterPdf.js'
 import { normalizeOutputFiles } from './utils/normalizeOutputFiles.js'
 import { buildImprovementHintFromSegment } from './utils/actionableAdvice.js'
 import parseJobDescriptionText from './utils/parseJobDescriptionText.js'
+import { buildCategoryChangeLog } from './utils/changeLogCategorySummaries.js'
 
 const CV_GENERATION_ERROR_MESSAGE =
   'Could not enhance CV; your formatting remained untouched.'
@@ -1233,6 +1234,18 @@ function buildChangeLogEntry(suggestion) {
       return a.item.localeCompare(b.item, undefined, { sensitivity: 'base' })
     })
 
+  const categoryChangelog = buildCategoryChangeLog({
+    summarySegments,
+    detail: detailText,
+    addedItems,
+    removedItems,
+    itemizedChanges,
+    before: beforeExcerpt,
+    after: afterExcerpt,
+    scoreDelta: suggestion?.scoreDelta,
+    suggestionType: suggestion?.type
+  })
+
   return {
     id: suggestion?.id,
     label,
@@ -1246,6 +1259,7 @@ function buildChangeLogEntry(suggestion) {
     addedItems,
     removedItems,
     itemizedChanges,
+    categoryChangelog,
     scoreDelta:
       typeof suggestion?.scoreDelta === 'number' && Number.isFinite(suggestion.scoreDelta)
         ? suggestion.scoreDelta
@@ -5539,6 +5553,7 @@ function App() {
                         addedItems={entry.addedItems}
                         removedItems={entry.removedItems}
                         itemizedChanges={entry.itemizedChanges}
+                        categoryChangelog={entry.categoryChangelog}
                       />
                     )}
                   </li>

--- a/client/src/components/ChangeComparisonView.jsx
+++ b/client/src/components/ChangeComparisonView.jsx
@@ -75,6 +75,7 @@ function ChangeComparisonView({
   addedItems = [],
   removedItems = [],
   itemizedChanges = [],
+  categoryChangelog = [],
   variant = 'compact',
   className = ''
 }) {
@@ -93,6 +94,8 @@ function ChangeComparisonView({
     const regex = patternSources.length ? new RegExp(`(${patternSources.join('|')})`, 'gi') : null
     return { addedSet, removedSet, regex }
   }, [addedItems, removedItems])
+
+  const hasCategoryChangelog = Array.isArray(categoryChangelog) && categoryChangelog.length > 0
 
   const renderHighlighted = (text) => {
     if (!text) return null
@@ -229,6 +232,70 @@ function ChangeComparisonView({
               </div>
             </div>
           )}
+        </div>
+      )}
+
+      {hasCategoryChangelog && (
+        <div className="space-y-3 rounded-2xl border border-blue-100 bg-white/75 p-4">
+          <div className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-wide text-blue-500">ATS Change Summary</p>
+            <p className="text-sm text-blue-700/80">
+              See why each core category shifted and which items were touched.
+            </p>
+          </div>
+          <ul className="space-y-3">
+            {categoryChangelog.map((category) => {
+              if (!category) return null
+              const added = Array.isArray(category.added) ? category.added : []
+              const removed = Array.isArray(category.removed) ? category.removed : []
+              const reasons = Array.isArray(category.reasons) ? category.reasons : []
+              const hasChips = added.length > 0 || removed.length > 0
+              return (
+                <li
+                  key={category.key || category.label}
+                  className="rounded-xl border border-blue-200 bg-white/85 p-3 text-sm text-slate-700"
+                >
+                  <div className="space-y-1">
+                    <p className="font-semibold text-slate-900">{category.label || 'Category'}</p>
+                    {typeof category.description === 'string' && category.description.trim() && (
+                      <p className="text-xs font-medium text-blue-500/80">
+                        {category.description}
+                      </p>
+                    )}
+                    {reasons.length > 0 && (
+                      <ul className="list-disc space-y-1 pl-5 text-xs text-slate-600">
+                        {reasons.map((reason, index) => (
+                          <li key={`${category.key || category.label}-reason-${index}`}>{reason}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                  {hasChips && (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {added.map((item) => (
+                        <span
+                          key={`category-added-${category.key || category.label}-${item}`}
+                          className="inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50/80 px-3 py-1 text-xs font-semibold text-emerald-700"
+                        >
+                          <span aria-hidden="true">＋</span>
+                          {item}
+                        </span>
+                      ))}
+                      {removed.map((item) => (
+                        <span
+                          key={`category-removed-${category.key || category.label}-${item}`}
+                          className="inline-flex items-center gap-1 rounded-full border border-rose-200 bg-rose-50/80 px-3 py-1 text-xs font-semibold text-rose-700"
+                        >
+                          <span aria-hidden="true">–</span>
+                          {item}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
         </div>
       )}
 

--- a/client/src/utils/__tests__/changeLogCategorySummaries.test.js
+++ b/client/src/utils/__tests__/changeLogCategorySummaries.test.js
@@ -1,0 +1,52 @@
+import { buildCategoryChangeLog } from '../changeLogCategorySummaries.js'
+
+describe('buildCategoryChangeLog', () => {
+  it('captures category updates with reasons from summary segments', () => {
+    const changeLog = buildCategoryChangeLog({
+      summarySegments: [
+        {
+          section: 'Skills',
+          added: ['Kubernetes', 'Terraform'],
+          removed: ['Flash'],
+          reason: ['Added for better fit to JD']
+        }
+      ],
+      detail: 'Inserted missing keywords so the CV satisfies the role requirements.',
+      suggestionType: 'add-missing-skills',
+      scoreDelta: 7
+    })
+
+    const skills = changeLog.find((entry) => entry.key === 'skills')
+    expect(skills).toBeDefined()
+    expect(skills.added).toEqual(expect.arrayContaining(['Kubernetes', 'Terraform']))
+    expect(skills.removed).toEqual(expect.arrayContaining(['Flash']))
+    expect(skills.reasons).toEqual(
+      expect.arrayContaining(['Added for better fit to JD'])
+    )
+
+    const ats = changeLog.find((entry) => entry.key === 'ats')
+    expect(ats).toBeDefined()
+    expect(ats.reasons.join(' ')).toContain('Score impact: +7 pts')
+  })
+
+  it('records designation swaps even when summary segments are absent', () => {
+    const changeLog = buildCategoryChangeLog({
+      detail: 'Aligned the visible designation with the target role title.',
+      before: 'Project Lead',
+      after: 'Product Manager',
+      suggestionType: 'change-designation'
+    })
+
+    const designation = changeLog.find((entry) => entry.key === 'designation')
+    expect(designation).toBeDefined()
+    expect(designation.added).toContain('Product Manager')
+    expect(designation.removed).toContain('Project Lead')
+    expect(designation.reasons.join(' ')).toContain('align with the JD role name')
+
+    const ats = changeLog.find((entry) => entry.key === 'ats')
+    expect(ats).toBeDefined()
+    expect(ats.reasons).toEqual(
+      expect.arrayContaining(['Aligned the visible designation with the target role title.'])
+    )
+  })
+})

--- a/client/src/utils/changeLogCategorySummaries.js
+++ b/client/src/utils/changeLogCategorySummaries.js
@@ -1,0 +1,292 @@
+const CATEGORY_METADATA = {
+  ats: {
+    key: 'ats',
+    label: 'ATS',
+    description: 'Score movement and JD alignment rationale.'
+  },
+  skills: {
+    key: 'skills',
+    label: 'Skills',
+    description: 'Keyword coverage surfaced across the resume.'
+  },
+  designation: {
+    key: 'designation',
+    label: 'Designation',
+    description: 'Visible job titles aligned to the target role.'
+  },
+  tasks: {
+    key: 'tasks',
+    label: 'Tasks',
+    description: 'Experience bullets, responsibilities, and project highlights.'
+  },
+  highlights: {
+    key: 'highlights',
+    label: 'Highlights',
+    description: 'Headline wins and summary messaging that were refreshed.'
+  },
+  certs: {
+    key: 'certs',
+    label: 'Certifications',
+    description: 'Credentials emphasised for the JD.'
+  }
+}
+
+const CATEGORY_ORDER = ['ats', 'skills', 'designation', 'tasks', 'highlights', 'certs']
+
+const SECTION_CATEGORY_MATCHERS = [
+  { keys: ['skills'], pattern: /skill|keyword/i },
+  { keys: ['designation'], pattern: /designation|title|headline|position/i },
+  { keys: ['tasks'], pattern: /experience|project|responsibilit|task|achievement|impact/i },
+  { keys: ['highlights'], pattern: /highlight|summary|profile|overview/i },
+  { keys: ['certs'], pattern: /cert|badge|accredit/i },
+  {
+    keys: ['ats'],
+    pattern: /ats|layout|readability|candidatescore|impact metric|probability|quality/i
+  }
+]
+
+const PRIMARY_CATEGORY_BY_SUGGESTION = {
+  'improve-summary': 'highlights',
+  'add-missing-skills': 'skills',
+  'align-experience': 'tasks',
+  'change-designation': 'designation',
+  'improve-certifications': 'certs',
+  'improve-projects': 'tasks',
+  'improve-highlights': 'highlights'
+}
+
+const RELATED_CATEGORIES_BY_SUGGESTION = {
+  'improve-summary': ['ats', 'highlights'],
+  'add-missing-skills': ['ats', 'skills'],
+  'align-experience': ['ats', 'tasks', 'highlights'],
+  'change-designation': ['ats', 'designation'],
+  'improve-certifications': ['ats', 'certs', 'skills'],
+  'improve-projects': ['ats', 'tasks', 'highlights'],
+  'improve-highlights': ['ats', 'highlights'],
+  'enhance-all': ['ats', 'skills', 'designation', 'tasks', 'highlights', 'certs']
+}
+
+function normaliseList(value) {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (typeof item === 'string') {
+          return item.trim()
+        }
+        if (item === null || item === undefined) {
+          return ''
+        }
+        return String(item || '').trim()
+      })
+      .filter(Boolean)
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed ? [trimmed] : []
+  }
+  if (value === null || value === undefined) {
+    return []
+  }
+  return [String(value || '').trim()].filter(Boolean)
+}
+
+function resolveSectionCategories(sectionLabel) {
+  if (!sectionLabel) {
+    return []
+  }
+  const lower = sectionLabel.toLowerCase()
+  const matched = new Set()
+  SECTION_CATEGORY_MATCHERS.forEach((matcher) => {
+    if (matcher.pattern.test(lower)) {
+      matcher.keys.forEach((key) => matched.add(key))
+    }
+  })
+  return Array.from(matched)
+}
+
+function ensureCategoryEntry(map, key) {
+  if (!CATEGORY_METADATA[key]) {
+    return null
+  }
+  if (!map.has(key)) {
+    map.set(key, {
+      key,
+      label: CATEGORY_METADATA[key].label,
+      description: CATEGORY_METADATA[key].description,
+      added: new Set(),
+      removed: new Set(),
+      reasons: new Set()
+    })
+  }
+  return map.get(key)
+}
+
+function pushItems(targetSet, items) {
+  normaliseList(items).forEach((item) => {
+    if (!item) return
+    targetSet.add(item)
+  })
+}
+
+function pushReasons(targetSet, reasons) {
+  normaliseList(reasons).forEach((reason) => {
+    if (!reason) return
+    const lower = reason.toLowerCase()
+    // Prevent near-duplicate rationale lines.
+    if (!Array.from(targetSet).some((existing) => existing.toLowerCase() === lower)) {
+      targetSet.add(reason)
+    }
+  })
+}
+
+function addScoreDeltaReason(categoryEntry, scoreDelta) {
+  if (!categoryEntry) return
+  if (typeof scoreDelta !== 'number' || Number.isNaN(scoreDelta) || !Number.isFinite(scoreDelta)) {
+    return
+  }
+  if (scoreDelta === 0) {
+    categoryEntry.reasons.add('Confirmed the ATS score stayed stable after the change.')
+    return
+  }
+  const rounded = Math.round(scoreDelta)
+  const prefix = rounded > 0 ? '+' : ''
+  categoryEntry.reasons.add(`Score impact: ${prefix}${rounded} pts versus the baseline upload.`)
+}
+
+export function buildCategoryChangeLog({
+  summarySegments = [],
+  detail,
+  addedItems = [],
+  removedItems = [],
+  itemizedChanges = [],
+  before,
+  after,
+  scoreDelta = null,
+  suggestionType
+} = {}) {
+  const detailText = typeof detail === 'string' ? detail.trim() : ''
+  const categoryMap = new Map()
+
+  const segments = Array.isArray(summarySegments) ? summarySegments : []
+
+  segments.forEach((rawSegment) => {
+    if (!rawSegment || typeof rawSegment !== 'object') {
+      return
+    }
+    const sectionLabel =
+      typeof rawSegment.section === 'string'
+        ? rawSegment.section
+        : typeof rawSegment.label === 'string'
+          ? rawSegment.label
+          : typeof rawSegment.key === 'string'
+            ? rawSegment.key
+            : ''
+    const sectionCategories = resolveSectionCategories(sectionLabel)
+    if (sectionCategories.length === 0) {
+      return
+    }
+    const segmentAdded = normaliseList(rawSegment.added)
+    const segmentRemoved = normaliseList(rawSegment.removed)
+    const segmentReason = normaliseList(rawSegment.reason)
+    const reasonsToUse = segmentReason.length > 0 ? segmentReason : detailText ? [detailText] : []
+
+    sectionCategories.forEach((categoryKey) => {
+      const entry = ensureCategoryEntry(categoryMap, categoryKey)
+      if (!entry) return
+      pushItems(entry.added, segmentAdded)
+      pushItems(entry.removed, segmentRemoved)
+      pushReasons(entry.reasons, reasonsToUse)
+    })
+  })
+
+  const suggestionKey = typeof suggestionType === 'string' ? suggestionType.trim() : ''
+  const primaryCategory = PRIMARY_CATEGORY_BY_SUGGESTION[suggestionKey] || null
+
+  if (primaryCategory) {
+    const entry = ensureCategoryEntry(categoryMap, primaryCategory)
+    if (entry) {
+      pushItems(entry.added, addedItems)
+      pushItems(entry.removed, removedItems)
+      if (entry.reasons.size === 0 && detailText) {
+        entry.reasons.add(detailText)
+      }
+    }
+  }
+
+  if (Array.isArray(itemizedChanges) && itemizedChanges.length > 0) {
+    const fallbackCategory = primaryCategory || (RELATED_CATEGORIES_BY_SUGGESTION[suggestionKey] || [])[0]
+    if (fallbackCategory) {
+      const entry = ensureCategoryEntry(categoryMap, fallbackCategory)
+      if (entry) {
+        itemizedChanges.forEach((change) => {
+          if (!change || typeof change !== 'object') return
+          const reasons = normaliseList(change.reasons)
+          pushReasons(entry.reasons, reasons)
+        })
+      }
+    }
+  }
+
+  if (suggestionKey === 'change-designation' && before && after && before !== after) {
+    const entry = ensureCategoryEntry(categoryMap, 'designation')
+    if (entry) {
+      entry.reasons.add('Updated your visible title to align with the JD role name.')
+      pushItems(entry.added, after)
+      pushItems(entry.removed, before)
+    }
+  }
+
+  if (suggestionKey === 'enhance-all') {
+    // Ensure all related categories inherit the overarching rationale.
+    const related = RELATED_CATEGORIES_BY_SUGGESTION[suggestionKey] || []
+    related.forEach((key) => {
+      const entry = ensureCategoryEntry(categoryMap, key)
+      if (entry && detailText) {
+        entry.reasons.add(detailText)
+      }
+    })
+  }
+
+  const relatedCategories = RELATED_CATEGORIES_BY_SUGGESTION[suggestionKey] || []
+  relatedCategories.forEach((key) => {
+    const entry = ensureCategoryEntry(categoryMap, key)
+    if (!entry) return
+    if (entry.reasons.size === 0 && detailText) {
+      entry.reasons.add(detailText)
+    }
+  })
+
+  if (detailText) {
+    const atsEntry = ensureCategoryEntry(categoryMap, 'ats')
+    if (atsEntry && atsEntry.reasons.size === 0) {
+      atsEntry.reasons.add(detailText)
+    }
+  }
+
+  addScoreDeltaReason(categoryMap.get('ats'), scoreDelta)
+
+  const result = CATEGORY_ORDER.map((key) => {
+    const entry = categoryMap.get(key)
+    if (!entry) {
+      return null
+    }
+    const added = Array.from(entry.added)
+    const removed = Array.from(entry.removed)
+    const reasons = Array.from(entry.reasons)
+    if (added.length === 0 && removed.length === 0 && reasons.length === 0) {
+      return null
+    }
+    return {
+      key,
+      label: entry.label,
+      description: entry.description,
+      added,
+      removed,
+      reasons
+    }
+  }).filter(Boolean)
+
+  return result
+}
+
+export default buildCategoryChangeLog


### PR DESCRIPTION
## Summary
- add a category-aware changelog utility that groups ATS, skills, designation, tasks, highlights, and certification updates with their rationale
- attach the derived category changelog to each improvement entry and surface it in the change comparison view so candidates see what shifted and why
- back the new categorisation with unit coverage around skill additions, score impacts, and designation swaps

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e205589aa0832bb9b3f6d971098e55