### PR TITLE
Fix S3 reference in improvement handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -11805,7 +11805,6 @@ async function handleImprovementRequest(type, req, res) {
         return;
       }
 
-      const s3 = s3Client;
       const applicantName = extractName(updatedResumeText);
       const sanitizedName = sanitizeName(applicantName) || 'candidate';
       const jobKeySegment = sanitizeJobSegment(jobIdInput);
@@ -11856,7 +11855,7 @@ async function handleImprovementRequest(type, req, res) {
 
       const enhancedDocs = await generateEnhancedDocumentsResponse({
         res,
-        s3,
+        s3: s3Client,
         dynamo,
         tableName,
         bucket,
@@ -11969,7 +11968,7 @@ async function handleImprovementRequest(type, req, res) {
     }
 
     await updateStageMetadata({
-      s3,
+      s3: s3Client,
       bucket,
       metadataKey: improvementMetadataKey,
       jobId: jobIdInput,


### PR DESCRIPTION
## Summary
- ensure the improvement handler passes the initialized S3 client to downstream helpers when generating enhanced documents and updating metadata to avoid ReferenceError crashes

## Testing
- npm test -- tests/uploadFormatsTemplates.e2e.test.js *(fails: missing @babel/preset-env dev dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e28bcbb0fc832b89a12107138b8c0c