### PR TITLE
Fix normalized URL handling in server build

### DIFF
--- a/server.js
+++ b/server.js
@@ -14879,7 +14879,7 @@ async function generateEnhancedDocumentsResponse({
     urls.push(urlEntry);
   }
 
-  const normalizedUrls = ensureOutputFileUrls(urls);
+  let normalizedUrls = ensureOutputFileUrls(urls);
   if (!normalizedUrls.length && urls.length) {
     const fallbackUrls = urls
       .map((entry) => {


### PR DESCRIPTION
## Summary
- allow normalized URL collections to be recomputed when fallback links are generated

## Testing
- `sam build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e481035260832bb276ac0a227524f6