### PR TITLE
Add S3 bucket policy for artifact uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Deployments still expect the following AWS SAM parameters:
 - `CreateResumeTable` – set to `false` when reusing a DynamoDB table created outside the stack (defaults to `true`).
 - `WebAclArn` – optional ARN of an AWS WAFv2 web ACL to associate with the CloudFront distribution for upload abuse protection. Leave blank to skip WAF attachment.
 
+When the stack provisions the S3 bucket it automatically applies a bucket policy that allows the Lambda execution role to `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, and `s3:ListBucket`. If you reuse an existing bucket by setting `CreateDataBucket` to `false`, make sure an equivalent policy is attached so uploads for all artifact types continue to succeed.
+
 ## IAM Policy
 Minimal permissions required by the server:
 

--- a/template.yaml
+++ b/template.yaml
@@ -116,6 +116,32 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
 
+  DataBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Condition: CreateDataBucketCondition
+    Properties:
+      Bucket: !Ref DataBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowLambdaBucketActions
+            Effect: Allow
+            Principal:
+              AWS: !GetAtt ResumeForgeFunctionRole.Arn
+            Action:
+              - s3:GetObject
+              - s3:PutObject
+              - s3:DeleteObject
+            Resource:
+              - !Sub arn:aws:s3:::${DataBucket}/*
+          - Sid: AllowLambdaListBucket
+            Effect: Allow
+            Principal:
+              AWS: !GetAtt ResumeForgeFunctionRole.Arn
+            Action:
+              - s3:ListBucket
+            Resource: !Sub arn:aws:s3:::${DataBucket}
+
   ResumeForgeTable:
     Type: AWS::DynamoDB::Table
     Condition: CreateResumeTableCondition


### PR DESCRIPTION
## Summary
- attach a bucket policy to the data bucket so the Lambda execution role can PUT, GET, delete, and list artifact objects
- document the requirement to mirror this policy when supplying an existing bucket so uploads remain allowed

## Testing
- npm test -- --runInBand *(fails: missing @babel/preset-env in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3449c7a48832b81be2168bae2ee82