### PR TITLE
Add cover letter template options to match CV selection

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -825,25 +825,51 @@ const TEMPLATE_ALIASES = {
   creative: 'modern'
 }
 
-const COVER_TEMPLATE_IDS = ['cover_modern', 'cover_classic']
+const COVER_TEMPLATE_IDS = [
+  'cover_modern',
+  'cover_classic',
+  'cover_professional',
+  'cover_ats',
+  'cover_2025'
+]
 
 const COVER_TEMPLATE_ALIASES = {
   modern: 'cover_modern',
   classic: 'cover_classic',
+  professional: 'cover_professional',
+  ats: 'cover_ats',
+  '2025': 'cover_2025',
+  futuristic: 'cover_2025',
   'cover-modern': 'cover_modern',
   'cover-classic': 'cover_classic',
+  'cover-professional': 'cover_professional',
+  'cover-ats': 'cover_ats',
+  'cover-2025': 'cover_2025',
   'modern-cover': 'cover_modern',
   'classic-cover': 'cover_classic',
+  'professional-cover': 'cover_professional',
+  'ats-cover': 'cover_ats',
+  '2025-cover': 'cover_2025',
   'cover modern': 'cover_modern',
   'cover classic': 'cover_classic',
+  'cover professional': 'cover_professional',
+  'cover ats': 'cover_ats',
+  'cover 2025': 'cover_2025',
   covermodern: 'cover_modern',
   coverclassic: 'cover_classic',
+  coverprofessional: 'cover_professional',
+  coverats: 'cover_ats',
+  cover2025: 'cover_2025',
   covermidnight: 'cover_classic'
 }
 
-const CLASSIC_STYLE_TEMPLATE_IDS = new Set(['classic', 'professional'])
-
-const RESUME_TO_COVER_TEMPLATE = {}
+const RESUME_TO_COVER_TEMPLATE = {
+  modern: 'cover_modern',
+  professional: 'cover_professional',
+  classic: 'cover_classic',
+  ats: 'cover_ats',
+  2025: 'cover_2025'
+}
 
 const DEFAULT_COVER_TEMPLATE = 'cover_modern'
 
@@ -858,16 +884,19 @@ const canonicalizeCoverTemplateId = (value, fallback = '') => {
   if (typeof value !== 'string') return fallback
   const trimmed = value.trim()
   if (!trimmed) return fallback
-  if (COVER_TEMPLATE_IDS.includes(trimmed)) return trimmed
-  const normalized = trimmed.replace(/\s+/g, '_').toLowerCase()
+  const lowerTrimmed = trimmed.toLowerCase()
+  if (COVER_TEMPLATE_IDS.includes(lowerTrimmed)) return lowerTrimmed
+  const normalized = lowerTrimmed.replace(/\s+/g, '_')
   if (COVER_TEMPLATE_IDS.includes(normalized)) {
     return normalized
   }
-  const alias =
-    COVER_TEMPLATE_ALIASES[normalized] || COVER_TEMPLATE_ALIASES[trimmed.toLowerCase()]
+  const alias = COVER_TEMPLATE_ALIASES[normalized] || COVER_TEMPLATE_ALIASES[lowerTrimmed]
   if (alias) return alias
   if (normalized.includes('classic')) return 'cover_classic'
   if (normalized.includes('modern')) return 'cover_modern'
+  if (normalized.includes('professional')) return 'cover_professional'
+  if (normalized.includes('2025')) return 'cover_2025'
+  if (normalized.includes('ats')) return 'cover_ats'
   return fallback
 }
 
