### PR TITLE
Ensure S3 bucket policy covers all deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Deployments still expect the following AWS SAM parameters:
 - `CreateResumeTable` – set to `false` when reusing a DynamoDB table created outside the stack (defaults to `true`).
 - `WebAclArn` – optional ARN of an AWS WAFv2 web ACL to associate with the CloudFront distribution for upload abuse protection. Leave blank to skip WAF attachment.
 
-When the stack provisions the S3 bucket it automatically applies a bucket policy that allows the Lambda execution role to `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, and `s3:ListBucket`. If you reuse an existing bucket by setting `CreateDataBucket` to `false`, make sure an equivalent policy is attached so uploads for all artifact types continue to succeed.
+Whether the stack creates the S3 bucket or reuses an existing one, it now attaches a bucket policy that allows the Lambda execution role to `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, and `s3:ListBucket`. This ensures every artifact type (original uploads, generated PDFs, logs, and change histories) can be written without requiring out-of-band IAM changes.
 
 ## IAM Policy
 Minimal permissions required by the server:

--- a/template.yaml
+++ b/template.yaml
@@ -118,9 +118,8 @@ Resources:
 
   DataBucketPolicy:
     Type: AWS::S3::BucketPolicy
-    Condition: CreateDataBucketCondition
     Properties:
-      Bucket: !Ref DataBucket
+      Bucket: !If [CreateDataBucketCondition, !Ref DataBucket, !Ref DataBucketName]
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -133,14 +132,20 @@ Resources:
               - s3:PutObject
               - s3:DeleteObject
             Resource:
-              - !Sub arn:aws:s3:::${DataBucket}/*
+              - !If
+                - CreateDataBucketCondition
+                - !Sub arn:aws:s3:::${DataBucket}/*
+                - !Sub arn:aws:s3:::${DataBucketName}/*
           - Sid: AllowLambdaListBucket
             Effect: Allow
             Principal:
               AWS: !GetAtt ResumeForgeFunctionRole.Arn
             Action:
               - s3:ListBucket
-            Resource: !Sub arn:aws:s3:::${DataBucket}
+            Resource: !If
+              - CreateDataBucketCondition
+              - !Sub arn:aws:s3:::${DataBucket}
+              - !Sub arn:aws:s3:::${DataBucketName}
 
   ResumeForgeTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
## Summary
- update the SAM template so the data bucket policy is attached even when reusing an existing bucket
- document that the deployment automatically grants the Lambda role S3 permissions for all artifact types

## Testing
- not run (infrastructure-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e368d9b304832b9b26eb2583dfdb5f