### PR TITLE
Gracefully fallback when PDF rendering fails

### DIFF
--- a/server.js
+++ b/server.js
@@ -6356,17 +6356,20 @@ let generatePdf = async function (
           requestedTemplateId,
           dependency: 'pdf-lib',
         });
-        logStructured('info', 'pdf_template_fallback_applied', {
-          requestedTemplateId,
-          fallbackTemplateId: templateId,
-          strategy: 'html_template_render',
-        });
       } else {
-        const templateError = new Error(CV_GENERATION_ERROR_MESSAGE);
-        templateError.code = 'TEMPLATE_RENDER_FAILED';
-        templateError.cause = err;
-        throw templateError;
+        logStructured('warn', 'pdf_renderer_error_recovered', {
+          templateId,
+          requestedTemplateId,
+          errorCode: err?.code,
+          errorMessage: err?.message,
+        });
       }
+      logStructured('info', 'pdf_template_fallback_applied', {
+        requestedTemplateId,
+        fallbackTemplateId: templateId,
+        strategy: 'html_template_render',
+        reason: err?.code || err?.message || 'unknown_error',
+      });
     }
   }
   let html;


### PR DESCRIPTION
## Summary
- allow the 2025 PDF renderer to log errors and defer to the HTML-based templates instead of failing the request
- add structured logging to distinguish recovered PDF renderer errors from missing dependencies

## Testing
- npm test *(fails: Cannot find package '@babel/preset-env' in the provided environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3417ceea4832b8f31b979a712027c