### PR TITLE
Normalize output URLs and add regression tests

### DIFF
--- a/tests/outputUrlNormalization.test.js
+++ b/tests/outputUrlNormalization.test.js
@@ -1,0 +1,40 @@
+import { ensureOutputFileUrls } from '../server.js';
+
+describe('ensureOutputFileUrls', () => {
+  it('derives url and fileUrl from typeUrl when no direct url is provided', () => {
+    const [entry] = ensureOutputFileUrls([
+      {
+        type: 'version1',
+        typeUrl: 'https://example.com/resume.pdf#version1',
+      },
+    ]);
+
+    expect(entry.url).toBe('https://example.com/resume.pdf');
+    expect(entry.fileUrl).toBe('https://example.com/resume.pdf');
+    expect(entry.typeUrl).toBe('https://example.com/resume.pdf#version1');
+  });
+
+  it('infers the document type from the typeUrl fragment when missing', () => {
+    const [entry] = ensureOutputFileUrls([
+      {
+        typeUrl: 'https://example.com/cover.pdf#cover_letter1',
+      },
+    ]);
+
+    expect(entry.type).toBe('cover_letter1');
+    expect(entry.url).toBe('https://example.com/cover.pdf');
+    expect(entry.fileUrl).toBe('https://example.com/cover.pdf');
+    expect(entry.typeUrl).toBe('https://example.com/cover.pdf#cover_letter1');
+  });
+
+  it('appends a type fragment when missing from the typeUrl value', () => {
+    const [entry] = ensureOutputFileUrls([
+      {
+        type: 'version2',
+        typeUrl: 'https://example.com/resume.pdf',
+      },
+    ]);
+
+    expect(entry.typeUrl).toBe('https://example.com/resume.pdf#version2');
+  });
+});


### PR DESCRIPTION
## Summary
- normalize generated asset metadata so fileUrl/typeUrl are always populated using a dedicated parser
- expose the normalization helper for reuse and future validation
- add unit coverage to lock in URL inference behaviour from typeUrl-only responses

## Testing
- npm test -- outputUrlNormalization.test.js *(fails: missing @babel/preset-env in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e26c521304832bab3b8bf467b3e084