### PR TITLE
Add structured cover letter metadata mapping

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -194,6 +194,23 @@ function isCoverLetterType(type) {
   return COVER_LETTER_TYPES.has(type)
 }
 
+function extractCoverLetterRawText(input) {
+  if (!input) return ''
+  if (typeof input === 'string') return input
+  if (typeof input === 'object') {
+    if (typeof input.raw === 'string') return input.raw
+    if (Array.isArray(input.paragraphs) && input.paragraphs.length) {
+      return input.paragraphs.join('\n\n')
+    }
+  }
+  return ''
+}
+
+function getCoverLetterTextFromFile(file) {
+  if (!file || typeof file !== 'object') return ''
+  return extractCoverLetterRawText(file.text)
+}
+
 function getBaselineScoreFromMatch(matchData) {
   if (!matchData || typeof matchData !== 'object') return null
   const { atsScoreAfter, enhancedScore, atsScoreBefore, originalScore } = matchData
@@ -214,7 +231,7 @@ function deriveCoverLetterStateFromFiles(files) {
     if (!file || typeof file !== 'object') return
     const type = file.type
     if (!isCoverLetterType(type)) return
-    const text = typeof file.text === 'string' ? file.text : ''
+    const text = getCoverLetterTextFromFile(file)
     drafts[type] = text
     originals[type] = text
   })
@@ -2454,7 +2471,7 @@ function App() {
     const isCoverLetter = presentation.category === 'cover' && isCoverLetterType(file.type)
     const coverDraftText = isCoverLetter ? coverLetterDrafts[file.type] ?? '' : ''
     const coverOriginalText = isCoverLetter
-      ? coverLetterOriginals[file.type] ?? (typeof file.text === 'string' ? file.text : '')
+      ? coverLetterOriginals[file.type] ?? getCoverLetterTextFromFile(file)
       : ''
     const coverEdited = isCoverLetter && coverDraftText && coverDraftText !== coverOriginalText
     const downloadStateKey = getDownloadStateKey(file)
@@ -5897,10 +5914,10 @@ function App() {
           const type = coverLetterEditor.type
           const draftText =
             coverLetterDrafts[type] ??
-            (typeof coverLetterEditor.file?.text === 'string' ? coverLetterEditor.file.text : '')
+            getCoverLetterTextFromFile(coverLetterEditor.file)
           const originalText =
             coverLetterOriginals[type] ??
-            (typeof coverLetterEditor.file?.text === 'string' ? coverLetterEditor.file.text : '')
+            getCoverLetterTextFromFile(coverLetterEditor.file)
           const hasChanges = draftText !== originalText
           const wordCount = draftText.trim()
             ? draftText

--- a/tests/mapCoverLetterFields.test.js
+++ b/tests/mapCoverLetterFields.test.js
@@ -1,0 +1,72 @@
+import { mapCoverLetterFields } from '../server.js'
+
+describe('mapCoverLetterFields', () => {
+  test('extracts structured contact, job, and motivation data', () => {
+    const text = [
+      'Dear Hiring Manager,',
+      'I am excited to apply for the Senior Software Engineer role at your company.',
+      'In my previous role I led cross-functional teams using JavaScript and AWS to ship secure APIs.',
+      'Thank you for your consideration.',
+      'Sincerely,',
+      'Jane Candidate'
+    ].join('\n\n')
+
+    const contactDetails = {
+      email: 'jane@example.com',
+      phone: '+1 555-123-4567',
+      linkedin: 'https://linkedin.com/in/janecandidate',
+      cityState: 'Austin, TX',
+      contactLines: [
+        'Email: jane@example.com',
+        'Phone: +1 555-123-4567',
+        'LinkedIn: https://linkedin.com/in/janecandidate'
+      ]
+    }
+
+    const result = mapCoverLetterFields({
+      text,
+      contactDetails,
+      jobTitle: 'Senior Software Engineer',
+      jobDescription:
+        'Design and build scalable services. Collaborate across teams to deliver secure APIs for customers.',
+      jobSkills: ['JavaScript', 'AWS', 'TypeScript'],
+      applicantName: 'Jane Candidate',
+      letterIndex: 1
+    })
+
+    expect(result.raw).toContain('excited to apply')
+    expect(result.greeting).toMatch(/^Dear Hiring Manager/i)
+    expect(result.contact.email).toBe('jane@example.com')
+    expect(result.contact.lines).toContain('Phone: +1 555-123-4567')
+    expect(result.job.title).toBe('Senior Software Engineer')
+    expect(result.job.skills).toEqual(expect.arrayContaining(['JavaScript', 'AWS', 'TypeScript']))
+    expect(result.job.summary).toContain('Design and build scalable services')
+    expect(result.motivation.paragraph).toMatch(/excited to apply/i)
+    expect(result.motivation.keywords).toContain('excited')
+    expect(result.motivation.matchedSkills).toContain('JavaScript')
+    expect(result.closing.salutation).toMatch(/^Sincerely/i)
+    expect(result.closing.signature).toMatch(/Jane Candidate/) 
+    expect(result.metadata.letterIndex).toBe(1)
+    expect(result.metadata.paragraphCount).toBeGreaterThan(0)
+  })
+
+  test('returns defaults when cover letter text is missing', () => {
+    const result = mapCoverLetterFields({
+      text: '',
+      contactDetails: {},
+      jobTitle: 'Product Manager',
+      jobDescription: 'Lead product strategy.',
+      jobSkills: ['Roadmaps'],
+      applicantName: 'Alex Doe',
+      letterIndex: 2
+    })
+
+    expect(result.raw).toBe('')
+    expect(result.paragraphs).toEqual([])
+    expect(result.contact.email).toBe('')
+    expect(result.job.title).toBe('Product Manager')
+    expect(result.job.skills).toEqual(['Roadmaps'])
+    expect(result.motivation.paragraph).toBe('')
+    expect(result.metadata.letterIndex).toBe(2)
+  })
+})

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -551,6 +551,45 @@ describe('/api/process-cv', () => {
     });
   });
 
