### PR TITLE
Adjust S3 key expectations in tests

### DIFF
--- a/tests/awsStorage.integration.test.js
+++ b/tests/awsStorage.integration.test.js
@@ -38,7 +38,7 @@ describe('AWS integrations for /api/process-cv', () => {
       (command) =>
         command.type === 'CopyObjectCommand' &&
         typeof command.key === 'string' &&
-        command.key.includes('/cv/')
+        command.key.includes('cv/')
     );
     expect(relocatedUpload).toBeTruthy();
 
@@ -52,7 +52,7 @@ describe('AWS integrations for /api/process-cv', () => {
     expect(tempDelete).toBeTruthy();
 
     const rawUploadKey = relocatedUpload.key;
-    expect(rawUploadKey).toContain('/cv/');
+    expect(rawUploadKey).toContain('cv/');
 
     const metadataCall = commandSummaries.find((command) =>
       typeof command.key === 'string' && command.key.endsWith('log.json')

--- a/tests/uploadFlow.e2e.test.js
+++ b/tests/uploadFlow.e2e.test.js
@@ -174,7 +174,7 @@ describe('upload to download flow (e2e)', () => {
       .filter((key) => typeof key === 'string' && key.endsWith('.pdf'));
 
     expect(pdfKeys.length).toBeGreaterThanOrEqual(4);
-    expect(pdfKeys.join('\n')).toContain('/cv/');
+    expect(pdfKeys.join('\n')).toContain('cv/');
     expect(pdfKeys.join('\n')).toContain('cover_letter_');
   });
 });


### PR DESCRIPTION
## Summary
- update upload flow and AWS integration tests to accept S3 keys prefixed with `cv/`

## Testing
- npm test -- tests/uploadFlow.e2e.test.js tests/awsStorage.integration.test.js *(fails: missing @babel/preset-env dependency in environment)*
- npm test *(fails: missing @babel/preset-env and jest-environment-jsdom dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e259c80080832b92d096928ab7f2e1