### PR TITLE
Clarify independent cover letter styling options

### DIFF
--- a/client/src/components/TemplatePicker.jsx
+++ b/client/src/components/TemplatePicker.jsx
@@ -28,9 +28,19 @@ function TemplatePicker({
   const hasCoverOptions = Array.isArray(coverOptions) && coverOptions.length > 0
   const showPreview = hasResumeOptions || hasCoverOptions
 
+  const normalizedCoverTemplateName = (() => {
+    if (typeof selectedCoverTemplateName !== 'string') {
+      return 'your selected cover letter style'
+    }
+    const trimmed = selectedCoverTemplateName.trim()
+    return trimmed || 'your selected cover letter style'
+  })()
   const coverSelectorDescription = isCoverLinkedToResume
     ? 'Cover letters mirror your selected CV template. Choose another style or switch off “Match CV style” to decouple them.'
-    : 'Choose a cover letter design to use even if your CV keeps a different look.'
+    : `Cover letters stay in the ${normalizedCoverTemplateName} design even if your CV uses another template. Pick a new style whenever you like.`
+  const coverLinkHelperText = isCoverLinkedToResume
+    ? 'Uncheck or pick a new cover letter template to mix and match styles.'
+    : 'Cover letters stay in this design when you swap CV templates.'
 
   const handleCoverLinkChange = (event) => {
     const nextValue = event.target.checked
@@ -68,9 +78,7 @@ function TemplatePicker({
                   <span className="block text-sm font-semibold text-purple-700">
                     Match cover letter style to CV template
                   </span>
-                  <span className="mt-1 block text-xs text-purple-600">
-                    Uncheck or pick a new cover letter template to mix and match styles.
-                  </span>
+                  <span className="mt-1 block text-xs text-purple-600">{coverLinkHelperText}</span>
                 </span>
               </label>
             </div>

--- a/client/src/components/TemplatePreview.jsx
+++ b/client/src/components/TemplatePreview.jsx
@@ -410,6 +410,20 @@ function TemplatePreview({
   const appliedCoverName =
     appliedCoverOption?.name || coverTemplateName || coverTemplateId || 'your current cover style'
 
+  const independentCoverDescriptor = useMemo(() => {
+    if (!appliedCoverName || typeof appliedCoverName !== 'string') {
+      return 'your selected cover letter style'
+    }
+    const trimmed = appliedCoverName.trim()
+    if (!trimmed) {
+      return 'your selected cover letter style'
+    }
+    if (/cover/i.test(trimmed)) {
+      return trimmed
+    }
+    return `${trimmed} cover letter style`
+  }, [appliedCoverName])
+
   const isPreviewingDifferentResume =
     previewResumeOption?.id && resumeTemplateId && previewResumeOption.id !== resumeTemplateId
   const isPreviewingDifferentCover =
@@ -685,11 +699,11 @@ function TemplatePreview({
                 ? `Currently applied: ${appliedCoverName}. Compare styles below before updating.`
                 : 'This template is already applied to your downloads.'}
             </p>
-            {isCoverLinkedToResume && (
-              <p className="mt-1 text-xs text-purple-500">
-                Cover letters stay synced with your CV until you pick a new style or turn off “Match CV style”.
-              </p>
-            )}
+            <p className="mt-1 text-xs text-purple-500">
+              {isCoverLinkedToResume
+                ? 'Cover letters stay synced with your CV until you pick a new style or turn off “Match CV style”.'
+                : `Cover letters stay in the ${independentCoverDescriptor} even if you swap CV templates.`}
+            </p>
           </div>
           {normalizedCoverTemplates.length > 1 && (
             <div className="space-y-3">

--- a/client/src/components/__tests__/TemplatePreview.test.jsx
+++ b/client/src/components/__tests__/TemplatePreview.test.jsx
@@ -67,4 +67,12 @@ describe('TemplatePreview comparison support', () => {
     ).not.toBeInTheDocument()
     expect(screen.getAllByRole('button', { name: /Use this cover style/i })).toHaveLength(2)
   })
+
+  it('explains when the cover letter style is independent from the CV', () => {
+    renderComponent({ isCoverLinkedToResume: false })
+
+    expect(
+      screen.getByText(/Cover letters stay in the Modern Cover even if you swap CV templates/i)
+    ).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary
- highlight when cover letters are styled independently from the chosen CV template
- expand template picker copy so users know their cover letters keep the selected look even after CV changes
- document the behaviour with a dedicated TemplatePreview test

## Testing
- `npm test -- TemplatePreview --watch=false` *(fails: missing jest-environment-jsdom and @babel/preset-env in test setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b23476a0832b9d079ecc371fcf4e