@@ -884,7 +913,7 @@ const deriveCoverTemplateFromResume = (templateId) => {
   if (RESUME_TO_COVER_TEMPLATE[canonical]) {
     return RESUME_TO_COVER_TEMPLATE[canonical]
   }
-  return CLASSIC_STYLE_TEMPLATE_IDS.has(canonical) ? 'cover_classic' : DEFAULT_COVER_TEMPLATE
+  return DEFAULT_COVER_TEMPLATE
 }
 
 const ensureCoverTemplateContext = (context, templateId) => {
@@ -1140,10 +1169,28 @@ const COVER_TEMPLATE_DETAILS = {
   cover_classic: {
     name: 'Classic Cover Letter',
     description: 'Elegant serif presentation with letterhead-inspired spacing and signature close.'
+  },
+  cover_professional: {
+    name: 'Professional Cover Letter',
+    description: 'Boardroom-ready styling with navy accents and structured paragraph spacing.'
+  },
+  cover_ats: {
+    name: 'ATS Cover Letter',
+    description: 'Single-column focus with neutral tones engineered for parsing clarity.'
+  },
+  cover_2025: {
+    name: 'Future Vision 2025 Cover Letter',
+    description: 'Futuristic layout with dark canvas, neon accents, and confident typography.'
   }
 }
 
-const COVER_TEMPLATE_ORDER = ['cover_modern', 'cover_classic']
+const COVER_TEMPLATE_ORDER = [
+  'cover_modern',
+  'cover_classic',
+  'cover_professional',
+  'cover_ats',
+  'cover_2025'
+]
 
 const COVER_TEMPLATE_OPTIONS = COVER_TEMPLATE_ORDER.filter((id) => COVER_TEMPLATE_DETAILS[id]).map(
   (id) => ({

--- a/client/src/components/TemplatePreview.jsx
+++ b/client/src/components/TemplatePreview.jsx
@@ -59,6 +59,27 @@ const COVER_TEMPLATE_PREVIEWS = {
     line: 'bg-amber-200/80',
     highlight: 'bg-amber-500/15 text-amber-900',
     badge: 'bg-amber-100 text-amber-700'
+  },
+  cover_professional: {
+    header: 'bg-gradient-to-r from-slate-900 via-blue-900 to-blue-700 text-slate-50',
+    border: 'border-slate-300 bg-slate-50',
+    line: 'bg-slate-200/80',
+    highlight: 'bg-blue-500/10 text-blue-900',
+    badge: 'bg-blue-100 text-blue-700'
+  },
+  cover_ats: {
+    header: 'bg-gradient-to-r from-slate-700 via-slate-600 to-slate-500 text-white',
+    border: 'border-slate-200 bg-white',
+    line: 'bg-slate-300/70',
+    highlight: 'bg-slate-400/10 text-slate-700',
+    badge: 'bg-slate-200 text-slate-700'
+  },
+  cover_2025: {
+    header: 'bg-gradient-to-r from-slate-900 via-slate-800 to-cyan-500 text-cyan-100',
+    border: 'border-slate-700 bg-slate-900 text-slate-100',
+    line: 'bg-slate-600/80',
+    highlight: 'bg-cyan-400/20 text-cyan-100',
+    badge: 'bg-cyan-500/30 text-cyan-100'
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -81,6 +81,9 @@ const axiosResponseInterceptor = ensureAxiosResponseInterceptor(axios);
 const COVER_TEMPLATE_DISPLAY_NAMES = {
   cover_modern: 'Modern Cover Letter',
   cover_classic: 'Classic Cover Letter',
+  cover_professional: 'Professional Cover Letter',
+  cover_ats: 'ATS Cover Letter',
+  cover_2025: 'Future Vision 2025 Cover Letter',
 };
 
 function formatTemplateDisplayName(templateId) {
@@ -1560,9 +1563,29 @@ const CV_TEMPLATE_ALIASES = {
 
 const CV_TEMPLATES = ['modern', 'professional', 'classic', 'ats', '2025'];
 const LEGACY_CV_TEMPLATES = Object.keys(CV_TEMPLATE_ALIASES);
-const CL_TEMPLATES = ['cover_modern', 'cover_classic'];
+const CL_TEMPLATES = [
+  'cover_modern',
+  'cover_classic',
+  'cover_professional',
+  'cover_ats',
+  'cover_2025',
+];
 const COVER_LETTER_VARIANT_KEYS = ['cover_letter1', 'cover_letter2'];
-const CLASSIC_CV_TEMPLATES = new Set(['classic', 'professional']);
+const COVER_TEMPLATE_ALIASES = {
+  modern: 'cover_modern',
+  classic: 'cover_classic',
+  professional: 'cover_professional',
+  ats: 'cover_ats',
+  '2025': 'cover_2025',
+  futuristic: 'cover_2025',
+};
+const COVER_TEMPLATE_BY_RESUME = {
+  modern: 'cover_modern',
+  classic: 'cover_classic',
+  professional: 'cover_professional',
+  ats: 'cover_ats',
+  2025: 'cover_2025',
+};
 const USER_TEMPLATE_ITEM_TYPE = 'USER_TEMPLATE_PREFERENCE';
 const USER_TEMPLATE_PREFIX = 'user_template#';
 const TEMPLATE_IDS = [...CV_TEMPLATES, ...LEGACY_CV_TEMPLATES]; // Backwards compatibility
@@ -1769,16 +1792,29 @@ function canonicalizeCoverTemplateId(templateId, fallback = CL_TEMPLATES[0]) {
   if (!templateId || typeof templateId !== 'string') {
     return fallback;
   }
-  const normalized = templateId.trim();
-  if (!normalized) {
+  const trimmed = templateId.trim();
+  if (!trimmed) {
     return fallback;
   }
+  const lowerTrimmed = trimmed.toLowerCase();
+  if (CL_TEMPLATES.includes(lowerTrimmed)) {
+    return lowerTrimmed;
+  }
+  const normalized = lowerTrimmed.replace(/\s+/g, '_');
   if (CL_TEMPLATES.includes(normalized)) {
     return normalized;
   }
-  const base = normalized.split(/[-_]/)[0];
-  if (base && CL_TEMPLATES.includes(base)) {
-    return base;
+  if (COVER_TEMPLATE_ALIASES[normalized]) {
+    return COVER_TEMPLATE_ALIASES[normalized];
+  }
+  if (COVER_TEMPLATE_ALIASES[lowerTrimmed]) {
+    return COVER_TEMPLATE_ALIASES[lowerTrimmed];
+  }
+  if (normalized.startsWith('cover_')) {
+    const suffix = normalized.slice('cover_'.length);
+    if (COVER_TEMPLATE_ALIASES[suffix]) {
+      return COVER_TEMPLATE_ALIASES[suffix];
+    }
   }
   return fallback;
 }
@@ -1788,10 +1824,7 @@ function deriveCoverTemplateFromCv(templateId) {
   if (!canonical) {
     return CL_TEMPLATES[0];
   }
-  if (CLASSIC_CV_TEMPLATES.has(canonical)) {
-    return 'cover_classic';
-  }
-  return 'cover_modern';
+  return COVER_TEMPLATE_BY_RESUME[canonical] || CL_TEMPLATES[0];
 }
 
 function uniqueValidCoverTemplates(list = []) {
@@ -7410,6 +7443,37 @@ let generatePdf = async function (
       nameFontSize: 30,
       bodyFontSize: 12,
       margin: 56
+    },
+    cover_professional: {
+      ...baseStyle,
+      headingColor: '#1d4ed8',
+      textColor: '#0f172a',
+      nameColor: '#0f172a',
+      headingFontSize: 16,
+      nameFontSize: 30,
+      bodyFontSize: 12,
+      margin: 56
+    },
+    cover_ats: {
+      ...baseStyle,
+      headingColor: '#1f2937',
+      textColor: '#1f2937',
+      nameColor: '#111827',
+      headingFontSize: 15,
+      nameFontSize: 28,
+      bodyFontSize: 11,
+      margin: 58
+    },
+    cover_2025: {
+      ...baseStyle,
+      headingColor: '#22d3ee',
+      textColor: '#e0f2fe',
+      nameColor: '#22d3ee',
+      headingFontSize: 17,
+      nameFontSize: 32,
+      bodyFontSize: 12,
+      margin: 60,
+      backgroundColor: '#0f172a'
     }
   };
 
@@ -7613,7 +7677,17 @@ let generatePdf = async function (
         if (fsSync.existsSync(hItalic)) doc.registerFont('Helvetica-Oblique', hItalic);
       } catch {}
       if (robotoAvailable) {
-        ['modern', 'professional', 'classic', 'ats', '2025', 'cover_modern'].forEach((tpl) => {
+        [
+          'modern',
+          'professional',
+          'classic',
+          'ats',
+          '2025',
+          'cover_modern',
+          'cover_professional',
+          'cover_ats',
+          'cover_2025'
+        ].forEach((tpl) => {
           if (styleMap[tpl]) {
             styleMap[tpl].font = 'Roboto';
             styleMap[tpl].bold = 'Roboto-Bold';

--- a/templates/cover_2025.html
+++ b/templates/cover_2025.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Cover Letter</title>
+  <style>
+    body { font-family: 'Poppins', 'Segoe UI', sans-serif; margin: 56px; background: #0f172a; color: #e0f2fe; line-height: 1.7; }
+    h1 { color: #22d3ee; margin-bottom: 20px; font-size: 32px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; }
+    p { margin: 0 0 16px; }
+  </style>
+</head>
+<body>
+  <h1>{{name}}</h1>
+  {{#each sections}}
+    {{#each items}}
+      <p>{{{this}}}</p>
+    {{/each}}
+  {{/each}}
+</body>
+</html>

--- a/templates/cover_ats.html
+++ b/templates/cover_ats.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Cover Letter</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 50px; color: #1f2937; line-height: 1.5; }
+    h1 { color: #111827; margin-bottom: 16px; font-size: 28px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; }
+    p { margin: 0 0 12px; }
+  </style>
+</head>
+<body>
+  <h1>{{name}}</h1>
+  {{#each sections}}
+    {{#each items}}
+      <p>{{{this}}}</p>
+    {{/each}}
+  {{/each}}
+</body>
+</html>

--- a/templates/cover_professional.html
+++ b/templates/cover_professional.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Cover Letter</title>
+  <style>
+    body { font-family: 'Helvetica Neue', Arial, sans-serif; margin: 48px; color: #0f172a; line-height: 1.6; }
+    h1 { color: #1d4ed8; margin-bottom: 18px; font-size: 30px; font-weight: 700; letter-spacing: 0.04em; }
+    p { margin: 0 0 14px; }
+  </style>
+</head>
+<body>
+  <h1>{{name}}</h1>
+  {{#each sections}}
+    {{#each items}}
+      <p>{{{this}}}</p>
+    {{/each}}
+  {{/each}}
+</body>
+</html>

--- a/templates/portal.html
+++ b/templates/portal.html
@@ -227,6 +227,9 @@
             <option value="">Let ResumeForge decide</option>
             <option value="cover_modern">Modern</option>
             <option value="cover_classic">Classic</option>
+            <option value="cover_professional">Professional</option>
+            <option value="cover_ats">ATS</option>
+            <option value="cover_2025">2025</option>
           </select>
         </label>
         <button type="submit">Evaluate me against the JD</button>

--- a/tests/generatePdf.test.js
+++ b/tests/generatePdf.test.js
@@ -16,10 +16,16 @@ import fs from 'fs/promises';
 import path from 'path';
 import Handlebars from '../lib/handlebars.js';
 
-const CLASSIC_CV_TEMPLATES = new Set(['classic', 'professional']);
+const EXPECTED_COVER_BY_TEMPLATE = {
+  modern: 'cover_modern',
+  professional: 'cover_professional',
+  classic: 'cover_classic',
+  ats: 'cover_ats',
+  2025: 'cover_2025',
+};
 
 const expectedCoverForTemplate = (templateId) =>
-  CLASSIC_CV_TEMPLATES.has(templateId) ? 'cover_classic' : 'cover_modern';
+  EXPECTED_COVER_BY_TEMPLATE[templateId] || 'cover_modern';
 
 function escapeHtml(str = '') {
   return str

--- a/tests/selectTemplatesGroup.test.js
+++ b/tests/selectTemplatesGroup.test.js
@@ -13,9 +13,14 @@ describe('selectTemplates respects preferred templates and contrast', () => {
     expect(CV_TEMPLATE_GROUPS[template1]).not.toBe(
       CV_TEMPLATE_GROUPS[template2]
     );
-    const expectedCover = ['classic', 'professional'].includes(template1)
-      ? 'cover_classic'
-      : 'cover_modern';
+    const expectedCoverMap = {
+      modern: 'cover_modern',
+      professional: 'cover_professional',
+      classic: 'cover_classic',
+      ats: 'cover_ats',
+      2025: 'cover_2025'
+    };
+    const expectedCover = expectedCoverMap[template1] || 'cover_modern';
     expect(coverTemplate1).toBe(expectedCover);
   });
 
@@ -26,8 +31,8 @@ describe('selectTemplates respects preferred templates and contrast', () => {
     expect(template1).toBe('ats');
     expect(template2).not.toBe('ats');
     expect(CV_TEMPLATE_GROUPS[template2]).not.toBe(CV_TEMPLATE_GROUPS['ats']);
-    expect(coverTemplate1).toBe('cover_modern');
-    expect(coverTemplates[0]).toBe('cover_modern');
+    expect(coverTemplate1).toBe('cover_ats');
+    expect(coverTemplates[0]).toBe('cover_ats');
   });
 
   test('derives cover template from resume style when not provided', () => {


### PR DESCRIPTION
## Summary
- expand the client dropdown data so both CV and cover letter selectors list Modern, Classic, Professional, ATS, and 2025 templates
- wire the server template registry, canonicalization, and PDF fallback styling to the new cover letter variants and add HTML sources for each style
- refresh supporting UI and tests (portal form, preview palettes, template selection tests) to recognise the additional cover templates

## Testing
- npm test *(fails: requires @babel/preset-env and jsdom environment which are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4862a5350832b85ca2fba13a3ce17