### PR TITLE
Align fonts with selected templates

### DIFF
--- a/templates/2025.css
+++ b/templates/2025.css
@@ -12,7 +12,7 @@
 }
 
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   margin: 0;
   padding: 32px;
   color: var(--text);

--- a/templates/ats.html
+++ b/templates/ats.html
@@ -4,12 +4,10 @@
   <meta charset="UTF-8" />
   <title>Resume</title>
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;600;700&display=swap');
-
     body {
       margin: 0;
       padding: 48px 40px;
-      font-family: 'Source Sans 3', Arial, sans-serif;
+      font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
       color: #1f2937;
       background: #f3f4f6;
     }

--- a/templates/classic.html
+++ b/templates/classic.html
@@ -4,8 +4,6 @@
   <meta charset="UTF-8" />
   <title>Resume</title>
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Source+Serif+4:wght@300;400;500;600&display=swap');
-
     :root {
       --ink: #1f2933;
       --muted: #52606d;
@@ -21,7 +19,7 @@
     body {
       margin: 0;
       padding: 48px 56px;
-      font-family: 'Source Serif 4', 'Times New Roman', serif;
+      font-family: 'Times New Roman', 'Times', serif;
       color: var(--ink);
       background: linear-gradient(180deg, rgba(241, 245, 249, 0.9), transparent 120%),
         var(--background);
@@ -79,7 +77,7 @@
     }
 
     header h1 {
-      font-family: 'Playfair Display', 'Times New Roman', serif;
+      font-family: 'Times New Roman', 'Times', serif;
       font-size: 38px;
       letter-spacing: 0.04em;
       margin: 0 0 6px;
@@ -151,7 +149,7 @@
     }
 
     h2 {
-      font-family: 'Playfair Display', 'Times New Roman', serif;
+      font-family: 'Times New Roman', 'Times', serif;
       font-size: 20px;
       font-weight: 700;
       letter-spacing: 0.16em;

--- a/templates/cover_2025.html
+++ b/templates/cover_2025.html
@@ -4,7 +4,9 @@
   <meta charset="UTF-8" />
   <title>Cover Letter</title>
   <style>
-    body { font-family: 'Poppins', 'Segoe UI', sans-serif; margin: 56px; background: #0f172a; color: #e0f2fe; line-height: 1.7; }
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+    body { font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif; margin: 56px; background: #0f172a; color: #e0f2fe; line-height: 1.7; }
     h1 { color: #22d3ee; margin-bottom: 20px; font-size: 32px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; }
     p { margin: 0 0 16px; }
   </style>

--- a/templates/cover_ats.html
+++ b/templates/cover_ats.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <title>Cover Letter</title>
   <style>
-    body { font-family: Arial, sans-serif; margin: 50px; color: #1f2937; line-height: 1.5; }
+    body { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; margin: 50px; color: #1f2937; line-height: 1.5; }
     h1 { color: #111827; margin-bottom: 16px; font-size: 28px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; }
     p { margin: 0 0 12px; }
   </style>

--- a/templates/cover_classic.html
+++ b/templates/cover_classic.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <title>Cover Letter</title>
   <style>
-    body { font-family: 'Times New Roman', serif; margin: 60px; color: #000; line-height: 1.4; }
-      h1 { text-align: center; font-size: 28px; margin-bottom: 24px; text-transform: uppercase; font-weight: 700; }
+    body { font-family: 'Times New Roman', 'Times', serif; margin: 60px; color: #000; line-height: 1.4; }
+    h1 { text-align: center; font-size: 28px; margin-bottom: 24px; text-transform: uppercase; font-weight: 700; }
     p { margin: 0 0 14px; }
   </style>
 </head>

--- a/templates/cover_modern.css
+++ b/templates/cover_modern.css
@@ -1,5 +1,7 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
 body {
-  font-family: 'Segoe UI', Tahoma, sans-serif;
+  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   margin: 40px;
   color: #333;
   line-height: 1.6;

--- a/templates/cover_professional.html
+++ b/templates/cover_professional.html
@@ -4,7 +4,9 @@
   <meta charset="UTF-8" />
   <title>Cover Letter</title>
   <style>
-    body { font-family: 'Helvetica Neue', Arial, sans-serif; margin: 48px; color: #0f172a; line-height: 1.6; }
+    @import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&display=swap');
+
+    body { font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif; margin: 48px; color: #0f172a; line-height: 1.6; }
     h1 { color: #1d4ed8; margin-bottom: 18px; font-size: 30px; font-weight: 700; letter-spacing: 0.04em; }
     p { margin: 0 0 14px; }
   </style>

--- a/templates/modern.html
+++ b/templates/modern.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <title>Resume</title>
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap');
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
     :root {
       --bg: #0f172a;
@@ -26,7 +26,7 @@
       margin: 0;
       min-height: 100vh;
       padding: clamp(32px, 6vw, 72px);
-      font-family: 'Poppins', 'Segoe UI', Tahoma, sans-serif;
+      font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
       background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.28), transparent 45%),
         radial-gradient(circle at bottom left, rgba(59, 130, 246, 0.22), transparent 48%),
         var(--bg);

--- a/templates/professional.html
+++ b/templates/professional.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <title>Resume</title>
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600;700&display=swap');
+    @import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&display=swap');
 
     :root {
       --bg: #eef2f7;
@@ -24,7 +24,7 @@
     body {
       margin: 0;
       padding: clamp(32px, 6vw, 72px);
-      font-family: 'Source Sans Pro', 'Helvetica Neue', Arial, sans-serif;
+      font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
       background: var(--bg);
       color: var(--text);
     }


### PR DESCRIPTION
## Summary
- switch the Modern, 2025, and matching cover templates to the Inter type stack
- migrate the Professional templates to Lato and the ATS templates to a Helvetica stack
- update the Classic resume and cover letter to rely solely on Times New Roman fallbacks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5b9390c98832b86defe49012210c3