### PR TITLE
Expose template metadata for generated downloads

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -506,6 +506,16 @@ describe('/api/process-cv', () => {
 
     res.body.urls.forEach((entry) => {
       expect(entry.url).toMatch(/\.pdf\?X-Amz-Signature=[^&]+&X-Amz-Expires=3600$/);
+      expect(entry.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(entry.templateName).toEqual(expect.any(String));
+      expect(entry.templateName.trim().length).toBeGreaterThan(0);
+      expect(entry.templateId).toEqual(expect.any(String));
+      expect(entry.templateId.trim().length).toBeGreaterThan(0);
+      if (entry.type === 'original_upload' || entry.type === 'version1' || entry.type === 'version2') {
+        expect(entry.templateType).toBe('resume');
+      } else if (entry.type === 'cover_letter1' || entry.type === 'cover_letter2') {
+        expect(entry.templateType).toBe('cover');
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- include template display helpers so each generated download response carries template ids, names, and timestamps
- surface the provided template metadata in the client download cards to keep template name and generated timestamp visible for every version
- extend the server integration test to cover the new metadata on download URLs

## Testing
- npm test -- --runTestsByPath tests/server.test.js *(fails: missing @babel/preset-env in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e23bf5638c832b833dcad024629f79