### PR TITLE
Nest cover letter PDFs under dedicated folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,16 +376,22 @@ ownload URLs expire after one hour:
 
 `originalScore` represents the percentage match between the job description and the uploaded resume. `enhancedScore` is the best match achieved by the generated resumes. `table` details how each job skill matched, `addedSkills` shows skills newly matched in the enhanced resume, and `missingSkills` lists skills from the job description still absent.
 
-S3 keys follow the pattern `cv/<candidate>/<ISO-date>/<session-id>/<document>.pdf`, where `<document>` identifies the variant (`original.pdf`, `enhanced_<template>.pdf`, `cover_letter_<template>.pdf`). The change log and extracted text live alongside the PDFs under `cv/<candidate>/<ISO-date>/<session-id>/artifacts/`. The API returns presigned download URLs along with an ISO 8601 timestamp (`expiresAt`) that indicates when each link will expire.
+S3 keys follow the pattern `cv/<candidate>/<ISO-date>/<session-id>/generated/<document>.pdf`, where `<document>` identifies the variant (`original.pdf`, `enhanced_<template>.pdf`, `cover_letter_<template>.pdf`). Cover letters are stored inside `generated/cover_letter/` so they are easy to filter. The change log and extracted text live alongside the PDFs under `cv/<candidate>/<ISO-date>/<session-id>/generated/artifacts/`. The API returns presigned download URLs along with an ISO 8601 timestamp (`expiresAt`) that indicates when each link will expire.
 
 ```
 cv/jane_doe/2025-01-15/1fb6e8c6-7b2f-46dc-89c9-1dd2efdd8793/
-├── original.pdf
-├── enhanced_modern_classic.pdf
-├── enhanced_elegant_slate.pdf
-├── cover_letter_refined.pdf
-├── cover_letter_refined_2.pdf
-└── artifacts/
+├── generated/
+│   ├── original.pdf
+│   ├── enhanced_modern_classic.pdf
+│   ├── enhanced_elegant_slate.pdf
+│   ├── cover_letter/
+│   │   ├── cover_letter_refined.pdf
+│   │   └── cover_letter_refined_2.pdf
+│   └── artifacts/
+│       ├── original.json
+│       ├── version1.json
+│       ├── version2.json
+│       └── changelog.json
     ├── original.json
     ├── version1.json
     ├── version2.json

--- a/server.js
+++ b/server.js
@@ -12521,7 +12521,8 @@ async function generateEnhancedDocumentsResponse({
       variant: name,
     });
     const uniqueBaseName = ensureUniqueFileBase(baseName, usedFileBaseNames);
-    const key = `${generatedPrefix}${uniqueBaseName}.pdf`;
+    const subdirectory = isCoverLetter ? 'cover_letter/' : '';
+    const key = `${generatedPrefix}${subdirectory}${uniqueBaseName}.pdf`;
 
     const resolvedTemplateParams = resolveTemplateParamsConfig(
       templateParamsConfig,


### PR DESCRIPTION
## Summary
- store generated cover letters under a dedicated `cover_letter/` subdirectory to match expected S3 key structure
- document the new generated asset layout and folder hierarchy in the README

## Testing
- npm test -- tests/uploadFlow.e2e.test.js *(fails: missing @babel/preset-env in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e253a9824c832b86d79e900980548f