### PR TITLE
Ensure cover letters follow selected templates during enhancements

### DIFF
--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -15,6 +15,11 @@ import fs from 'fs/promises';
 import path from 'path';
 import Handlebars from '../lib/handlebars.js';
 
+const CLASSIC_CV_TEMPLATES = new Set(['classic', 'professional', 'ucmo']);
+
+const expectedCoverForTemplate = (templateId) =>
+  CLASSIC_CV_TEMPLATES.has(templateId) ? 'cover_classic' : 'cover_modern';
+
 function escapeHtml(str = '') {
   return str
     .replace(/&/g, '&amp;')
@@ -283,18 +288,18 @@ describe('generatePdf and parsing', () => {
     expect(template2).not.toBe('ucmo');
     expect(CV_TEMPLATE_GROUPS[template2]).not.toBe(CV_TEMPLATE_GROUPS['ucmo']);
     expect(CV_TEMPLATES).toContain(template2);
-    expect(coverTemplate1).not.toBe(coverTemplate2);
-    expect(CL_TEMPLATES).toContain(coverTemplate1);
-    expect(CL_TEMPLATES).toContain(coverTemplate2);
+    expect(coverTemplate1).toBe(expectedCoverForTemplate(template1));
+    expect(coverTemplate2).toBe(expectedCoverForTemplate(template2));
   });
 
   test('explicit template preference becomes primary', () => {
     const preferred = CV_TEMPLATES.find((tpl) => tpl !== 'ucmo') || CV_TEMPLATES[0];
-    const { template1, template2 } = selectTemplates({ preferredTemplate: preferred });
+    const { template1, template2, coverTemplate1 } = selectTemplates({ preferredTemplate: preferred });
     expect(template1).toBe(preferred);
     expect(template2).not.toBe(preferred);
     expect(CV_TEMPLATES).toContain(template2);
     expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(CV_TEMPLATE_GROUPS[template2]);
+    expect(coverTemplate1).toBe(expectedCoverForTemplate(template1));
   });
 
   test('script tags render as text', () => {

--- a/tests/selectTemplatesGroup.test.js
+++ b/tests/selectTemplatesGroup.test.js
@@ -4,28 +4,38 @@ import path from 'path';
 
 describe('selectTemplates respects preferred templates and contrast', () => {
   test.each(CV_TEMPLATES)('prioritises preferred template %s', (tpl) => {
-    const { template1, template2 } = selectTemplates({ preferredTemplate: tpl });
+    const { template1, template2, coverTemplate1 } = selectTemplates({
+      preferredTemplate: tpl,
+    });
     expect(template1).toBe(tpl);
     expect(template2).not.toBe(template1);
     expect(CV_TEMPLATES).toContain(template2);
     expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
       CV_TEMPLATE_GROUPS[template2]
     );
+    const expectedCover = ['classic', 'professional', 'ucmo'].includes(template1)
+      ? 'cover_classic'
+      : 'cover_modern';
+    expect(coverTemplate1).toBe(expectedCover);
   });
 
   test('uses explicit template1 when no preference supplied', () => {
-    const { template1, template2 } = selectTemplates({ template1: 'vibrant' });
+    const { template1, template2, coverTemplate1 } = selectTemplates({
+      template1: 'vibrant',
+    });
     expect(template1).toBe('vibrant');
     expect(template2).not.toBe('vibrant');
     expect(CV_TEMPLATE_GROUPS[template2]).not.toBe(CV_TEMPLATE_GROUPS['vibrant']);
+    expect(coverTemplate1).toBe('cover_modern');
   });
 
   test('defaults to ucmo when nothing provided', () => {
-    const { template1, template2 } = selectTemplates();
+    const { template1, template2, coverTemplate1 } = selectTemplates();
     expect(template1).toBe('ucmo');
     expect(template2).not.toBe('ucmo');
     expect(CV_TEMPLATES).toContain(template2);
     expect(CV_TEMPLATE_GROUPS[template2]).not.toBe(CV_TEMPLATE_GROUPS['ucmo']);
+    expect(coverTemplate1).toBe('cover_classic');
   });
 
   test('heading styles are bold across templates', async () => {


### PR DESCRIPTION
## Summary
- derive cover-letter templates from the chosen CV style on the server so generated assets stay visually aligned
- include the current template context with improvement requests and refresh download links and cover-letter state when improvements return assets
- update template selection tests to reflect the cover-letter alignment rules

## Testing
- npm test *(fails: environment is missing @babel/preset-env for Jest)*

------
https://chatgpt.com/codex/tasks/task_e_68e208c949a0832ba5857e545f9c7963