### PR TITLE
Fix improvement session logging initialization

### DIFF
--- a/server.js
+++ b/server.js
@@ -12661,15 +12661,16 @@ async function handleImprovementRequest(type, req, res) {
   res.locals.jobId = jobIdInput;
   captureUserContext(req, res);
   const requestId = res.locals.requestId;
+  const improvementSessionSegment =
+    sanitizeS3KeyComponent(requestId, { fallback: '' }) ||
+    sanitizeS3KeyComponent(`session-${createIdentifier()}`);
+
   const logContext = {
     requestId,
     jobId: jobIdInput,
     type,
     sessionId: improvementSessionSegment,
   };
-  const improvementSessionSegment =
-    sanitizeS3KeyComponent(requestId, { fallback: '' }) ||
-    sanitizeS3KeyComponent(`session-${createIdentifier()}`);
 
   const profileIdentifier =
     resolveProfileIdentifier({


### PR DESCRIPTION
## Summary
- ensure the improvement session segment is generated before constructing the log context
- keep logging context initialization consistent for downstream error reporting

## Testing
- npm test -- tests/uploadFormatsTemplates.e2e.test.js *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68e3d563bca0832ba609796f2fc8de35