### PR TITLE
Align cover letter layouts with resume themes

### DIFF
--- a/templates/cover_2025.html
+++ b/templates/cover_2025.html
@@ -6,17 +6,173 @@
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
-    body { font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif; margin: 56px; background: #0f172a; color: #e0f2fe; line-height: 1.7; }
-    h1 { color: #22d3ee; margin-bottom: 20px; font-size: 32px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; }
-    p { margin: 0 0 16px; }
+    :root {
+      --accent: #24368a;
+      --accent-soft: #eff3ff;
+      --border: #d7def0;
+      --text: #1c2434;
+      --muted: #5b6b85;
+      --pill: #6366f1;
+      --pill-bg: rgba(99, 102, 241, 0.12);
+      --card-shadow: 0 18px 32px rgba(48, 68, 134, 0.08);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      padding: 32px;
+      font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      color: var(--text);
+      background: #f8fafc;
+      background-image: radial-gradient(circle at 0% 0%, rgba(99, 102, 241, 0.12), transparent 55%),
+        radial-gradient(circle at 100% 30%, rgba(37, 99, 235, 0.08), transparent 45%);
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+    }
+
+    .letter-page {
+      width: 100%;
+      max-width: 820px;
+      background: #ffffff;
+      border-radius: 20px;
+      box-shadow: var(--card-shadow);
+      padding: clamp(40px, 8vw, 72px) clamp(32px, 6vw, 60px);
+      display: grid;
+      gap: 28px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .letter-page::before,
+    .letter-page::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+    }
+
+    .letter-page::before {
+      background: radial-gradient(circle at 12% 8%, rgba(99, 102, 241, 0.18), transparent 42%);
+      mix-blend-mode: multiply;
+    }
+
+    .letter-page::after {
+      background: radial-gradient(circle at 88% 92%, rgba(15, 118, 110, 0.12), transparent 40%);
+      mix-blend-mode: screen;
+    }
+
+    .letter-header {
+      position: relative;
+      z-index: 1;
+      display: grid;
+      gap: 16px;
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 24px;
+    }
+
+    .letter-header h1 {
+      margin: 0;
+      font-size: clamp(2.4rem, 4vw, 3.2rem);
+      letter-spacing: -0.02em;
+      color: var(--accent);
+    }
+
+    .letter-tagline {
+      margin: 0;
+      font-size: 1.05rem;
+      color: var(--muted);
+      max-width: 42ch;
+    }
+
+    .letter-contact {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .letter-contact li {
+      display: inline-flex;
+      align-items: center;
+      padding: 6px 14px;
+      border-radius: 999px;
+      background: var(--pill-bg);
+      color: var(--pill);
+      font-size: 0.85rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.2);
+    }
+
+    .letter-body {
+      position: relative;
+      z-index: 1;
+      display: grid;
+      gap: 18px;
+      font-size: 1.05rem;
+      line-height: 1.75;
+      color: var(--muted);
+    }
+
+    .letter-body p {
+      margin: 0;
+    }
+
+    .letter-body p strong {
+      color: var(--text);
+    }
+
+    @media print {
+      body {
+        padding: 0;
+        background: #ffffff;
+      }
+
+      .letter-page {
+        border-radius: 0;
+        box-shadow: none;
+        padding: 48px 56px;
+      }
+
+      .letter-page::before,
+      .letter-page::after {
+        display: none;
+      }
+    }
   </style>
 </head>
 <body>
-  <h1>{{name}}</h1>
-  {{#each sections}}
-    {{#each items}}
-      <p>{{{this}}}</p>
-    {{/each}}
-  {{/each}}
+  <div class="letter-page">
+    <header class="letter-header">
+      <h1>{{name}}</h1>
+      {{#if headline}}
+      <p class="letter-tagline">{{headline}}</p>
+      {{/if}}
+      {{#if title}}
+      <p class="letter-tagline">{{title}}</p>
+      {{/if}}
+      {{#if contactLines.length}}
+      <ul class="letter-contact">
+        {{#each contactLines}}
+        <li>{{this}}</li>
+        {{/each}}
+      </ul>
+      {{/if}}
+    </header>
+    <main class="letter-body">
+      {{#each sections}}
+        {{#each items}}
+          <p>{{{this}}}</p>
+        {{/each}}
+      {{/each}}
+    </main>
+  </div>
 </body>
 </html>

--- a/templates/cover_ats.html
+++ b/templates/cover_ats.html
@@ -4,17 +4,121 @@
   <meta charset="UTF-8" />
   <title>Cover Letter</title>
   <style>
-    body { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; margin: 50px; color: #1f2937; line-height: 1.5; }
-    h1 { color: #111827; margin-bottom: 16px; font-size: 28px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; }
-    p { margin: 0 0 12px; }
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      padding: 48px 40px;
+      font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      color: #1f2937;
+      background: #f3f4f6;
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+    }
+
+    .letter-page {
+      width: 100%;
+      max-width: 760px;
+      background: #ffffff;
+      border: 1px solid #d1d5db;
+      box-shadow: 0 18px 42px rgba(17, 24, 39, 0.1);
+      padding: 48px 56px;
+      display: grid;
+      gap: 24px;
+    }
+
+    .letter-header {
+      border-bottom: 1px solid #d1d5db;
+      padding-bottom: 16px;
+      display: grid;
+      gap: 8px;
+    }
+
+    .letter-header h1 {
+      margin: 0;
+      font-size: 32px;
+      font-weight: 700;
+      letter-spacing: -0.01em;
+    }
+
+    .letter-tagline {
+      margin: 0;
+      font-size: 14px;
+      color: #4b5563;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .letter-contact {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px 16px;
+      font-size: 0.95rem;
+      color: #4b5563;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    .letter-body {
+      display: grid;
+      gap: 16px;
+      font-size: 1rem;
+      line-height: 1.7;
+    }
+
+    .letter-body p {
+      margin: 0;
+    }
+
+    .letter-body p strong {
+      color: #111827;
+    }
+
+    @media print {
+      body {
+        padding: 0;
+        background: #ffffff;
+      }
+
+      .letter-page {
+        border: none;
+        box-shadow: none;
+        padding: 32px 40px;
+      }
+    }
   </style>
 </head>
 <body>
-  <h1>{{name}}</h1>
-  {{#each sections}}
-    {{#each items}}
-      <p>{{{this}}}</p>
-    {{/each}}
-  {{/each}}
+  <div class="letter-page">
+    <header class="letter-header">
+      <h1>{{name}}</h1>
+      {{#if headline}}
+      <p class="letter-tagline">{{headline}}</p>
+      {{/if}}
+      {{#if title}}
+      <p class="letter-tagline">{{title}}</p>
+      {{/if}}
+      {{#if contactLines.length}}
+      <ul class="letter-contact">
+        {{#each contactLines}}
+        <li>{{this}}</li>
+        {{/each}}
+      </ul>
+      {{/if}}
+    </header>
+    <main class="letter-body">
+      {{#each sections}}
+        {{#each items}}
+          <p>{{{this}}}</p>
+        {{/each}}
+      {{/each}}
+    </main>
+  </div>
 </body>
 </html>

--- a/templates/cover_classic.html
+++ b/templates/cover_classic.html
@@ -4,17 +4,133 @@
   <meta charset="UTF-8" />
   <title>Cover Letter</title>
   <style>
-    body { font-family: 'Times New Roman', 'Times', serif; margin: 60px; color: #000; line-height: 1.4; }
-    h1 { text-align: center; font-size: 28px; margin-bottom: 24px; text-transform: uppercase; font-weight: 700; }
-    p { margin: 0 0 14px; }
+    :root {
+      --ink: #1f2933;
+      --muted: #52606d;
+      --accent: #2d5a9e;
+      --background: #fbfaf7;
+      --border: rgba(31, 41, 51, 0.12);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      padding: 48px 56px;
+      font-family: 'Times New Roman', 'Times', serif;
+      color: var(--ink);
+      background: linear-gradient(180deg, rgba(241, 245, 249, 0.9), transparent 120%),
+        var(--background);
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+    }
+
+    .letter-sheet {
+      width: 100%;
+      max-width: 820px;
+      margin: 0 auto;
+      background: #ffffff;
+      border: 1px solid var(--border);
+      box-shadow: 0 24px 50px rgba(31, 41, 51, 0.08);
+      padding: 56px 64px;
+      border-radius: 12px;
+      display: grid;
+      gap: 28px;
+    }
+
+    .letter-header {
+      border-bottom: 2px solid var(--accent);
+      padding-bottom: 24px;
+      display: grid;
+      gap: 12px;
+    }
+
+    .letter-header h1 {
+      font-size: 36px;
+      letter-spacing: 0.04em;
+      margin: 0;
+      text-transform: uppercase;
+    }
+
+    .letter-tagline {
+      margin: 0;
+      font-size: 16px;
+      letter-spacing: 0.12em;
+      color: var(--muted);
+      text-transform: uppercase;
+    }
+
+    .letter-contact {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px 16px;
+      font-size: 0.95rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .letter-body {
+      display: grid;
+      gap: 18px;
+      font-size: 1.05rem;
+      line-height: 1.7;
+    }
+
+    .letter-body p {
+      margin: 0;
+    }
+
+    .letter-body p strong {
+      color: var(--accent);
+    }
+
+    @media print {
+      body {
+        padding: 0;
+        background: #ffffff;
+      }
+
+      .letter-sheet {
+        border-radius: 0;
+        border: none;
+        box-shadow: none;
+        padding: 48px 56px;
+      }
+    }
   </style>
 </head>
 <body>
-  <h1>{{name}}</h1>
-  {{#each sections}}
-    {{#each items}}
-      <p>{{{this}}}</p>
-    {{/each}}
-  {{/each}}
+  <div class="letter-sheet">
+    <header class="letter-header">
+      <h1>{{name}}</h1>
+      {{#if headline}}
+      <p class="letter-tagline">{{headline}}</p>
+      {{/if}}
+      {{#if title}}
+      <p class="letter-tagline">{{title}}</p>
+      {{/if}}
+      {{#if contactLines.length}}
+      <ul class="letter-contact">
+        {{#each contactLines}}
+        <li>{{this}}</li>
+        {{/each}}
+      </ul>
+      {{/if}}
+    </header>
+    <main class="letter-body">
+      {{#each sections}}
+        {{#each items}}
+          <p>{{{this}}}</p>
+        {{/each}}
+      {{/each}}
+    </main>
+  </div>
 </body>
 </html>

--- a/templates/cover_modern.css
+++ b/templates/cover_modern.css
@@ -1,19 +1,139 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
+:root {
+  --bg: #0f172a;
+  --surface: #0b1120;
+  --accent: #38bdf8;
+  --accent-soft: rgba(56, 189, 248, 0.22);
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --shadow: 0 24px 60px rgba(8, 47, 73, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  font-family: 'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  margin: 40px;
-  color: #333;
-  line-height: 1.6;
+  margin: 0;
+  min-height: 100vh;
+  padding: clamp(32px, 6vw, 72px);
+  font-family: 'Inter', 'Inter var', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.28), transparent 45%),
+    radial-gradient(circle at bottom left, rgba(59, 130, 246, 0.22), transparent 48%),
+    var(--bg);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
 }
 
-h1 {
-  color: #2a9d8f;
-  margin-bottom: 20px;
-  font-size: 32px;
+.letter-shell {
+  width: 100%;
+  max-width: 760px;
+  background: var(--surface);
+  border-radius: 28px;
+  padding: clamp(40px, 6vw, 60px);
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  display: grid;
+  gap: clamp(28px, 5vw, 36px);
+  position: relative;
+  overflow: hidden;
+}
+
+.letter-shell::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.12), transparent 55%);
+  pointer-events: none;
+}
+
+.letter-header {
+  position: relative;
+  z-index: 1;
+  border-radius: 24px;
+  padding: clamp(24px, 4vw, 32px);
+  background: linear-gradient(120deg, rgba(14, 165, 233, 0.45), rgba(56, 189, 248, 0.18));
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(226, 232, 240, 0.12);
+  display: grid;
+  gap: 18px;
+}
+
+.letter-identity {
+  display: grid;
+  gap: 6px;
+}
+
+.letter-header h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 3rem);
   font-weight: 700;
+  letter-spacing: -0.01em;
+  color: #ffffff;
 }
 
-p {
-  margin: 0 0 12px;
+.letter-tagline {
+  margin: 0;
+  color: rgba(241, 245, 249, 0.85);
+  font-size: 1rem;
+  max-width: 40ch;
+}
+
+.letter-contact {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+}
+
+.letter-contact li {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: rgba(226, 232, 240, 0.9);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.letter-body {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 18px;
+  font-size: 1.05rem;
+  line-height: 1.8;
+  color: var(--text);
+}
+
+.letter-body p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.letter-body p strong {
+  color: var(--text);
+}
+
+@media print {
+  body {
+    padding: 0;
+    background: #ffffff;
+    color: #000000;
+  }
+
+  .letter-shell {
+    box-shadow: none;
+    border-radius: 0;
+    border: none;
+    padding: 48px 56px;
+    background: #ffffff;
+  }
+
+  .letter-shell::after {
+    display: none;
+  }
 }

--- a/templates/cover_modern.html
+++ b/templates/cover_modern.html
@@ -1,16 +1,37 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>Cover Letter</title>
-  <link rel="stylesheet" href="cover_modern.css" />
-</head>
-<body>
-  <h1>{{name}}</h1>
-  {{#each sections}}
-    {{#each items}}
-      <p>{{{this}}}</p>
-    {{/each}}
-  {{/each}}
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cover Letter</title>
+    <link rel="stylesheet" href="cover_modern.css" />
+  </head>
+  <body>
+    <div class="letter-shell">
+      <header class="letter-header">
+        <div class="letter-identity">
+          <h1>{{name}}</h1>
+          {{#if headline}}
+          <p class="letter-tagline">{{headline}}</p>
+          {{/if}}
+          {{#if title}}
+          <p class="letter-tagline">{{title}}</p>
+          {{/if}}
+        </div>
+        {{#if contactLines.length}}
+        <ul class="letter-contact">
+          {{#each contactLines}}
+          <li>{{this}}</li>
+          {{/each}}
+        </ul>
+        {{/if}}
+      </header>
+      <main class="letter-body">
+        {{#each sections}}
+          {{#each items}}
+            <p>{{{this}}}</p>
+          {{/each}}
+        {{/each}}
+      </main>
+    </div>
+  </body>
 </html>

--- a/templates/cover_professional.html
+++ b/templates/cover_professional.html
@@ -6,17 +6,140 @@
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&display=swap');
 
-    body { font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif; margin: 48px; color: #0f172a; line-height: 1.6; }
-    h1 { color: #1d4ed8; margin-bottom: 18px; font-size: 30px; font-weight: 700; letter-spacing: 0.04em; }
-    p { margin: 0 0 14px; }
+    :root {
+      --bg: #eef2f7;
+      --sheet: #ffffff;
+      --accent: #1d3557;
+      --accent-soft: rgba(29, 53, 87, 0.08);
+      --border: #d7dee8;
+      --text: #1f2a37;
+      --muted: #556072;
+      --highlight: #f3f5fb;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      padding: clamp(32px, 6vw, 72px);
+      font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+    }
+
+    .letter-wrapper {
+      width: 100%;
+      max-width: 760px;
+      background: var(--sheet);
+      border-radius: 28px;
+      padding: clamp(48px, 6vw, 64px);
+      box-shadow: 0 24px 50px rgba(15, 23, 42, 0.12);
+      border: 1px solid rgba(209, 213, 219, 0.6);
+      display: grid;
+      gap: clamp(28px, 4vw, 36px);
+    }
+
+    .letter-header {
+      border-bottom: 2px solid var(--border);
+      padding-bottom: 28px;
+      display: grid;
+      gap: 10px;
+    }
+
+    .letter-header h1 {
+      margin: 0;
+      font-size: clamp(2.2rem, 4vw, 3rem);
+      color: var(--accent);
+      letter-spacing: -0.01em;
+    }
+
+    .letter-tagline {
+      margin: 0;
+      color: var(--muted);
+      font-size: 1.05rem;
+      max-width: 48ch;
+    }
+
+    .letter-contact {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 16px;
+    }
+
+    .letter-contact li {
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--accent);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .letter-body {
+      display: grid;
+      gap: 18px;
+      font-size: 1.05rem;
+      line-height: 1.75;
+      color: var(--text);
+    }
+
+    .letter-body p {
+      margin: 0;
+      color: var(--muted);
+    }
+
+    .letter-body p strong {
+      color: var(--accent);
+    }
+
+    @media print {
+      body {
+        padding: 0;
+        background: #ffffff;
+      }
+
+      .letter-wrapper {
+        box-shadow: none;
+        border-radius: 0;
+        border: none;
+        padding: 48px 56px;
+      }
+    }
   </style>
 </head>
 <body>
-  <h1>{{name}}</h1>
-  {{#each sections}}
-    {{#each items}}
-      <p>{{{this}}}</p>
-    {{/each}}
-  {{/each}}
+  <div class="letter-wrapper">
+    <header class="letter-header">
+      <h1>{{name}}</h1>
+      {{#if headline}}
+      <p class="letter-tagline">{{headline}}</p>
+      {{/if}}
+      {{#if title}}
+      <p class="letter-tagline">{{title}}</p>
+      {{/if}}
+      {{#if contactLines.length}}
+      <ul class="letter-contact">
+        {{#each contactLines}}
+        <li>{{this}}</li>
+        {{/each}}
+      </ul>
+      {{/if}}
+    </header>
+    <main class="letter-body">
+      {{#each sections}}
+        {{#each items}}
+          <p>{{{this}}}</p>
+        {{/each}}
+      {{/each}}
+    </main>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restyled each cover letter template to mirror its paired resume header, spacing, and typography
- added optional headline and contact pill rendering so cover letters inherit resume metadata when available
- refreshed the modern cover stylesheet to share the gradient shell, print tweaks, and spacing used by the CV theme

## Testing
- npm test *(fails: Cannot find package '@babel/preset-env' imported from babel-virtual-resolve-base.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e68acc0ce8832b97b8b45d5c7f8148