### PR TITLE
feat: enable multi-template previews

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2664,6 +2664,11 @@ function App() {
           coverTemplateId={selectedCoverTemplate}
           coverTemplateName={formatCoverTemplateName(selectedCoverTemplate)}
           coverTemplateDescription={getCoverTemplateDescription(selectedCoverTemplate)}
+          availableResumeTemplates={availableTemplateOptions}
+          availableCoverTemplates={availableCoverTemplateOptions}
+          onResumeTemplateApply={handleTemplateSelect}
+          onCoverTemplateApply={handleCoverTemplateSelect}
+          isApplying={isProcessing}
         />
       </>
     )


### PR DESCRIPTION
## Summary
- enhance the template preview module so users can cycle through available resume and cover designs without leaving the page
- surface apply buttons and wiring from the dashboard to keep template choices in sync while previewing

## Testing
- npm --prefix client test

------
https://chatgpt.com/codex/tasks/task_e_68e279199fb8832bbc45be1e93ee414a