### PR TITLE
Fix cover letter text type in generation response

### DIFF
--- a/server.js
+++ b/server.js
@@ -12624,7 +12624,7 @@ async function generateEnhancedDocumentsResponse({
         applicantName,
         letterIndex: name === 'cover_letter1' ? 1 : 2,
       });
-      urlEntry.text = coverLetterFields;
+      urlEntry.text = coverLetterText;
       urlEntry.coverLetterFields = coverLetterFields;
     } else if (entry?.text) {
       urlEntry.text = entry.text;


### PR DESCRIPTION
## Summary
- ensure cover letter URL entries in the generation response continue to expose text content as a string
- retain structured cover letter fields alongside the text for downstream consumers

## Testing
- npm test -- tests/uploadFlow.e2e.test.js *(fails: environment is missing @babel/preset-env dev dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e2168f852c832b99f8cb3ec3090f2a