### PR TITLE
Organize S3 artifacts by template structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,23 +384,24 @@ ownload URLs expire after one hour:
 
 `originalScore` represents the percentage match between the job description and the uploaded resume. `enhancedScore` is the best match achieved by the generated resumes. `table` details how each job skill matched, `addedSkills` shows skills newly matched in the enhanced resume, and `missingSkills` lists skills from the job description still absent.
 
-S3 keys follow the pattern `cv/<candidate>/<ISO-date>/<session-id>/runs/<request-id>/<document>.pdf`, where `<document>` identifies the variant (`original.pdf`, `enhanced_<template>.pdf`, `cover_letter_<template>.pdf`). Each generation run receives its own folder so regenerated resumes and cover letters never overwrite prior artifacts. The run-specific change log and extracted text live alongside the PDFs under `cv/<candidate>/<ISO-date>/<session-id>/runs/<request-id>/artifacts/`, while the canonical session history is written to `cv/<candidate>/<ISO-date>/<session-id>/logs/change-log.json`. The API returns presigned download URLs along with an ISO 8601 timestamp (`expiresAt`) that indicates when each link will expire.
+S3 keys follow the pattern `cv/<candidate>/<session>/<template>/<variant>.pdf`, so every generated document is tagged by the template that produced it (for example, `cv/jane_doe/session-123/modern/version1.pdf` or `cv/jane_doe/session-123/cover_modern/cover_letter1.pdf`). Text artifacts produced during the same run live under `cv/<candidate>/<session>/artifacts/`, while the canonical session history is written to `cv/<candidate>/<session>/logs/change-log.json`. The API returns presigned download URLs along with an ISO 8601 timestamp (`expiresAt`) that indicates when each link will expire.
 
 ```
-cv/jane_doe/2025-01-15/1fb6e8c6-7b2f-46dc-89c9-1dd2efdd8793/
+cv/jane_doe/session-123/
 ├── original.pdf
-├── logs/
-│   └── processing.jsonl
-└── runs/7c86e7bf-f3d8-4ed8-98d8-65b3b2d0d5cb/
-    ├── enhanced_modern_classic.pdf
-    ├── enhanced_elegant_slate.pdf
-    ├── cover_letter_refined.pdf
-    ├── cover_letter_refined_2.pdf
-    └── artifacts/
-        ├── original.json
-        ├── version1.json
-        ├── version2.json
-        └── changelog.json
+├── modern/
+│   ├── version1.pdf
+│   └── version2.pdf
+├── cover_modern/
+│   ├── cover_letter1.pdf
+│   └── cover_letter2.pdf
+├── artifacts/
+│   ├── original.json
+│   ├── version1.json
+│   ├── version2.json
+│   └── changelog.json
+└── logs/
+    └── processing.jsonl
 ```
 
 Each entry in `urls` points to a PDF stored in Amazon S3. If no cover letters or CVs are produced, the server responds with HTTP 500 and an error message.

