### PR TITLE
Add dropdown template selection and require preview before downloads

### DIFF
--- a/client/src/__tests__/AppTemplateSelection.test.jsx
+++ b/client/src/__tests__/AppTemplateSelection.test.jsx
@@ -1,32 +1,30 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen, fireEvent, within } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import TemplateSelector from '../components/TemplateSelector.jsx'
 
 describe('TemplateSelector', () => {
   const options = [
     { id: 'modern', name: 'Modern Minimal', description: 'Minimal layout with ATS-safe spacing.' },
-    { id: 'professional', name: 'Professional Blue', description: 'Conservative layout with blue dividers.' }
+    {
+      id: 'professional',
+      name: 'Professional Blue',
+      description: 'Conservative layout with blue dividers.'
+    }
   ]
 
-  it('highlights the selected template and updates when a new template is chosen', () => {
+  it('reflects the selected template and updates when a new template is chosen', () => {
     const handleSelect = jest.fn()
-    render(
-      <TemplateSelector
-        options={options}
-        selectedTemplate="modern"
-        onSelect={handleSelect}
-      />
+    render(<TemplateSelector options={options} selectedTemplate="modern" onSelect={handleSelect} />)
+
+    const dropdown = screen.getByRole('combobox', { name: /Template Style/i })
+    expect(dropdown).toHaveValue('modern')
+    expect(screen.getByTestId('template-selector-selected-description')).toHaveTextContent(
+      /Minimal layout with ATS-safe spacing\./i
     )
 
-    const modernButton = screen.getByRole('radio', { name: /Modern Minimal/i })
-    expect(within(modernButton).getByText(/Selected/i)).toBeInTheDocument()
-
-    const professionalButton = screen.getByRole('radio', { name: /Professional Blue/i })
-    expect(within(professionalButton).queryByText(/Selected/i)).toBeNull()
-
-    fireEvent.click(professionalButton)
+    fireEvent.change(dropdown, { target: { value: 'professional' } })
     expect(handleSelect).toHaveBeenCalledWith('professional')
   })
 
@@ -39,8 +37,6 @@ describe('TemplateSelector', () => {
       />
     )
 
-    expect(
-      screen.getByText(/You tried Professional, Modern, and Classic/i)
-    ).toBeInTheDocument()
+    expect(screen.getByText(/You tried Professional, Modern, and Classic/i)).toBeInTheDocument()
   })
 })

--- a/client/src/components/TemplateSelector.jsx
+++ b/client/src/components/TemplateSelector.jsx
@@ -11,57 +11,56 @@ function TemplateSelector({
   if (!options.length) return null
 
   const labelId = `${idPrefix}-label`
+  const descriptionId = description ? `${idPrefix}-description` : undefined
+  const historyId = historySummary ? `${idPrefix}-history` : undefined
+  const selectId = `${idPrefix}-select`
+  const selectedOption = options.find((option) => option.id === selectedTemplate) || null
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       <div>
-        <p className="text-sm font-semibold text-purple-700" id={labelId}>
+        <label className="text-sm font-semibold text-purple-700" id={labelId} htmlFor={selectId}>
           {title}
-        </p>
-        {description && <p className="text-xs text-purple-600">{description}</p>}
+        </label>
+        {description && (
+          <p className="text-xs text-purple-600" id={descriptionId}>
+            {description}
+          </p>
+        )}
       </div>
       {historySummary && (
-        <p className="text-xs text-purple-500">
+        <p className="text-xs text-purple-500" id={historyId}>
           You tried {historySummary}
         </p>
       )}
-      <div
-        id={idPrefix}
-        role="radiogroup"
-        className="grid grid-cols-1 md:grid-cols-2 gap-3"
-        data-testid={idPrefix}
-        aria-labelledby={labelId}
-      >
-        {options.map((option) => {
-          const isSelected = option.id === selectedTemplate
-          const stateClass = isSelected
-            ? 'border-purple-500 bg-purple-50 shadow-md'
-            : 'border-purple-200 bg-white'
-
-          return (
-            <button
-              key={option.id}
-              type="button"
-              role="radio"
-              aria-checked={isSelected}
-              aria-disabled={disabled || undefined}
-              onClick={() => onSelect?.(option.id)}
-              disabled={disabled}
-              className={`text-left rounded-2xl border p-4 transition transform hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-purple-400 ${stateClass} ${
-                disabled ? 'cursor-not-allowed opacity-60' : ''
-              }`}
-              data-testid={`${idPrefix}-option-${option.id}`}
-            >
-              <h3 className="text-lg font-semibold text-purple-800">{option.name}</h3>
-              <p className="text-sm text-purple-600">{option.description}</p>
-              {isSelected && (
-                <span className="mt-2 inline-block text-xs font-semibold text-purple-500 uppercase">
-                  Selected
-                </span>
-              )}
-            </button>
-          )
-        })}
+      <div>
+        <select
+          id={selectId}
+          name={selectId}
+          className={`w-full rounded-2xl border border-purple-200 bg-white px-4 py-3 text-sm text-purple-900 shadow-sm transition focus:border-purple-400 focus:outline-none focus:ring-2 focus:ring-purple-300 ${
+            disabled ? 'cursor-not-allowed bg-purple-50 text-purple-400' : ''
+          }`}
+          aria-labelledby={labelId}
+          aria-describedby={[descriptionId, historyId].filter(Boolean).join(' ') || undefined}
+          value={selectedTemplate || ''}
+          onChange={(event) => onSelect?.(event.target.value)}
+          disabled={disabled}
+          data-testid={selectId}
+        >
+          <option value="" disabled>
+            Select a template
+          </option>
+          {options.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.name}
+            </option>
+          ))}
+        </select>
+        {selectedOption && (
+          <p className="mt-2 text-xs text-purple-600" data-testid={`${idPrefix}-selected-description`}>
+            {selectedOption.description}
+          </p>
+        )}
       </div>
     </div>
   )

