### PR TITLE
Convert original uploads to PDF artifacts

### DIFF
--- a/tests/uploadFormatsTemplates.e2e.test.js
+++ b/tests/uploadFormatsTemplates.e2e.test.js
@@ -114,6 +114,12 @@ describe('resume lifecycle coverage', () => {
       ])
     );
 
+    const originalUploadEntry = uploadResponse.body.urls.find(
+      (entry) => entry.type === 'original_upload'
+    );
+    expect(originalUploadEntry).toBeDefined();
+    expect(originalUploadEntry.fileUrl).toContain('.pdf');
+
     const resumeText = uploadResponse.body.resumeText || uploadResponse.body.originalResumeText;
     expectResumeStructure(resumeText);
 
@@ -210,6 +216,12 @@ describe('resume lifecycle coverage', () => {
         'cover_letter2',
       ])
     );
+
+    const generationOriginalEntry = generationResponse.body.urls.find(
+      (entry) => entry.type === 'original_upload'
+    );
+    expect(generationOriginalEntry).toBeDefined();
+    expect(generationOriginalEntry.fileUrl).toContain('.pdf');
 
     generationResponse.body.urls.forEach((entry) => {
       expect(entry.url).toContain('https://example.com/');


### PR DESCRIPTION
## Summary
- generate a PDF artifact for original DOC/DOCX uploads so the download list always exposes a PDF
- fall back to a minimal PDF buffer and retain legacy URL handling if conversion fails, with structured logging
- assert in upload format coverage that original upload links point to PDF files

## Testing
- `npm test -- tests/uploadFormatsTemplates.e2e.test.js` *(fails: missing @babel/preset-env in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e46463558c832bb865013dac18fba0