### PR TITLE
Ensure cover letter URLs expose structured metadata

### DIFF
--- a/server.js
+++ b/server.js
@@ -12624,8 +12624,9 @@ async function generateEnhancedDocumentsResponse({
         applicantName,
         letterIndex: name === 'cover_letter1' ? 1 : 2,
       });
-      urlEntry.text = coverLetterText;
+      urlEntry.text = coverLetterFields;
       urlEntry.coverLetterFields = coverLetterFields;
+      urlEntry.rawText = coverLetterText;
     } else if (entry?.text) {
       urlEntry.text = entry.text;
     } else if (name !== 'original_upload') {

--- a/tests/uploadFlow.e2e.test.js
+++ b/tests/uploadFlow.e2e.test.js
@@ -152,7 +152,16 @@ describe('upload to download flow (e2e)', () => {
 
     generationResponse.body.urls.forEach((entry) => {
       expect(entry.url).toContain('https://example.com/');
-      if (entry.type !== 'original_upload') {
+      if (entry.type === 'cover_letter1' || entry.type === 'cover_letter2') {
+        expect(entry.text).toEqual(
+          expect.objectContaining({
+            raw: expect.any(String),
+            contact: expect.any(Object),
+            job: expect.any(Object),
+          })
+        );
+        expect(entry.text.raw.length).toBeGreaterThan(0);
+      } else if (entry.type !== 'original_upload') {
         expect(typeof entry.text).toBe('string');
         expect(entry.text.length).toBeGreaterThan(0);
       }


### PR DESCRIPTION
## Summary
- return structured cover letter metadata in the `text` field while preserving the raw string separately
- update the upload flow E2E test to validate the structured cover letter shape

## Testing
- npm test -- server.test.js *(fails: environment is missing @babel/preset-env)*
- npm test *(fails: environment is missing @babel/preset-env and jest-environment-jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68e2177a143c832b9cb1ad938719fbaf