### PR TITLE
Add infrastructure test confirming S3 PUT permissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "js-yaml": "^4.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "supertest": "^6.3.4"
@@ -4533,6 +4534,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -9373,18 +9388,24 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/js-yaml/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/jsdom": {
       "version": "20.0.3",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "js-yaml": "^4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "supertest": "^6.3.4"

--- a/tests/infrastructure/s3Policies.test.js
+++ b/tests/infrastructure/s3Policies.test.js
@@ -1,0 +1,78 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+const { Type, DEFAULT_SCHEMA } = yaml;
+
+const scalarIntrinsic = (tag, key) =>
+  new Type(tag, {
+    kind: 'scalar',
+    construct: (data) => ({ [key]: data }),
+  });
+
+const sequenceIntrinsic = (tag, key) =>
+  new Type(tag, {
+    kind: 'sequence',
+    construct: (data) => ({ [key]: data }),
+  });
+
+const cloudFormationSchema = DEFAULT_SCHEMA.extend([
+  scalarIntrinsic('!Ref', 'Ref'),
+  scalarIntrinsic('!Condition', 'Condition'),
+  scalarIntrinsic('!GetAtt', 'Fn::GetAtt'),
+  sequenceIntrinsic('!GetAtt', 'Fn::GetAtt'),
+  scalarIntrinsic('!Sub', 'Fn::Sub'),
+  sequenceIntrinsic('!Sub', 'Fn::Sub'),
+  sequenceIntrinsic('!If', 'Fn::If'),
+  sequenceIntrinsic('!Equals', 'Fn::Equals'),
+  sequenceIntrinsic('!Not', 'Fn::Not'),
+  sequenceIntrinsic('!And', 'Fn::And'),
+  sequenceIntrinsic('!Or', 'Fn::Or'),
+  sequenceIntrinsic('!Select', 'Fn::Select'),
+  sequenceIntrinsic('!Split', 'Fn::Split'),
+  sequenceIntrinsic('!Join', 'Fn::Join'),
+  scalarIntrinsic('!ImportValue', 'Fn::ImportValue'),
+]);
+
+describe('infrastructure S3 access policies', () => {
+  const templatePath = path.join(process.cwd(), 'template.yaml');
+  const template = yaml.load(readFileSync(templatePath, 'utf8'), {
+    schema: cloudFormationSchema,
+  });
+
+  test('DataBucket policy allows Lambda role to put artifacts', () => {
+    const bucketPolicy = template?.Resources?.DataBucketPolicy;
+    expect(bucketPolicy).toBeDefined();
+
+    const statements = bucketPolicy.Properties?.PolicyDocument?.Statement || [];
+    const allowPutStatement = statements.find((statement) => {
+      if (!statement || statement.Effect !== 'Allow') return false;
+      const actions = Array.isArray(statement.Action)
+        ? statement.Action
+        : [statement.Action].filter(Boolean);
+      return actions.includes('s3:PutObject');
+    });
+
+    expect(allowPutStatement).toBeDefined();
+  });
+
+  test('ResumeForge function IAM policies include s3:PutObject access', () => {
+    const lambda = template?.Resources?.ResumeForgeFunction;
+    expect(lambda).toBeDefined();
+
+    const policies = lambda.Properties?.Policies || [];
+    const inlineStatements = policies
+      .map((policy) => policy?.Statement)
+      .filter(Boolean)
+      .flat();
+
+    const hasPutObject = inlineStatements.some((statement) => {
+      const actions = Array.isArray(statement?.Action)
+        ? statement.Action
+        : [statement?.Action].filter(Boolean);
+      return actions.includes('s3:PutObject');
+    });
+
+    expect(hasPutObject).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add an infrastructure-focused Jest suite that parses the SAM template and asserts s3:PutObject is allowed for the data bucket and Lambda role
- introduce the js-yaml dev dependency so the test can load CloudFormation intrinsics

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3798a79e8832bad74c393c8483330