### PR TITLE
Restore bullet markers in modern template

### DIFF
--- a/templates/modern.html
+++ b/templates/modern.html
@@ -199,11 +199,6 @@
       min-width: 0;
     }
 
-    .content .bullet,
-    .content .edu-bullet {
-      display: none;
-    }
-
     strong {
       color: #f8fafc;
     }


### PR DESCRIPTION
## Summary
- remove the CSS rule in the modern HTML template that hid bullet markers so section bullets remain visible

## Testing
- npm test -- --runTestsByPath tests/boldHeadings.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e55e216f28832b8eb91c7e8849768d