### PR TITLE
Clarify ATS and selection score summaries

### DIFF
--- a/client/src/components/ATSScoreDashboard.jsx
+++ b/client/src/components/ATSScoreDashboard.jsx
@@ -198,6 +198,18 @@ function ATSScoreDashboard({
           typeof match?.atsScoreBefore === 'number' ? match.atsScoreBefore : match?.originalScore,
           typeof match?.atsScoreAfter === 'number' ? match.atsScoreAfter : match?.enhancedScore
         )
+  const atsScoreSummary = (() => {
+    if (originalScoreValue !== null && enhancedScoreValue !== null) {
+      return `ATS score moved from ${originalScoreValue}% to ${enhancedScoreValue}%${matchDelta ? ` (${matchDelta})` : ''}.`
+    }
+    if (originalScoreValue !== null) {
+      return `Current ATS score before enhancements: ${originalScoreValue}%.`
+    }
+    if (enhancedScoreValue !== null) {
+      return `Current ATS score after enhancements: ${enhancedScoreValue}%.`
+    }
+    return null
+  })()
   const selectionProbabilityBeforeValue =
     typeof match?.selectionProbabilityBefore === 'number'
       ? match.selectionProbabilityBefore
@@ -243,6 +255,18 @@ function ATSScoreDashboard({
     typeof selectionProbabilityBeforeValue === 'number' && typeof selectionProbabilityAfterValue === 'number'
       ? formatDelta(selectionProbabilityBeforeValue, selectionProbabilityAfterValue)
       : null
+  const selectionProbabilitySummary = (() => {
+    if (typeof selectionProbabilityBeforeValue === 'number' && typeof selectionProbabilityAfterValue === 'number') {
+      return `Selection chance moved from ${selectionProbabilityBeforeValue}% to ${selectionProbabilityAfterValue}%${selectionProbabilityDelta ? ` (${selectionProbabilityDelta})` : ''}.`
+    }
+    if (typeof selectionProbabilityBeforeValue === 'number') {
+      return `Selection chance before enhancements: ${selectionProbabilityBeforeValue}%.`
+    }
+    if (typeof selectionProbabilityAfterValue === 'number') {
+      return `Selection chance after enhancements: ${selectionProbabilityAfterValue}%.`
+    }
+    return null
+  })()
   const hasComparableScores =
     typeof originalScoreValue === 'number' && typeof enhancedScoreValue === 'number'
   const scoreBands = hasComparableScores
@@ -393,6 +417,24 @@ function ATSScoreDashboard({
           className={`grid grid-cols-1 gap-4 ${hasSelectionProbability ? 'md:grid-cols-4' : 'md:grid-cols-3'}`}
           aria-label="match comparison"
         >
+          {(atsScoreSummary || selectionProbabilitySummary) && (
+            <div
+              className="rounded-3xl border border-purple-100/80 bg-purple-50/60 p-4 shadow-sm md:col-span-full"
+              data-testid="score-summary-banner"
+            >
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-purple-600">Score Snapshot</p>
+              {atsScoreSummary && (
+                <p className="mt-2 text-sm text-purple-800" data-testid="ats-score-summary">
+                  {atsScoreSummary}
+                </p>
+              )}
+              {selectionProbabilitySummary && (
+                <p className="mt-1 text-sm text-purple-800" data-testid="selection-summary">
+                  {selectionProbabilitySummary}
+                </p>
+              )}
+            </div>
+          )}
           <div className="rounded-3xl border border-indigo-100 bg-white/80 p-6 shadow-lg backdrop-blur">
             <div className="flex items-center justify-between gap-3">
               <p className="text-xs font-semibold uppercase tracking-[0.3em] text-indigo-500">ATS Score Before</p>

--- a/client/src/components/__tests__/ATSScoreDashboard.test.jsx
+++ b/client/src/components/__tests__/ATSScoreDashboard.test.jsx
@@ -64,6 +64,9 @@ describe('ATSScoreDashboard', () => {
     expect(cards).toHaveLength(metrics.length)
     expect(screen.getAllByText('ATS Score Before')).not.toHaveLength(0)
     expect(screen.getAllByText('ATS Score After')).not.toHaveLength(0)
+    expect(screen.getByTestId('ats-score-summary')).toHaveTextContent(
+      'ATS score moved from 48% to 76% (+28 pts).'
+    )
     expect(screen.getByLabelText('match comparison')).toBeInTheDocument()
     expect(screen.getByTestId('original-score')).toHaveTextContent('48%')
     expect(screen.getByTestId('enhanced-score')).toHaveTextContent('76%')
@@ -171,5 +174,21 @@ describe('ATSScoreDashboard', () => {
     expect(card).toBeInTheDocument()
     const tip = within(card).getByTestId('metric-tip')
     expect(tip).toHaveTextContent('Tighten formatting')
+  })
+
+  it('describes selection probability changes before and after enhancements', () => {
+    const match = {
+      ...baseMatch,
+      selectionProbabilityBefore: 42,
+      selectionProbabilityAfter: 71
+    }
+
+    render(<ATSScoreDashboard metrics={metrics} baselineMetrics={baselineMetrics} match={match} />)
+
+    expect(screen.getByTestId('selection-summary')).toHaveTextContent(
+      'Selection chance moved from 42% to 71% (+29 pts).'
+    )
+    expect(screen.getByText('Selection % Before')).toBeInTheDocument()
+    expect(screen.getByText('Selection % After')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- add a score snapshot banner that highlights ATS scores before and after enhancements, including the point delta when available
- surface a similar summary for selection probability shifts so users can quickly compare shortlist odds pre- and post-enhancement
- expand dashboard tests to cover the new summaries and ensure the selection probability callouts render

## Testing
- npm test -- ATSScoreDashboard (fails: missing jest-environment-jsdom and @babel/preset-env in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2a569995c832b9b86d2fc2a117a46