### PR TITLE
Centralize resume template registry

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -25,6 +25,10 @@ import { normalizePdfBlob } from './utils/assetValidation.js'
 import { buildImprovementHintFromSegment } from './utils/actionableAdvice.js'
 import parseJobDescriptionText from './utils/parseJobDescriptionText.js'
 import { buildCategoryChangeLog } from './utils/changeLogCategorySummaries.js'
+import { BASE_TEMPLATE_OPTIONS, canonicalizeTemplateId } from './templateRegistry.js'
+
+export { BASE_TEMPLATE_OPTIONS, canonicalizeTemplateId } from './templateRegistry.js'
+export { SUPPORTED_RESUME_TEMPLATE_IDS } from './templateRegistry.js'
 
 const CV_GENERATION_ERROR_MESSAGE =
   'Our Lambda resume engine could not generate your PDFs. Please try again shortly.'
@@ -819,12 +823,6 @@ const jobFitToneStyles = {
   }
 }
 
-const TEMPLATE_ALIASES = {
-  ucmo: 'classic',
-  vibrant: 'modern',
-  creative: 'modern'
-}
-
 const COVER_TEMPLATE_IDS = [
   'cover_modern',
   'cover_classic',
@@ -872,13 +870,6 @@ const RESUME_TO_COVER_TEMPLATE = {
 }
 
 const DEFAULT_COVER_TEMPLATE = 'cover_modern'
-
-const canonicalizeTemplateId = (value) => {
-  if (typeof value !== 'string') return ''
-  const trimmed = value.trim().toLowerCase()
-  if (!trimmed) return ''
-  return TEMPLATE_ALIASES[trimmed] || trimmed
-}
 
 const canonicalizeCoverTemplateId = (value, fallback = '') => {
   if (typeof value !== 'string') return fallback
@@ -1200,34 +1191,6 @@ const formatTemplateName = (id) => {
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ')
 }
-
-const BASE_TEMPLATE_OPTIONS = [
-  {
-    id: 'modern',
-    name: 'Modern Minimal',
-    description: 'Sleek two-column layout with clean dividers and ATS-safe spacing.'
-  },
-  {
-    id: 'professional',
-    name: 'Professional Edge',
-    description: 'Refined corporate styling with confident headings and balanced whitespace.'
-  },
-  {
-    id: 'classic',
-    name: 'Classic Heritage',
-    description: 'Timeless serif typography with structured section framing.'
-  },
-  {
-    id: 'ats',
-    name: 'ATS Optimized',
-    description: 'Single-column structure engineered for parsing accuracy.'
-  },
-  {
-    id: '2025',
-    name: 'Future Vision 2025',
-    description: 'Futuristic grid layout with crisp typography and subtle neon cues.'
-  }
-]
 
 const COVER_TEMPLATE_DETAILS = {
   cover_modern: {

--- a/client/src/__tests__/templateRegistry.test.jsx
+++ b/client/src/__tests__/templateRegistry.test.jsx
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment node
+ */
+let BASE_TEMPLATE_OPTIONS
+let canonicalizeTemplateId
+
+beforeAll(async () => {
+  const registry = await import('../templateRegistry.js')
+  BASE_TEMPLATE_OPTIONS = registry.BASE_TEMPLATE_OPTIONS
+  canonicalizeTemplateId = registry.canonicalizeTemplateId
+})
+
+describe('resume template registry', () => {
+  it('exposes at least four distinct resume templates by default', () => {
+    const ids = BASE_TEMPLATE_OPTIONS.map((option) => option.id)
+    const uniqueIds = new Set(ids)
+
+    expect(uniqueIds.size).toBeGreaterThanOrEqual(4)
+    ids.forEach((id) => {
+      expect(canonicalizeTemplateId(id)).toBe(id)
+    })
+  })
+
+  it('maps legacy aliases onto supported templates', () => {
+    expect(canonicalizeTemplateId('UcMo')).toBe('classic')
+    expect(canonicalizeTemplateId('vibrant')).toBe('modern')
+    expect(canonicalizeTemplateId('creative')).toBe('modern')
+  })
+
+  it('filters unsupported or experimental template identifiers', () => {
+    ;['portal', 'precision', 'structured', 'beta-template'].forEach((id) => {
+      expect(canonicalizeTemplateId(id)).toBe('')
+    })
+  })
+})

--- a/client/src/templateRegistry.js
+++ b/client/src/templateRegistry.js
@@ -1,0 +1,49 @@
+const TEMPLATE_ALIASES = {
+  ucmo: 'classic',
+  vibrant: 'modern',
+  creative: 'modern'
+}
+
+export const SUPPORTED_RESUME_TEMPLATE_IDS = new Set([
+  'modern',
+  'professional',
+  'classic',
+  'ats',
+  '2025'
+])
+
+export const canonicalizeTemplateId = (value) => {
+  if (typeof value !== 'string') return ''
+  const trimmed = value.trim().toLowerCase()
+  if (!trimmed) return ''
+  const canonical = TEMPLATE_ALIASES[trimmed] || trimmed
+  return SUPPORTED_RESUME_TEMPLATE_IDS.has(canonical) ? canonical : ''
+}
+
+export const BASE_TEMPLATE_OPTIONS = [
+  {
+    id: 'modern',
+    name: 'Modern Minimal',
+    description: 'Sleek two-column layout with clean dividers and ATS-safe spacing.'
+  },
+  {
+    id: 'professional',
+    name: 'Professional Edge',
+    description: 'Refined corporate styling with confident headings and balanced whitespace.'
+  },
+  {
+    id: 'classic',
+    name: 'Classic Heritage',
+    description: 'Timeless serif typography with structured section framing.'
+  },
+  {
+    id: 'ats',
+    name: 'ATS Optimized',
+    description: 'Single-column structure engineered for parsing accuracy.'
+  },
+  {
+    id: '2025',
+    name: 'Future Vision 2025',
+    description: 'Futuristic grid layout with crisp typography and subtle neon cues.'
+  }
+]


### PR DESCRIPTION
## Summary
- centralize the supported resume template whitelist and canonicalizer in a shared registry module
- update the app to consume the shared registry instead of duplicating template metadata
- add focused tests to confirm aliases resolve and unsupported template drafts are filtered out

## Testing
- npm test -- templateRegistry

------
https://chatgpt.com/codex/tasks/task_e_68e5b476d6d4832bbdc6f568f6c208e1