+  test('cover letter urls include structured metadata', async () => {
+    const res = await request(app)
+      .post('/api/process-cv')
+      .field('manualJobDescription', MANUAL_JOB_DESCRIPTION)
+      .field('linkedinProfileUrl', 'http://linkedin.com/in/example')
+      .attach('resume', Buffer.from('dummy'), 'resume.pdf');
+
+    const coverLetterEntry = res.body.urls.find((entry) => entry.type === 'cover_letter1');
+    expect(coverLetterEntry).toBeTruthy();
+    expect(coverLetterEntry.text).toEqual(
+      expect.objectContaining({
+        raw: expect.any(String),
+        contact: expect.objectContaining({
+          email: expect.any(String),
+          phone: expect.any(String),
+          linkedin: expect.any(String),
+          location: expect.any(String),
+          lines: expect.any(Array),
+        }),
+        job: expect.objectContaining({
+          title: expect.any(String),
+          skills: expect.any(Array),
+          summary: expect.any(String),
+          focus: expect.any(String),
+          matchedSkills: expect.any(Array),
+        }),
+        motivation: expect.objectContaining({
+          paragraph: expect.any(String),
+          keywords: expect.any(Array),
+          matchedSkills: expect.any(Array),
+        }),
+        metadata: expect.objectContaining({
+          paragraphCount: expect.any(Number),
+          letterIndex: expect.any(Number),
+        }),
+      })
+    );
+  });
+
   test('uses provided templates in preferred order', async () => {
     generateContentMock.mockReset();
     generateContentMock.mockResolvedValue({


### PR DESCRIPTION
## Summary
- add a cover letter field mapper that captures contact details, job context, motivation signals, and metadata for API responses
- update the client to read structured cover letter payloads while preserving editing flows
- extend server and unit test coverage to exercise the new structured cover letter data

## Testing
- npm test -- --runTestsByPath tests/mapCoverLetterFields.test.js
- npm test -- --runTestsByPath tests/server.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e20fe16d58832b8e0af0d71ae01d03