### PR TITLE
Ensure cover letter template follows CV selection

### DIFF
--- a/server.js
+++ b/server.js
@@ -1544,17 +1544,24 @@ function selectTemplates({
   const derivedCoverFromPrimary = deriveCoverTemplateFromCv(primaryTemplate);
   const derivedCoverFromSecondary = deriveCoverTemplateFromCv(secondaryTemplate);
   const coverFallbackCandidates = [
-    ...parseTemplateArray(clTemplates),
     coverTemplate1,
     coverTemplate2,
-    defaultClTemplate,
+    ...parseTemplateArray(clTemplates),
     derivedCoverFromPreferred,
     derivedCoverFromPrimary,
     derivedCoverFromSecondary,
+    defaultClTemplate,
   ];
   let parsedCoverTemplates = uniqueValidCoverTemplates(coverFallbackCandidates);
   if (!parsedCoverTemplates.length) {
     parsedCoverTemplates = uniqueValidCoverTemplates([
+      derivedCoverFromPrimary,
+      derivedCoverFromSecondary,
+      ...CL_TEMPLATES,
+    ]);
+  } else {
+    parsedCoverTemplates = uniqueValidCoverTemplates([
+      ...parsedCoverTemplates,
       derivedCoverFromPrimary,
       derivedCoverFromSecondary,
       ...CL_TEMPLATES,

--- a/tests/selectTemplatesGroup.test.js
+++ b/tests/selectTemplatesGroup.test.js
@@ -20,12 +20,29 @@ describe('selectTemplates respects preferred templates and contrast', () => {
   });
 
   test('uses explicit template1 when no preference supplied', () => {
-    const { template1, template2, coverTemplate1 } = selectTemplates({
+    const { template1, template2, coverTemplate1, coverTemplates } = selectTemplates({
       template1: 'vibrant',
     });
     expect(template1).toBe('vibrant');
     expect(template2).not.toBe('vibrant');
     expect(CV_TEMPLATE_GROUPS[template2]).not.toBe(CV_TEMPLATE_GROUPS['vibrant']);
+    expect(coverTemplate1).toBe('cover_modern');
+    expect(coverTemplates[0]).toBe('cover_modern');
+  });
+
+  test('derives cover template from resume style when not provided', () => {
+    const { coverTemplate1, coverTemplates } = selectTemplates({
+      template1: 'classic',
+    });
+    expect(coverTemplate1).toBe('cover_classic');
+    expect(coverTemplates[0]).toBe('cover_classic');
+  });
+
+  test('respects explicit cover template selection', () => {
+    const { coverTemplate1 } = selectTemplates({
+      template1: 'classic',
+      coverTemplate1: 'cover_modern',
+    });
     expect(coverTemplate1).toBe('cover_modern');
   });
 


### PR DESCRIPTION
## Summary
- prioritize the cover letter template that matches the selected CV style when no explicit cover preference is provided
- keep derived and default cover letter options in the available template list while still honoring an explicit cover letter choice
- extend the selectTemplates tests to cover the new fallback ordering and explicit cover template handling

## Testing
- npm test -- selectTemplatesGroup.test.js *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68e20b2e2070832b99dfcf4caa0e1dce