### PR TITLE
Simplify stage metadata to essential fields

### DIFF
--- a/server.js
+++ b/server.js
@@ -11978,8 +11978,6 @@ async function handleImprovementRequest(type, req, res) {
       data: {
         completedAt: new Date().toISOString(),
         improvementType: type,
-        confidence: result.confidence,
-        missingSkillsResolved: missingSkills.length,
       },
       logContext,
     });
@@ -13182,8 +13180,6 @@ async function generateEnhancedDocumentsResponse({
     data: {
       completedAt: generationCompletedAt || new Date().toISOString(),
       artifactCount: uploadedArtifacts.length,
-      textArtifactCount: textArtifactTypes.length,
-      urlCount: normalizedUrls.length,
     },
     logContext,
   });
@@ -14608,11 +14604,6 @@ app.post(
       data: {
         uploadedAt: timestamp,
         fileType: storedFileType,
-        storage: {
-          bucket,
-          key: originalUploadKey,
-          initialKey: initialUploadKey,
-        },
       },
       logContext,
     });
@@ -14939,15 +14930,13 @@ app.post(
         bucket,
         metadataKey: scoringMetadataKey,
         jobId,
-        stage: 'scoring',
-        data: {
-          completedAt: scoringCompletedAt,
-          score: scoringUpdate.normalizedScore,
-          missingSkillsCount: scoringUpdate.normalizedMissingSkills.length,
-          addedSkillsCount: scoringUpdate.normalizedAddedSkills.length,
-        },
-        logContext,
-      });
+      stage: 'scoring',
+      data: {
+        completedAt: scoringCompletedAt,
+        score: scoringUpdate.normalizedScore,
+      },
+      logContext,
+    });
     } catch (updateErr) {
       logStructured('error', 'process_cv_status_update_failed', {
         ...logContext,

--- a/tests/awsStorage.integration.test.js
+++ b/tests/awsStorage.integration.test.js
@@ -73,25 +73,24 @@ describe('AWS integrations for /api/process-cv', () => {
           upload: expect.objectContaining({
             uploadedAt: expect.any(String),
             fileType: expect.any(String),
-            storage: expect.objectContaining({
-              bucket: 'integration-bucket',
-              key: expect.stringContaining('original'),
-            }),
           }),
           scoring: expect.objectContaining({
             completedAt: expect.any(String),
             score: expect.any(Number),
-            missingSkillsCount: expect.any(Number),
           }),
           download: expect.objectContaining({
             completedAt: expect.any(String),
             artifactCount: expect.any(Number),
-            textArtifactCount: expect.any(Number),
-            urlCount: expect.any(Number),
           }),
         }),
       })
     );
+
+    expect(metadataPayload.stages.upload).not.toHaveProperty('storage');
+    expect(metadataPayload.stages.scoring).not.toHaveProperty('missingSkillsCount');
+    expect(metadataPayload.stages.scoring).not.toHaveProperty('addedSkillsCount');
+    expect(metadataPayload.stages.download).not.toHaveProperty('textArtifactCount');
+    expect(metadataPayload.stages.download).not.toHaveProperty('urlCount');
 
     const generatedPdf = commandSummaries.find(
       (command) =>


### PR DESCRIPTION
## Summary
- trim the upload stage metadata to the uploaded timestamp and file type only
- reduce scoring, improvement, and download stage metadata to the essential fields needed by the dashboard
- update the AWS integration test expectations to match the leaner metadata payloads

## Testing
- npm test -- awsStorage.integration.test.js *(fails: missing @babel/preset-env preset in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2918bdcfc832b922c2559add20403