### PR TITLE
Fix PDF content type detection for uploaded resumes

### DIFF
--- a/server.js
+++ b/server.js
@@ -6308,7 +6308,7 @@ function determineUploadContentType(file) {
   if (!file || typeof file !== 'object') {
     return fallbackType;
   }
-  const { mimetype, buffer } = file;
+  const { mimetype, buffer, originalname } = file;
   const normalizedType = typeof mimetype === 'string' ? mimetype.trim() : '';
   if (normalizedType === 'application/pdf') {
     if (Buffer.isBuffer(buffer) && buffer.length >= 4) {
@@ -6317,7 +6317,10 @@ function determineUploadContentType(file) {
         return normalizedType;
       }
     }
-    return fallbackType;
+    if (typeof originalname === 'string' && /\.pdf$/i.test(originalname)) {
+      return normalizedType;
+    }
+    return normalizedType || fallbackType;
   }
   return normalizedType || fallbackType;
 }


### PR DESCRIPTION
## Summary
- ensure determineUploadContentType respects declared PDF uploads even when the file buffer lacks a signature
- fall back to the provided filename extension before downgrading content type for PDF uploads

## Testing
- npm test -- --runTestsByPath tests/processCvTemplates.integration.test.js --testTimeout=20000 --silent

------
https://chatgpt.com/codex/tasks/task_e_68e389244e50832b850a6d6c2cf9815e