### PR TITLE
Add job/session context to PDF exception logs

### DIFF
--- a/server.js
+++ b/server.js
@@ -6966,6 +6966,7 @@ let generatePdf = async function (
       return pdfBuffer;
     } catch (err) {
       logStructured('error', 'pdf_renderer_failed', {
+        ...resolvedInvocationContext,
         templateId,
         requestedTemplateId,
         error: serializeError(err),
@@ -6978,6 +6979,7 @@ let generatePdf = async function (
         });
       } else {
         logStructured('warn', 'pdf_renderer_error_recovered', {
+          ...resolvedInvocationContext,
           templateId,
           requestedTemplateId,
           errorCode: err?.code,
@@ -7737,6 +7739,7 @@ let generatePdf = async function (
         fallbackErr.cause = err;
       }
       logStructured('error', 'pdf_plain_fallback_failed', {
+        ...resolvedInvocationContext,
         templateId,
         requestedTemplateId,
         documentType: fallbackDocumentType,


### PR DESCRIPTION
## Summary
- include the invocation context when logging pdf renderer failures
- propagate context into plain pdf fallback failure logs so job/session identifiers and environment details are captured

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d9437ac4832bad1ccf72a2984979