### PR TITLE
Fix initialization order for generation session logging context

### DIFF
--- a/server.js
+++ b/server.js
@@ -14961,15 +14961,15 @@ app.post(
     const jobId = jobIdInput;
     res.locals.jobId = jobId;
     const requestId = res.locals.requestId;
+    const generationSessionSegment =
+      sanitizeS3KeyComponent(requestId, { fallback: '' }) ||
+      sanitizeS3KeyComponent(`session-${createIdentifier()}`);
     const logContext = {
       requestId,
       jobId,
       route: 'generate-enhanced-docs',
       sessionId: generationSessionSegment,
     };
-    const generationSessionSegment =
-      sanitizeS3KeyComponent(requestId, { fallback: '' }) ||
-      sanitizeS3KeyComponent(`session-${createIdentifier()}`);
 
     captureUserContext(req, res);
 


### PR DESCRIPTION
## Summary
- ensure the generation session segment is created before building the logging context to prevent ReferenceError during enhanced document generation

## Testing
- `npm test -- tests/uploadFormatsTemplates.e2e.test.js` *(fails: Cannot find package '@babel/preset-env')*

------
https://chatgpt.com/codex/tasks/task_e_68e3d78c8f0c832bad65053ace0a835a