### PR TITLE
Gracefully handle PDF generation failures

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -27,7 +27,7 @@ import parseJobDescriptionText from './utils/parseJobDescriptionText.js'
 import { buildCategoryChangeLog } from './utils/changeLogCategorySummaries.js'
 
 const CV_GENERATION_ERROR_MESSAGE =
-  'Could not enhance CV; your formatting remained untouched.'
+  'Could not generate PDF, please try again'
 
 const SCORE_UPDATE_IN_PROGRESS_MESSAGE =
   'Please wait for the current ATS score refresh to finish before applying another improvement.'
@@ -2588,7 +2588,7 @@ function App() {
       setCoverLetterClipboardStatus('Updated PDF downloaded.')
     } catch (err) {
       console.error('Cover letter PDF generation failed', err)
-      setCoverLetterDownloadError('Unable to create the PDF. Please try again.')
+      setCoverLetterDownloadError('Could not generate PDF, please try again')
     } finally {
       setIsCoverLetterDownloading(false)
     }

--- a/server.js
+++ b/server.js
@@ -153,7 +153,7 @@ axiosResponseInterceptor?.use(
 );
 
 const CV_GENERATION_ERROR_MESSAGE =
-  'Could not enhance CV; your formatting remained untouched.';
+  'Could not generate PDF, please try again';
 
 let chromium;
 let puppeteerCore;
@@ -12269,7 +12269,7 @@ async function generateEnhancedDocumentsResponse({
       level: 'error',
       message: 'Unable to construct resume variants from extracted content',
     });
-    sendError(res, 500, 'AI_RESPONSE_INVALID', 'AI response invalid');
+    sendError(res, 500, 'AI_RESPONSE_INVALID', CV_GENERATION_ERROR_MESSAGE);
     return null;
   }
 
@@ -12716,9 +12716,9 @@ async function generateEnhancedDocumentsResponse({
       jobId,
       event: 'generation_no_outputs',
       level: 'error',
-      message: 'AI response invalid',
+      message: CV_GENERATION_ERROR_MESSAGE,
     });
-    sendError(res, 500, 'AI_RESPONSE_INVALID', 'AI response invalid');
+    sendError(res, 500, 'AI_RESPONSE_INVALID', CV_GENERATION_ERROR_MESSAGE);
     return null;
   }
 


### PR DESCRIPTION
## Summary
- replace the PDF generation failure copy across server and client with "Could not generate PDF, please try again"
- ensure API responses for missing document variants and outputs surface the same friendly error message
- align cover letter download error handling with the unified PDF failure message

## Testing
- npm test -- --runTestsByPath tests/server.test.js *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68e2607154d0832bb9e51a5837f51c1d