### PR TITLE
Refactor template selection into reusable picker

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,8 +3,7 @@ import { formatMatchMessage } from './formatMatchMessage.js'
 import { buildApiUrl, resolveApiBase } from './resolveApiBase.js'
 import ATSScoreDashboard from './components/ATSScoreDashboard.jsx'
 import InfoTooltip from './components/InfoTooltip.jsx'
-import TemplateSelector from './components/TemplateSelector.jsx'
-import TemplatePreview from './components/TemplatePreview.jsx'
+import TemplatePicker from './components/TemplatePicker.jsx'
 import DeltaSummaryPanel from './components/DeltaSummaryPanel.jsx'
 import ProcessFlow from './components/ProcessFlow.jsx'
 import ChangeComparisonView from './components/ChangeComparisonView.jsx'
@@ -2757,48 +2756,23 @@ function App() {
   }, [])
 
   const renderTemplateSelection = (context = 'improvements') => {
-    const resumeSelectorIdPrefix =
-      context === 'downloads' ? 'download-resume-template-selector' : 'resume-template-selector'
-    const coverSelectorIdPrefix =
-      context === 'downloads' ? 'download-cover-template-selector' : 'cover-template-selector'
-
     return (
-      <>
-        <TemplateSelector
-          idPrefix={resumeSelectorIdPrefix}
-          title="CV Template Style"
-          description="Choose the CV aesthetic that mirrors your personality and the JD tone."
-          options={availableTemplateOptions}
-          selectedTemplate={selectedTemplate}
-          onSelect={handleTemplateSelect}
-          disabled={isProcessing}
-          historySummary={templateHistorySummary}
-        />
-
-        <TemplateSelector
-          idPrefix={coverSelectorIdPrefix}
-          title="Cover Letter Template"
-          description="Align your letter visuals with your selected CV or explore a bold alternative."
-          options={availableCoverTemplateOptions}
-          selectedTemplate={selectedCoverTemplate}
-          onSelect={handleCoverTemplateSelect}
-          disabled={isProcessing}
-        />
-
-        <TemplatePreview
-          resumeTemplateId={selectedTemplate}
-          resumeTemplateName={formatTemplateName(selectedTemplate)}
-          resumeTemplateDescription={selectedTemplateOption?.description || ''}
-          coverTemplateId={selectedCoverTemplate}
-          coverTemplateName={formatCoverTemplateName(selectedCoverTemplate)}
-          coverTemplateDescription={getCoverTemplateDescription(selectedCoverTemplate)}
-          availableResumeTemplates={availableTemplateOptions}
-          availableCoverTemplates={availableCoverTemplateOptions}
-          onResumeTemplateApply={handleTemplateSelect}
-          onCoverTemplateApply={handleCoverTemplateSelect}
-          isApplying={isProcessing}
-        />
-      </>
+      <TemplatePicker
+        context={context}
+        resumeOptions={availableTemplateOptions}
+        resumeHistorySummary={templateHistorySummary}
+        selectedResumeTemplateId={selectedTemplate}
+        selectedResumeTemplateName={formatTemplateName(selectedTemplate)}
+        selectedResumeTemplateDescription={selectedTemplateOption?.description || ''}
+        onResumeTemplateSelect={handleTemplateSelect}
+        coverOptions={availableCoverTemplateOptions}
+        selectedCoverTemplateId={selectedCoverTemplate}
+        selectedCoverTemplateName={formatCoverTemplateName(selectedCoverTemplate)}
+        selectedCoverTemplateDescription={getCoverTemplateDescription(selectedCoverTemplate)}
+        onCoverTemplateSelect={handleCoverTemplateSelect}
+        disabled={isProcessing}
+        isApplying={isProcessing}
+      />
     )
   }
 

--- a/client/src/components/TemplatePicker.jsx
+++ b/client/src/components/TemplatePicker.jsx
@@ -1,0 +1,75 @@
+import TemplateSelector from './TemplateSelector.jsx'
+import TemplatePreview from './TemplatePreview.jsx'
+
+function TemplatePicker({
+  context = 'improvements',
+  resumeOptions = [],
+  resumeHistorySummary = '',
+  selectedResumeTemplateId,
+  selectedResumeTemplateName,
+  selectedResumeTemplateDescription = '',
+  onResumeTemplateSelect,
+  coverOptions = [],
+  selectedCoverTemplateId,
+  selectedCoverTemplateName,
+  selectedCoverTemplateDescription = '',
+  onCoverTemplateSelect,
+  disabled = false,
+  isApplying = false
+}) {
+  const resumeSelectorIdPrefix =
+    context === 'downloads' ? 'download-resume-template-selector' : 'resume-template-selector'
+  const coverSelectorIdPrefix =
+    context === 'downloads' ? 'download-cover-template-selector' : 'cover-template-selector'
+
+  const hasResumeOptions = Array.isArray(resumeOptions) && resumeOptions.length > 0
+  const hasCoverOptions = Array.isArray(coverOptions) && coverOptions.length > 0
+  const showPreview = hasResumeOptions || hasCoverOptions
+
+  return (
+    <>
+      {hasResumeOptions && (
+        <TemplateSelector
+          idPrefix={resumeSelectorIdPrefix}
+          title="CV Template Style"
+          description="Choose the CV aesthetic that mirrors your personality and the JD tone."
+          options={resumeOptions}
+          selectedTemplate={selectedResumeTemplateId}
+          onSelect={onResumeTemplateSelect}
+          disabled={disabled}
+          historySummary={resumeHistorySummary}
+        />
+      )}
+
+      {hasCoverOptions && (
+        <TemplateSelector
+          idPrefix={coverSelectorIdPrefix}
+          title="Cover Letter Template"
+          description="Align your letter visuals with your selected CV or explore a bold alternative."
+          options={coverOptions}
+          selectedTemplate={selectedCoverTemplateId}
+          onSelect={onCoverTemplateSelect}
+          disabled={disabled}
+        />
+      )}
+
+      {showPreview && (
+        <TemplatePreview
+          resumeTemplateId={selectedResumeTemplateId}
+          resumeTemplateName={selectedResumeTemplateName}
+          resumeTemplateDescription={selectedResumeTemplateDescription}
+          coverTemplateId={selectedCoverTemplateId}
+          coverTemplateName={selectedCoverTemplateName}
+          coverTemplateDescription={selectedCoverTemplateDescription}
+          availableResumeTemplates={resumeOptions}
+          availableCoverTemplates={coverOptions}
+          onResumeTemplateApply={onResumeTemplateSelect}
+          onCoverTemplateApply={onCoverTemplateSelect}
+          isApplying={isApplying}
+        />
+      )}
+    </>
+  )
+}
+
+export default TemplatePicker


### PR DESCRIPTION
## Summary
- add a dedicated TemplatePicker component that combines both template selectors with the live preview
- update App.jsx to use the new picker so users can review template styles in one cohesive block

## Testing
- npm run build *(fails: Vite cannot resolve pdf-lib in createCoverLetterPdf.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a356c6f0832baeac31af5200416b