### PR TITLE
Update published CloudFront metadata test expectations

### DIFF
--- a/tests/publishedCloudfront.test.js
+++ b/tests/publishedCloudfront.test.js
@@ -55,6 +55,8 @@ describe('published CloudFront helpers', () => {
         cloudfront: {
           stackName: metadata.stackName,
           url: 'https://d3exampleabcdef8.cloudfront.net',
+          fileUrl: 'https://d3exampleabcdef8.cloudfront.net',
+          typeUrl: 'https://d3exampleabcdef8.cloudfront.net#download',
           distributionId: metadata.distributionId,
           updatedAt: metadata.updatedAt,
         },


### PR DESCRIPTION
## Summary
- update the published CloudFront metadata test to account for normalized file and type URLs returned by the server

## Testing
- npm test -- publishedCloudfront.test.js *(fails: missing dev dependency `@babel/preset-env` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e26e916b20832b97e178de59670bd1