### PR TITLE
Normalize API error details and enforce output URL metadata

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -361,6 +361,7 @@ describe('/api/process-cv', () => {
     expect(failed.body.success).toBe(false);
     expect(failed.body.error.code).toBe('JOB_DESCRIPTION_REQUIRED');
     expect(failed.body.error.message).toBe('manualJobDescription required');
+    expect(failed.body.error.details).toEqual({});
 
     const manual = await request(app)
       .post('/api/process-cv')
@@ -1154,7 +1155,27 @@ describe('/api/process-cv', () => {
     });
   });
 
+});
+
+describe('/api/generate-enhanced-docs', () => {
+  test('responds with structured details when jobId is missing', async () => {
+    const response = await request(app).post('/api/generate-enhanced-docs').send({
+      resumeText: 'Sample resume text',
+      jobDescriptionText: 'A detailed description of the role.',
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      success: false,
+      error: expect.objectContaining({
+        code: 'JOB_ID_REQUIRED',
+        message: 'jobId is required to generate enhanced documents.',
+        requestId: expect.any(String),
+        details: {},
+      }),
+    });
   });
+});
 
   describe('classifyDocument', () => {
   test('identifies resumes by section structure', async () => {


### PR DESCRIPTION
## Summary
- normalize API error responses so details are always structured objects
- ensure generated document metadata always includes file/type URLs, even when reused
- extend server tests to assert structured error details for missing inputs

## Testing
- npm test -- --runTestsByPath tests/server.test.js tests/publishedCloudfront.test.js *(fails: missing @babel/preset-env preset in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2638db810832b823478069d6f8d89