--- a/tests/awsStorage.integration.test.js
+++ b/tests/awsStorage.integration.test.js
@@ -100,7 +100,11 @@ describe('AWS integrations for /api/process-cv', () => {
         command.key.includes('cv/')
     );
     expect(generatedPdf).toBeTruthy();
-    expect(generatedPdf.key).toContain('/runs/');
+    const pdfSegments = generatedPdf.key.split('/');
+    expect(pdfSegments.length).toBeGreaterThanOrEqual(5);
+    expect(pdfSegments[0]).toBe('cv');
+    expect(pdfSegments[3]).toMatch(/[a-z0-9_-]+/);
+    expect(pdfSegments[4]).toMatch(/[a-z0-9_-]+\.pdf$/);
 
     const dynamoPut = mocks.mockDynamoSend.mock.calls.find(
       ([command]) => command.__type === 'PutItemCommand'

--- a/tests/processCvTemplates.integration.test.js
+++ b/tests/processCvTemplates.integration.test.js
@@ -43,7 +43,7 @@ describe('template coverage for /api/process-cv', () => {
 
       expect(pdfCommands.length).toBeGreaterThan(0);
       expect(
-        pdfCommands.some((command) => command.input.Key.includes(`enhanced_${templateId}`))
+        pdfCommands.some((command) => command.input.Key.includes(`/${templateId}/`))
       ).toBe(true);
       const generatedPdfCommands = pdfCommands.filter(
         (command) => !/\/incoming\//.test(String(command.input?.Key))

--- a/tests/uploadFlow.e2e.test.js
+++ b/tests/uploadFlow.e2e.test.js
@@ -180,7 +180,11 @@ describe('upload to download flow (e2e)', () => {
 
     expect(pdfKeys.length).toBeGreaterThanOrEqual(4);
     expect(pdfKeys.join('\n')).toContain('cv/');
-    expect(pdfKeys.join('\n')).toContain('cover_letter_');
-    expect(pdfKeys.join('\n')).toContain('/runs/');
+    pdfKeys.forEach((key) => {
+      const segments = key.split('/');
+      expect(segments.length).toBeGreaterThanOrEqual(5);
+    });
+    expect(pdfKeys.some((key) => key.endsWith('/cover_letter1.pdf'))).toBe(true);
+    expect(pdfKeys.some((key) => key.endsWith('/cover_letter2.pdf'))).toBe(true);
   });
 });

--- a/tests/uploadFormatsTemplates.e2e.test.js
+++ b/tests/uploadFormatsTemplates.e2e.test.js
@@ -255,9 +255,14 @@ describe('resume lifecycle coverage', () => {
 
     expect(pdfKeys.length).toBeGreaterThanOrEqual(4);
     expect(pdfKeys.join('\n')).toContain('cv/');
-    expect(pdfKeys.join('\n')).toContain('/runs/');
-    expect(pdfKeys.some((key) => key.includes('enhanced_'))).toBe(true);
-    expect(pdfKeys.some((key) => key.includes('cover_letter_'))).toBe(true);
+    pdfKeys.forEach((key) => {
+      const segments = key.split('/');
+      expect(segments.length).toBeGreaterThanOrEqual(5);
+    });
+    expect(pdfKeys.some((key) => key.endsWith('/version1.pdf'))).toBe(true);
+    expect(pdfKeys.some((key) => key.endsWith('/version2.pdf'))).toBe(true);
+    expect(pdfKeys.some((key) => key.endsWith('/cover_letter1.pdf'))).toBe(true);
+    expect(pdfKeys.some((key) => key.endsWith('/cover_letter2.pdf'))).toBe(true);
     const pdfPutCommands = mocks.mockS3Send.mock.calls
       .map(([command]) => command)
       .filter(
@@ -396,11 +401,11 @@ describe('resume lifecycle coverage', () => {
       .filter((key) => typeof key === 'string' && key.endsWith('.pdf'));
 
     CV_TEMPLATES.forEach((template) => {
-      expect(pdfKeys.some((key) => key.includes(`enhanced_${template}`))).toBe(true);
+      expect(pdfKeys.some((key) => key.includes(`/${template}/`))).toBe(true);
     });
 
     CL_TEMPLATES.forEach((template) => {
-      expect(pdfKeys.some((key) => key.includes(`cover_letter_${template}`))).toBe(true);
+      expect(pdfKeys.some((key) => key.includes(`/${template}/`))).toBe(true);
     });
   }, TEST_TIMEOUT_MS);
 });


### PR DESCRIPTION
## Summary
- update S3 key generation so generated PDFs live under cv/<candidate>/<session>/<template>/<variant>.pdf
- add helpers to sanitize and dedupe template-scoped keys and adjust artifact handling accordingly
- refresh docs and tests to reflect the new storage layout and expectations

## Testing
- npm test *(fails: environment is missing @babel/preset-env and jest-environment-jsdom, preventing suites from running)*

------
https://chatgpt.com/codex/tasks/task_e_68e5404e0218832b9cbe13684656f54a