### PR TITLE
Replace anonymisation helpers with normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Because the configuration is loaded and cached once, the service reuses the same
 
 ### Privacy and data handling
 
-- DynamoDB stores candidate names, LinkedIn URLs, IP addresses, and user agents exactly as submitted so ongoing sessions can be resumed without any background cleanup processes.
+- DynamoDB stores candidate names, LinkedIn URLs, IP addresses, and user agents exactly as submitted (only trimmed for whitespace) so ongoing sessions can be resumed without any anonymisation or background cleanup processes.
 - Generated PDFs, cover letters, and change logs are stored in S3 only for the active session that produced them. Old keys are overwritten as users regenerate documents, so the bucket naturally keeps just the current versions without relying on scheduled deletion jobs.
 
 ### Required parameters for AWS deployment


### PR DESCRIPTION
## Summary
- replace the anonymisation helper with a normalizePersonalData utility and use it wherever persisted records are created
- update DynamoDB template preference writes to capture the normalized user identifier in a dedicated userIdValue attribute
- clarify privacy documentation to note that persisted personal fields are stored exactly as submitted without anonymisation

## Testing
- npm test -- --runInBand *(fails: missing dev dependency @babel/preset-env in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e25eaa53d4832ba59a639662c4fca3