### PR TITLE
Allow independent cover letter template selection

### DIFF
--- a/client/src/components/TemplatePicker.jsx
+++ b/client/src/components/TemplatePicker.jsx
@@ -14,6 +14,8 @@ function TemplatePicker({
   selectedCoverTemplateName,
   selectedCoverTemplateDescription = '',
   onCoverTemplateSelect,
+  isCoverLinkedToResume = true,
+  onCoverLinkToggle,
   disabled = false,
   isApplying = false
 }) {
@@ -25,6 +27,15 @@ function TemplatePicker({
   const hasResumeOptions = Array.isArray(resumeOptions) && resumeOptions.length > 0
   const hasCoverOptions = Array.isArray(coverOptions) && coverOptions.length > 0
   const showPreview = hasResumeOptions || hasCoverOptions
+
+  const coverSelectorDescription = isCoverLinkedToResume
+    ? 'Cover letters mirror your selected CV template. Choose another style or switch off “Match CV style” to decouple them.'
+    : 'Choose a cover letter design to use even if your CV keeps a different look.'
+
+  const handleCoverLinkChange = (event) => {
+    const nextValue = event.target.checked
+    onCoverLinkToggle?.(nextValue)
+  }
 
   return (
     <>
@@ -42,15 +53,39 @@ function TemplatePicker({
       )}
 
       {hasCoverOptions && (
-        <TemplateSelector
-          idPrefix={coverSelectorIdPrefix}
-          title="Cover Letter Template"
-          description="Align your letter visuals with your selected CV or explore a bold alternative."
-          options={coverOptions}
-          selectedTemplate={selectedCoverTemplateId}
-          onSelect={onCoverTemplateSelect}
-          disabled={disabled}
-        />
+        <div className="space-y-3">
+          {typeof onCoverLinkToggle === 'function' && (
+            <div className="rounded-2xl border border-purple-100 bg-purple-50/50 p-3">
+              <label className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  className="mt-1 h-4 w-4 rounded border-purple-300 text-purple-600 focus:ring-purple-400"
+                  checked={isCoverLinkedToResume}
+                  onChange={handleCoverLinkChange}
+                  disabled={disabled}
+                />
+                <span>
+                  <span className="block text-sm font-semibold text-purple-700">
+                    Match cover letter style to CV template
+                  </span>
+                  <span className="mt-1 block text-xs text-purple-600">
+                    Uncheck or pick a new cover letter template to mix and match styles.
+                  </span>
+                </span>
+              </label>
+            </div>
+          )}
+
+          <TemplateSelector
+            idPrefix={coverSelectorIdPrefix}
+            title="Cover Letter Template"
+            description={coverSelectorDescription}
+            options={coverOptions}
+            selectedTemplate={selectedCoverTemplateId}
+            onSelect={onCoverTemplateSelect}
+            disabled={disabled}
+          />
+        </div>
       )}
 
       {showPreview && (
@@ -65,6 +100,7 @@ function TemplatePicker({
           availableCoverTemplates={coverOptions}
           onResumeTemplateApply={onResumeTemplateSelect}
           onCoverTemplateApply={onCoverTemplateSelect}
+          isCoverLinkedToResume={isCoverLinkedToResume}
           isApplying={isApplying}
         />
       )}

--- a/client/src/components/TemplatePreview.jsx
+++ b/client/src/components/TemplatePreview.jsx
@@ -227,6 +227,7 @@ function TemplatePreview({
   availableCoverTemplates = [],
   onResumeTemplateApply,
   onCoverTemplateApply,
+  isCoverLinkedToResume = false,
   isApplying = false
 }) {
   const normalizedResumeTemplates = useMemo(() => {
@@ -512,6 +513,8 @@ function TemplatePreview({
           style,
           note: isApplied
             ? 'This cover letter style is currently selected for your downloads.'
+            : isCoverLinkedToResume
+            ? 'Apply this cover letter style to break the sync with your CV template and use it for your downloads.'
             : 'Apply this cover letter style to use it for your downloads.',
           canApply: !isApplied && Boolean(onCoverTemplateApply)
         }
@@ -525,7 +528,9 @@ function TemplatePreview({
           option: previewCoverOption,
           style: coverStyle,
           note: isPreviewingDifferentCover
-            ? 'Apply this look to replace your current cover letter style.'
+            ? isCoverLinkedToResume
+              ? 'Apply this look to break the sync with your CV template and refresh your cover letter style.'
+              : 'Apply this look to replace your current cover letter style.'
             : 'Already applied to your downloads.',
           canApply: isPreviewingDifferentCover && Boolean(onCoverTemplateApply)
         },
@@ -680,6 +685,11 @@ function TemplatePreview({
                 ? `Currently applied: ${appliedCoverName}. Compare styles below before updating.`
                 : 'This template is already applied to your downloads.'}
             </p>
+            {isCoverLinkedToResume && (
+              <p className="mt-1 text-xs text-purple-500">
+                Cover letters stay synced with your CV until you pick a new style or turn off “Match CV style”.
+              </p>
+            )}
           </div>
           {normalizedCoverTemplates.length > 1 && (
             <div className="space-y-3">


### PR DESCRIPTION
## Summary
- track whether cover letters should stay linked to the chosen CV template or can diverge
- add UI controls so users can match or decouple cover letter styling and update preview messaging accordingly
- ensure cover template context honours the user’s preference when syncing or selecting templates

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e5574ae6d8832b91aa9a92c88e2d21