### PR TITLE
Ensure whitespace cover letters trigger fallback copy

### DIFF
--- a/server.js
+++ b/server.js
@@ -14187,20 +14187,24 @@ async function generateEnhancedDocumentsResponse({
     resumeText: combinedProfile,
   });
   const missingCoverLetters = [];
-  if (!coverData.cover_letter1) {
-    const fallback = fallbackLetters.cover_letter1?.trim();
-    if (fallback) {
-      coverData.cover_letter1 = fallback;
-      missingCoverLetters.push('cover_letter1');
+  const ensureCoverLetterValue = (key) => {
+    const currentValue = coverData[key];
+    const hasUsableValue =
+      typeof currentValue === 'string' && currentValue.trim().length > 0;
+    if (hasUsableValue) {
+      return;
     }
-  }
-  if (!coverData.cover_letter2) {
-    const fallback = fallbackLetters.cover_letter2?.trim();
-    if (fallback) {
-      coverData.cover_letter2 = fallback;
-      missingCoverLetters.push('cover_letter2');
+    const fallbackValue = fallbackLetters?.[key];
+    const normalizedFallback =
+      typeof fallbackValue === 'string' ? fallbackValue.trim() : '';
+    if (normalizedFallback) {
+      coverData[key] = normalizedFallback;
+      missingCoverLetters.push(key);
     }
-  }
+  };
+
+  ensureCoverLetterValue('cover_letter1');
+  ensureCoverLetterValue('cover_letter2');
   if (missingCoverLetters.length) {
     logStructured('warn', 'generation_cover_letters_fallback', {
       ...logContext,


### PR DESCRIPTION
## Summary
- ensure cover letter fallbacks replace blank or whitespace-only responses so users still receive drafts
- log fallback usage and keep unavailable messaging for cases where no cover letter text can be produced
- add an API test that verifies whitespace cover letters are converted to fallback text and surface the expected message

## Testing
- npm test -- --runTestsByPath tests/server.test.js --testNamePattern="replaces whitespace cover letters" --silent

------
https://chatgpt.com/codex/tasks/task_e_68e482f77170832bba7df6f29ada01cc