--- a/client/src/components/__tests__/TemplateSelector.test.jsx
+++ b/client/src/components/__tests__/TemplateSelector.test.jsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen, fireEvent, within } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import TemplateSelector from '../TemplateSelector.jsx'
 
 describe('TemplateSelector', () => {
@@ -10,49 +10,33 @@ describe('TemplateSelector', () => {
     { id: 'professional', name: 'Professional Blue', description: 'Classic layout.' }
   ]
 
-  it('renders options and highlights the selected template', () => {
+  it('renders options and reflects the selected template', () => {
     const { rerender } = render(
-      <TemplateSelector
-        options={options}
-        selectedTemplate="modern"
-        onSelect={jest.fn()}
-      />
+      <TemplateSelector options={options} selectedTemplate="modern" onSelect={jest.fn()} />
     )
 
-    const selectedBadge = within(
-      screen.getByTestId('template-selector-option-modern')
-    ).getByText(/selected/i)
-    expect(selectedBadge).toBeInTheDocument()
-    expect(
-      within(screen.getByTestId('template-selector-option-professional')).queryByText(/selected/i)
-    ).not.toBeInTheDocument()
-
-    rerender(
-      <TemplateSelector
-        options={options}
-        selectedTemplate="professional"
-        onSelect={jest.fn()}
-      />
+    const select = screen.getByRole('combobox', { name: /Template Style/i })
+    expect(select).toHaveValue('modern')
+    expect(screen.getByTestId('template-selector-selected-description')).toHaveTextContent(
+      /Two-column balance\./i
     )
 
-    const newlySelectedBadge = within(
-      screen.getByTestId('template-selector-option-professional')
-    ).getByText(/selected/i)
-    expect(newlySelectedBadge).toBeInTheDocument()
+    rerender(<TemplateSelector options={options} selectedTemplate="professional" onSelect={jest.fn()} />)
+
+    expect(select).toHaveValue('professional')
+    expect(screen.getByTestId('template-selector-selected-description')).toHaveTextContent(
+      /Classic layout\./i
+    )
   })
 
   it('invokes onSelect when a template is chosen', () => {
     const handleSelect = jest.fn()
     render(
-      <TemplateSelector
-        options={options}
-        selectedTemplate="modern"
-        onSelect={handleSelect}
-      />
+      <TemplateSelector options={options} selectedTemplate="modern" onSelect={handleSelect} />
     )
 
-    const optionButton = screen.getByTestId('template-selector-option-professional')
-    fireEvent.click(optionButton)
+    const select = screen.getByRole('combobox', { name: /Template Style/i })
+    fireEvent.change(select, { target: { value: 'professional' } })
 
     expect(handleSelect).toHaveBeenCalledWith('professional')
   })
@@ -68,9 +52,9 @@ describe('TemplateSelector', () => {
       />
     )
 
-    const optionButton = screen.getByTestId('template-selector-option-professional')
-    expect(optionButton).toBeDisabled()
-    fireEvent.click(optionButton)
+    const select = screen.getByRole('combobox', { name: /Template Style/i })
+    expect(select).toBeDisabled()
+    fireEvent.change(select, { target: { value: 'professional' } })
     expect(handleSelect).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- replace the template selector tile grid with a single dropdown that keeps the selected template description visible
- require users to open the preview before downloading, queuing resume downloads inside the modal and routing cover-letter downloads through the editor
- extend the preview modal with confirmation messaging and an inline download button that reflects link state

## Testing
- npm test *(fails: Cannot find package '@babel/preset-env' in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2406dc5c0832bad189a11dea4f06a