### PR TITLE
Adjust manual job description error test expectation

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -361,7 +361,9 @@ describe('/api/process-cv', () => {
     expect(failed.body.success).toBe(false);
     expect(failed.body.error.code).toBe('JOB_DESCRIPTION_REQUIRED');
     expect(failed.body.error.message).toBe('manualJobDescription required');
-    expect(failed.body.error.details).toEqual({});
+    expect(failed.body.error.details).toEqual({
+      field: 'manualJobDescription'
+    });
 
     const manual = await request(app)
       .post('/api/process-cv')


### PR DESCRIPTION
## Summary
- update the process-cv tests to expect the manualJobDescription field in error details

## Testing
- npm test -- tests/server.test.js *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68e269634c5c832bb79d06f372c9139e