### PR TITLE
Enforce job description requirement after resume upload

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1858,6 +1858,21 @@ function App() {
   }, [cvFile, handleScoreSubmit, isProcessing, manualJobDescription, scoreComplete])
 
   useEffect(() => {
+    if (!cvFile) {
+      return
+    }
+    if (manualJobDescription.trim()) {
+      return
+    }
+    setManualJobDescriptionRequired((prev) => {
+      if (!prev) {
+        manualJobDescriptionRef.current?.focus?.()
+      }
+      return true
+    })
+  }, [cvFile, manualJobDescription])
+
+  useEffect(() => {
     if (manualJobDescriptionRequired && manualJobDescription.trim()) {
       setManualJobDescriptionRequired(false)
     }


### PR DESCRIPTION
## Summary
- automatically flag the job description textarea as required once a CV is uploaded with no text provided
- focus the job description field to prompt users to paste the JD before continuing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e22c8c7868832bb33c292cc5ad5131