### PR TITLE
Stabilize upload format e2e coverage

### DIFF
--- a/tests/uploadFormatsTemplates.e2e.test.js
+++ b/tests/uploadFormatsTemplates.e2e.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import request from 'supertest';
 import { setupTestServer, primeSuccessfulAi } from './utils/testServer.js';
 
@@ -45,6 +46,11 @@ function expectResumeStructure(text = '') {
 }
 
 describe('resume lifecycle coverage', () => {
+  const TEST_TIMEOUT_MS = 45000;
+
+  beforeAll(() => {
+    jest.setTimeout(TEST_TIMEOUT_MS);
+  });
 
   const FORMATS = [
     {
@@ -384,5 +390,5 @@ describe('resume lifecycle coverage', () => {
     CL_TEMPLATES.forEach((template) => {
       expect(pdfKeys.some((key) => key.includes(`cover_letter_${template}`))).toBe(true);
     });
-  }, 30000);
+  }, TEST_TIMEOUT_MS);
 });


### PR DESCRIPTION
## Summary
- import the Jest globals explicitly in the upload format e2e suite and centralise the timeout
- raise the suite timeout to 45s so the end-to-end runs do not fail under the default 5s limit

## Testing
- npm test -- uploadFormatsTemplates.e2e.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a7767e50832ba1655b0c6bf34521