### PR TITLE
Prevent TemplateSelector from firing onSelect while disabled

### DIFF
--- a/client/src/components/TemplateSelector.jsx
+++ b/client/src/components/TemplateSelector.jsx
@@ -16,6 +16,11 @@ function TemplateSelector({
   const selectId = `${idPrefix}-select`
   const selectedOption = options.find((option) => option.id === selectedTemplate) || null
 
+  const handleChange = (event) => {
+    if (disabled || event.target.disabled) return
+    onSelect?.(event.target.value)
+  }
+
   return (
     <div className="space-y-3">
       <div>
@@ -43,7 +48,7 @@ function TemplateSelector({
           aria-labelledby={labelId}
           aria-describedby={[descriptionId, historyId].filter(Boolean).join(' ') || undefined}
           value={selectedTemplate || ''}
-          onChange={(event) => onSelect?.(event.target.value)}
+          onChange={handleChange}
           disabled={disabled}
           data-testid={selectId}
         >


### PR DESCRIPTION
## Summary
- guard TemplateSelector's change handler so disabled dropdowns don't trigger onSelect

## Testing
- npm test -- TemplateSelector *(fails: environment is missing jest-environment-jsdom and related Babel presets in this context)*

------
https://chatgpt.com/codex/tasks/task_e_68e246e7b120832bb215808a75ff1c47