### PR TITLE
Add opt-in plain PDF fallback flag

### DIFF
--- a/config/runtime-config.example.json5
+++ b/config/runtime-config.example.json5
@@ -12,5 +12,8 @@
   CLOUDFRONT_ORIGINS: [
     'http://localhost:3000',
     'http://localhost:5173'
-  ]
+  ],
+  // Optional: set to true to enable plaintext PDF fallback generation when
+  // template rendering fails. Leave unset to return an error instead.
+  ENABLE_PLAIN_PDF_FALLBACK: false
 }


### PR DESCRIPTION
## Summary
- add boolean environment parsing helpers to support additional runtime flags
- propagate a configurable plain PDF fallback toggle through CV generation so failures bubble to clients by default
- document the new ENABLE_PLAIN_PDF_FALLBACK option in the runtime configuration example

## Testing
- npm test *(fails: missing @babel/preset-env dev dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e35355e3c0832b8c8dc39c0187e7ed