### PR TITLE
Ensure API responses validate download URLs

### DIFF
--- a/tests/outputUrlNormalization.test.js
+++ b/tests/outputUrlNormalization.test.js
@@ -37,4 +37,22 @@ describe('ensureOutputFileUrls', () => {
 
     expect(entry.typeUrl).toBe('https://example.com/resume.pdf#version2');
   });
+
+  it('filters out entries that do not resolve to a downloadable url', () => {
+    const normalized = ensureOutputFileUrls([
+      { type: 'version1', url: '   ' },
+      { type: 'version2', typeUrl: '#version2' },
+      { type: 'version3', downloadUrl: 'https://example.com/v3.pdf ' },
+    ]);
+
+    expect(normalized).toHaveLength(1);
+    expect(normalized[0]).toEqual(
+      expect.objectContaining({
+        type: 'version3',
+        url: 'https://example.com/v3.pdf',
+        fileUrl: 'https://example.com/v3.pdf',
+        typeUrl: 'https://example.com/v3.pdf#version3',
+      })
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- harden output URL normalization by trimming sources and discarding entries without usable links
- fail improvement and CV processing flows with structured errors when no downloadable URLs can be produced
- extend test coverage for invalid URL handling and structured error responses

## Testing
- npm test -- --runTestsByPath tests/outputUrlNormalization.test.js *(fails: missing @babel/preset-env in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e27047a9d4832ba61b7362bf34fc9e