### PR TITLE
Reset UI after previous version download

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4586,12 +4586,13 @@ function App() {
         link.click()
         document.body.removeChild(link)
         URL.revokeObjectURL(url)
+        resetUiAfterDownload()
       } catch (err) {
         console.error('Unable to download previous resume version', err)
         setError('Unable to download the previous version. Please try again.')
       }
     },
-    [changeLog, resumeHistoryMap, setError]
+    [changeLog, resetUiAfterDownload, resumeHistoryMap, setError]
   )
 
   const handleRevertChange = useCallback(


### PR DESCRIPTION
## Summary
- reset the analysis UI after downloading a previous resume version so users are prompted to try another template or JD

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e29d7375a4832ba1e5a21769d6cfd8