### PR TITLE
Align modern resume template typography with Inter

### DIFF
--- a/docs/ats-template-audit.md
+++ b/docs/ats-template-audit.md
@@ -35,7 +35,7 @@ The audit reviews each template in `templates/` for stylistic complexity, spacin
 ### `modern.html`
 - **Style & layout:** Neon gradients, dark background, and card hover states add heavy visuals that frequently fail ATS parsing, especially due to two-column grid.【F:templates/modern.html†L25-L174】
 - **Spacing:** Adequate spacing but reliant on decorative overlays that can obscure text in conversions.【F:templates/modern.html†L36-L135】
-- **Fonts:** Poppins import is readable; fallback exists but color contrast (light text on dark background) may degrade in ATS.【F:templates/modern.html†L7-L34】
+- **Fonts:** Inter import is readable; fallback exists but color contrast (light text on dark background) may degrade in ATS.【F:templates/modern.html†L7-L34】
 - **Sections & headers:** Uses custom markers and icon boxes that some parsers ignore, risking content loss.【F:templates/modern.html†L95-L195】
 - **Compliance assessment:** ❌ **Not ATS-friendly**; needs simplification to light background, single column, and standard bullets.
 
@@ -75,7 +75,7 @@ The audit reviews each template in `templates/` for stylistic complexity, spacin
 
 ### `cover_2025.html`
 - **Style & layout:** Dark background with bright accent header may create contrast issues in parsing/export.【F:templates/cover_2025.html†L6-L19】
-- **Fonts:** Poppins stack is fine, but uppercase neon header feels decorative.【F:templates/cover_2025.html†L7-L9】
+- **Fonts:** Inter stack is fine, but uppercase neon header feels decorative.【F:templates/cover_2025.html†L7-L9】
 - **Compliance assessment:** ⚠️ **Moderate risk**; recommend light background and standard header formatting.
 
 ### `cover_classic.html`

--- a/templates/modern.html
+++ b/templates/modern.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <title>Resume</title>
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap');
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
     :root {
       --bg: #0f172a;
@@ -26,7 +26,7 @@
       margin: 0;
       min-height: 100vh;
       padding: clamp(32px, 6vw, 72px);
-      font-family: 'Poppins', 'Segoe UI', Tahoma, sans-serif;
+      font-family: 'Inter', 'Inter var', 'Helvetica Neue', Helvetica, Arial, sans-serif;
       background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.28), transparent 45%),
         radial-gradient(circle at bottom left, rgba(59, 130, 246, 0.22), transparent 48%),
         var(--bg);

--- a/tests/__snapshots__/boldHeadings.test.js.snap
+++ b/tests/__snapshots__/boldHeadings.test.js.snap
@@ -7,7 +7,7 @@ exports[`all headings including Skills are bold in HTML and PDF outputs: html 1`
   <meta charset="UTF-8" />
   <title>Resume</title>
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap');
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
     :root {
       --bg: #0f172a;
@@ -29,7 +29,7 @@ exports[`all headings including Skills are bold in HTML and PDF outputs: html 1`
       margin: 0;
       min-height: 100vh;
       padding: clamp(32px, 6vw, 72px);
-      font-family: 'Poppins', 'Segoe UI', Tahoma, sans-serif;
+      font-family: 'Inter', 'Inter var', 'Helvetica Neue', Helvetica, Arial, sans-serif;
       background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.28), transparent 45%),
         radial-gradient(circle at bottom left, rgba(59, 130, 246, 0.22), transparent 48%),
         var(--bg);


### PR DESCRIPTION
## Summary
- switch the modern resume template to use the Inter font stack in place of Poppins
- refresh documentation and snapshots to reflect the Inter typography guidance

## Testing
- npm test -- --updateSnapshot *(fails: environment missing @babel/preset-env dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c76925d0832bb0632e8426dff374