### PR TITLE
Restructure generated document S3 keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,22 +376,16 @@ ownload URLs expire after one hour:
 
 `originalScore` represents the percentage match between the job description and the uploaded resume. `enhancedScore` is the best match achieved by the generated resumes. `table` details how each job skill matched, `addedSkills` shows skills newly matched in the enhanced resume, and `missingSkills` lists skills from the job description still absent.
 
-S3 keys follow the pattern `cv/<candidate>/<ISO-date>/<session-id>/generated/<document>.pdf`, where `<document>` identifies the variant (`original.pdf`, `enhanced_<template>.pdf`, `cover_letter_<template>.pdf`). Cover letters are stored inside `generated/cover_letter/` so they are easy to filter. The change log and extracted text live alongside the PDFs under `cv/<candidate>/<ISO-date>/<session-id>/generated/artifacts/`. The API returns presigned download URLs along with an ISO 8601 timestamp (`expiresAt`) that indicates when each link will expire.
+S3 keys follow the pattern `cv/<candidate>/<ISO-date>/<session-id>/<document>.pdf`, where `<document>` identifies the variant (`original.pdf`, `enhanced_<template>.pdf`, `cover_letter_<template>.pdf`). Consistent file names keep cover letters (`cover_letter_<template>.pdf`) easy to filter without relying on nested folders. The change log and extracted text live alongside the PDFs under `cv/<candidate>/<ISO-date>/<session-id>/artifacts/`. The API returns presigned download URLs along with an ISO 8601 timestamp (`expiresAt`) that indicates when each link will expire.
 
 ```
 cv/jane_doe/2025-01-15/1fb6e8c6-7b2f-46dc-89c9-1dd2efdd8793/
-├── generated/
-│   ├── original.pdf
-│   ├── enhanced_modern_classic.pdf
-│   ├── enhanced_elegant_slate.pdf
-│   ├── cover_letter/
-│   │   ├── cover_letter_refined.pdf
-│   │   └── cover_letter_refined_2.pdf
-│   └── artifacts/
-│       ├── original.json
-│       ├── version1.json
-│       ├── version2.json
-│       └── changelog.json
+├── original.pdf
+├── enhanced_modern_classic.pdf
+├── enhanced_elegant_slate.pdf
+├── cover_letter_refined.pdf
+├── cover_letter_refined_2.pdf
+└── artifacts/
     ├── original.json
     ├── version1.json
     ├── version2.json

--- a/server.js
+++ b/server.js
@@ -8732,7 +8732,7 @@ function buildDocumentSessionPrefix({
     fallback: new Date().toISOString().slice(0, 10),
   });
   const safeJob = sanitizeS3KeyComponent(jobSegment);
-  let prefix = `${safeOwner}/cv/`;
+  let prefix = `cv/${safeOwner}/`;
   if (safeDate) {
     prefix += `${safeDate}/`;
   }
@@ -12408,7 +12408,7 @@ async function generateEnhancedDocumentsResponse({
         dateSegment: generationDateSegment,
         jobSegment: jobSegmentForKeys,
       });
-  const generatedPrefix = `${prefix}generated/`;
+  const generatedPrefix = `${prefix}`;
   const coverLetter1Tokens = tokenizeCoverLetterText(coverData.cover_letter1 || '', {
     letterIndex: 1,
   });
@@ -12521,8 +12521,7 @@ async function generateEnhancedDocumentsResponse({
       variant: name,
     });
     const uniqueBaseName = ensureUniqueFileBase(baseName, usedFileBaseNames);
-    const subdirectory = isCoverLetter ? 'cover_letter/' : '';
-    const key = `${generatedPrefix}${subdirectory}${uniqueBaseName}.pdf`;
+    const key = `${generatedPrefix}${uniqueBaseName}.pdf`;
 
     const resolvedTemplateParams = resolveTemplateParamsConfig(
       templateParamsConfig,

--- a/tests/uploadFlow.e2e.test.js
+++ b/tests/uploadFlow.e2e.test.js
@@ -175,6 +175,6 @@ describe('upload to download flow (e2e)', () => {
 
     expect(pdfKeys.length).toBeGreaterThanOrEqual(4);
     expect(pdfKeys.join('\n')).toContain('/cv/');
-    expect(pdfKeys.join('\n')).toContain('/cover_letter/');
+    expect(pdfKeys.join('\n')).toContain('cover_letter_');
   });
 });


### PR DESCRIPTION
## Summary
- update the document session prefix so generated artifacts live under `cv/<candidate>/...`
- flatten the cover letter keys and keep PDF base names unique without subdirectories
- refresh documentation and tests to reflect the new S3 layout

## Testing
- npm test -- --runTestsByPath tests/server.test.js tests/uploadFlow.e2e.test.js *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68e255f39e6c832b9a2205ca391e1dae