### PR TITLE
Fix MIMEType import to use Node util

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ import mammoth from 'mammoth';
 import WordExtractorPackage from 'word-extractor';
 import JSON5 from 'json5';
 import mime from 'mime-types';
-import { MIMEType } from 'whatwg-mimetype';
+import { MIMEType } from 'node:util';
 import { renderTemplatePdf } from './lib/pdf/index.js';
 import { backstopPdfTemplates as runPdfTemplateBackstop } from './lib/pdf/backstop.js';
 import {


### PR DESCRIPTION
## Summary
- replace the whatwg-mimetype import in the server with Node's built-in util MIMEType class to avoid module export errors during tests

## Testing
- npm test -- --runInBand *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68e3a78843dc832b9cfb3c92b5782946