### PR TITLE
Add structured error handling and expose file/type URLs

### DIFF
--- a/client/src/utils/normalizeOutputFiles.js
+++ b/client/src/utils/normalizeOutputFiles.js
@@ -1,4 +1,4 @@
-const URL_KEYS = ['url', 'downloadUrl', 'href', 'link', 'signedUrl']
+const URL_KEYS = ['url', 'fileUrl', 'typeUrl', 'downloadUrl', 'href', 'link', 'signedUrl']
 const EXPIRES_AT_KEYS = [
   'expiresAt',
   'expiryAt',

--- a/server.js
+++ b/server.js
@@ -11861,13 +11861,12 @@ app.get('/', async (req, res) => {
     logStructured('error', 'client_ui_load_failed', {
       error: serializeError(err),
     });
-    res
-      .status(500)
-      .json({
-        status: 'error',
-        message:
-          'Client application is unavailable. Please try again later or contact support.',
-      });
+    sendError(
+      res,
+      500,
+      'CLIENT_UI_UNAVAILABLE',
+      'Client application is unavailable. Please try again later or contact support.'
+    );
   }
 });
 
@@ -12487,9 +12486,12 @@ async function generateEnhancedDocumentsResponse({
       const expiresAt = new Date(
         Date.now() + URL_EXPIRATION_SECONDS * 1000
       ).toISOString();
+      const typeFragment = encodeURIComponent('original_upload');
       urls.push({
         type: 'original_upload',
         url: originalSignedUrl,
+        fileUrl: originalSignedUrl,
+        typeUrl: `${originalSignedUrl}#${typeFragment}`,
         expiresAt,
         generatedAt: artifactTimestamp,
         templateId: 'original',
@@ -12595,9 +12597,12 @@ async function generateEnhancedDocumentsResponse({
     const expiresAt = new Date(
       Date.now() + URL_EXPIRATION_SECONDS * 1000
     ).toISOString();
+    const typeFragment = encodeURIComponent(name);
     const urlEntry = {
       type: name,
       url: signedUrl,
+      fileUrl: signedUrl,
+      typeUrl: `${signedUrl}#${typeFragment}`,
       expiresAt,
       generatedAt: artifactTimestamp,
     };

--- a/tests/improvementRoutes.test.js
+++ b/tests/improvementRoutes.test.js
@@ -172,8 +172,12 @@ describe('targeted improvement routes', () => {
         expect.objectContaining({
           type: expect.any(String),
           url: expect.stringMatching(/\.pdf\?X-Amz-Signature=[^&]+&X-Amz-Expires=3600$/),
+          fileUrl: expect.stringMatching(/\.pdf\?X-Amz-Signature=[^&]+&X-Amz-Expires=3600$/),
+          typeUrl: expect.stringMatching(/\.pdf\?X-Amz-Signature=[^&]+&X-Amz-Expires=3600#.+$/),
         })
       );
+      const fragment = entry.typeUrl.slice(entry.typeUrl.indexOf('#') + 1);
+      expect(decodeURIComponent(fragment)).toBe(entry.type);
     });
   });
 
@@ -273,8 +277,12 @@ describe('targeted improvement routes', () => {
         expect.objectContaining({
           type: expect.any(String),
           url: expect.stringMatching(/\.pdf\?X-Amz-Signature=[^&]+&X-Amz-Expires=3600$/),
+          fileUrl: expect.stringMatching(/\.pdf\?X-Amz-Signature=[^&]+&X-Amz-Expires=3600$/),
+          typeUrl: expect.stringMatching(/\.pdf\?X-Amz-Signature=[^&]+&X-Amz-Expires=3600#.+$/),
         })
       );
+      const fragment = entry.typeUrl.slice(entry.typeUrl.indexOf('#') + 1);
+      expect(decodeURIComponent(fragment)).toBe(entry.type);
     });
   });
 

--- a/tests/improvements.e2e.test.js
+++ b/tests/improvements.e2e.test.js
@@ -366,8 +366,12 @@ describe('targeted improvement endpoints (integration)', () => {
           expect.objectContaining({
             type: expect.any(String),
             url: expect.stringMatching(/\.pdf\?X-Amz-Signature=[^&]+&X-Amz-Expires=3600$/),
+            fileUrl: expect.stringMatching(/\.pdf\?X-Amz-Signature=[^&]+&X-Amz-Expires=3600$/),
+            typeUrl: expect.stringMatching(/\.pdf\?X-Amz-Signature=[^&]+&X-Amz-Expires=3600#.+$/),
           })
         );
+        const fragment = entry.typeUrl.slice(entry.typeUrl.indexOf('#') + 1);
+        expect(decodeURIComponent(fragment)).toBe(entry.type);
       });
     }
 

--- a/tests/processCv.e2e.test.js
+++ b/tests/processCv.e2e.test.js
@@ -29,8 +29,13 @@ describe('end-to-end CV processing', () => {
         expect.objectContaining({
           type: expect.any(String),
           url: expect.stringContaining('https://'),
+          fileUrl: expect.stringContaining('https://'),
+          typeUrl: expect.stringContaining('https://'),
         })
       );
+      expect(entry.typeUrl).toContain('#');
+      const fragment = entry.typeUrl.slice(entry.typeUrl.indexOf('#') + 1);
+      expect(decodeURIComponent(fragment)).toBe(entry.type);
     });
     expect(typeof response.body.applicantName).toBe('string');
     expect(typeof response.body.originalScore).toBe('number');

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -510,6 +510,10 @@ describe('/api/process-cv', () => {
 
     res.body.urls.forEach((entry) => {
       expect(entry.url).toMatch(/\.pdf\?X-Amz-Signature=[^&]+&X-Amz-Expires=3600$/);
+      expect(entry.fileUrl).toMatch(/\.pdf\?X-Amz-Signature=[^&]+&X-Amz-Expires=3600$/);
+      expect(entry.typeUrl).toMatch(/\.pdf\?X-Amz-Signature=[^&]+&X-Amz-Expires=3600#.+$/);
+      const fragment = entry.typeUrl.slice(entry.typeUrl.indexOf('#') + 1);
+      expect(decodeURIComponent(fragment)).toBe(entry.type);
       expect(entry.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
       expect(entry.templateName).toEqual(expect.any(String));
       expect(entry.templateName.trim().length).toBeGreaterThan(0);

--- a/tests/uploadFlow.e2e.test.js
+++ b/tests/uploadFlow.e2e.test.js
@@ -152,6 +152,11 @@ describe('upload to download flow (e2e)', () => {
 
     generationResponse.body.urls.forEach((entry) => {
       expect(entry.url).toContain('https://example.com/');
+      expect(entry.fileUrl).toContain('https://example.com/');
+      expect(entry.typeUrl).toContain('https://example.com/');
+      expect(entry.typeUrl).toContain('#');
+      const fragment = entry.typeUrl.slice(entry.typeUrl.indexOf('#') + 1);
+      expect(decodeURIComponent(fragment)).toBe(entry.type);
       if (entry.type === 'cover_letter1' || entry.type === 'cover_letter2') {
         expect(entry.text).toEqual(
           expect.objectContaining({


### PR DESCRIPTION
## Summary
- ensure the root route returns structured API errors via the shared helper
- include both fileUrl and typeUrl metadata on generated document links and surface them in tests
- let the client output normalizer understand the new URL keys for downstream consumers

## Testing
- npm test *(fails: missing optional Babel/JSDOM dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e261ac612c832b858e4e243b8bf075