### PR TITLE
Align inline markers with template styling

### DIFF
--- a/server.js
+++ b/server.js
@@ -6104,12 +6104,25 @@ function renderSectionTokensToHtml(
   { sectionKey, enhancementTokenMap, presentation } = {}
 ) {
   let skipBullets = false;
-  if (presentation && Object.prototype.hasOwnProperty.call(presentation, 'showMarkers')) {
-    skipBullets = presentation.showMarkers === false;
+  let presentationMarkerClasses = [];
+  if (presentation) {
+    if (Object.prototype.hasOwnProperty.call(presentation, 'showMarkers')) {
+      skipBullets = presentation.showMarkers === false;
+    }
+    if (presentation.markerClass) {
+      presentationMarkerClasses = String(presentation.markerClass)
+        .split(/\s+/)
+        .filter(Boolean);
+    }
   } else if (sectionKey) {
     try {
       const resolvedPresentation = resolveTemplatePresentation(sectionKey);
       skipBullets = resolvedPresentation.showMarkers === false;
+      if (resolvedPresentation.markerClass) {
+        presentationMarkerClasses = String(resolvedPresentation.markerClass)
+          .split(/\s+/)
+          .filter(Boolean);
+      }
     } catch {
       skipBullets = sectionKey === 'summary' || sectionKey === 'contact';
     }
@@ -6133,10 +6146,11 @@ function renderSectionTokensToHtml(
       if (t.type === 'tab') return '<span class="tab"></span>';
       if (t.type === 'bullet') {
         if (skipBullets) return '';
-        if (sectionKey === 'education') {
-          return '<span class="edu-bullet">•</span> ';
-        }
-        return '<span class="bullet">•</span> ';
+        const baseClass = sectionKey === 'education' ? 'edu-bullet' : 'bullet';
+        const classNames = new Set([baseClass]);
+        presentationMarkerClasses.forEach((cls) => classNames.add(cls));
+        const classAttr = `class="${Array.from(classNames).join(' ')}"`;
+        return `<span ${classAttr}>•</span> `;
       }
       if (t.type === 'jobsep') return '';
       return text;

--- a/templates/2025.css
+++ b/templates/2025.css
@@ -195,6 +195,11 @@ body {
   min-width: 0;
 }
 
+.section-item .item-content .bullet,
+.section-item .item-content .edu-bullet {
+  display: none;
+}
+
 .section-item strong {
   color: var(--accent);
 }

--- a/templates/modern.html
+++ b/templates/modern.html
@@ -199,6 +199,11 @@
       min-width: 0;
     }
 
+    .content .bullet,
+    .content .edu-bullet {
+      display: none;
+    }
+
     strong {
       color: #f8fafc;
     }

--- a/templates/professional.html
+++ b/templates/professional.html
@@ -165,6 +165,11 @@
       min-width: 0;
     }
 
+    .item-text .bullet,
+    .item-text .edu-bullet {
+      display: none;
+    }
+
     strong {
       color: var(--accent);
     }

--- a/tests/templateSections.test.js
+++ b/tests/templateSections.test.js
@@ -57,12 +57,14 @@ describe('buildTemplateSectionContext', () => {
     expect(contactSection.showMarkers).toBe(false);
 
     const experienceSection = context.sections.find((sec) => sec.key === 'experience');
-    expect(experienceSection.htmlItems[0]).toContain('class="bullet"');
+    expect(experienceSection.htmlItems[0]).toContain('class="bullet');
+    expect(experienceSection.htmlItems[0]).toContain('marker--experience');
     expect(experienceSection.showMarkers).toBe(true);
     expect(experienceSection.markerClass).toContain('marker--experience');
 
     const educationSection = context.sections.find((sec) => sec.key === 'education');
-    expect(educationSection.htmlItems[0]).toContain('class="edu-bullet"');
+    expect(educationSection.htmlItems[0]).toContain('class="edu-bullet');
+    expect(educationSection.htmlItems[0]).toContain('marker--education');
     expect(educationSection.markerClass).toContain('marker--education');
 
     const skillsSection = context.sections.find((sec) => sec.key === 'skills');


### PR DESCRIPTION
## Summary
- propagate presentation marker classes onto inline bullet spans so templates can style section-specific markers consistently
- suppress inline bullet glyphs in templates that render their own marker elements to preserve intended bullet shapes
- update template section tests to expect marker class propagation on experience and education bullets

## Testing
- npm test -- --watch=false *(fails: Cannot find package '@babel/preset-env')*


------
https://chatgpt.com/codex/tasks/task_e_68e55367a394832ba2d65e94dd4bd7af