### PR TITLE
Fix QR code mock to return valid PNG data URL

### DIFF
--- a/tests/mocks/qrcode.js
+++ b/tests/mocks/qrcode.js
@@ -3,6 +3,8 @@ export default {
     return 'MOCK_QR_CODE'
   },
   async toDataURL() {
-    return 'data:image/png;base64,MOCK'
+    const transparentPixelBase64 =
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P8z8BQDwAFgwJ/lwKc8wAAAABJRU5ErkJggg=='
+    return `data:image/png;base64,${transparentPixelBase64}`
   }
 }


### PR DESCRIPTION
## Summary
- update the Jest QR code mock to emit a valid base64-encoded PNG so pdf-lib can embed it during tests

## Testing
- npm test -- tests/pdfTemplateBackstop.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e39aeda7c4832bb427bad37fe7f307