### PR TITLE
Fix LinkedIn profile URL reference in enhanced docs route

### DIFF
--- a/server.js
+++ b/server.js
@@ -13068,6 +13068,7 @@ app.post(
 
     const submittedLinkedIn =
       typeof req.body.linkedinProfileUrl === 'string' ? req.body.linkedinProfileUrl.trim() : '';
+    const linkedinProfileUrl = submittedLinkedIn || '';
     const profileIdentifier =
       resolveProfileIdentifier({
         linkedinProfileUrl: submittedLinkedIn,


### PR DESCRIPTION
## Summary
- ensure the generate-enhanced-docs handler defines the linkedinProfileUrl before it is used
- pass the normalized LinkedIn URL to downstream helpers to prevent runtime ReferenceErrors during document generation

## Testing
- npm test -- tests/uploadFlow.e2e.test.js *(fails: environment missing @babel/preset-env and jest-environment-jsdom packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e2242896ec832ba490888a89315925