### PR TITLE
Improve ATS resume rendering for ATS mode

### DIFF
--- a/templates/ats.html
+++ b/templates/ats.html
@@ -6,61 +6,92 @@
   <style>
     body {
       margin: 0;
-      padding: 48px 40px;
+      padding: 40px 32px;
       font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
-      color: #1f2937;
-      background: #f3f4f6;
+      color: #111827;
+      background: #f8fafc;
     }
 
     .page {
-      max-width: 800px;
+      max-width: 760px;
       margin: 0 auto;
       background: #ffffff;
-      border: 1px solid #d1d5db;
-      box-shadow: 0 18px 42px rgba(17, 24, 39, 0.1);
+      border: 1px solid #e5e7eb;
       padding: 48px 56px;
     }
 
     header {
-      border-bottom: 1px solid #d1d5db;
-      padding-bottom: 16px;
-      margin-bottom: 24px;
+      margin-bottom: 28px;
     }
 
     header h1 {
       margin: 0;
-      font-size: 32px;
+      font-size: 30px;
       font-weight: 700;
       letter-spacing: -0.01em;
     }
 
-    header p {
-      margin: 4px 0 0;
-      font-size: 14px;
-      color: #4b5563;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-    }
-
-    section {
-      margin-bottom: 22px;
-    }
-
-    h2 {
-      margin: 0 0 12px;
+    .subtitle {
+      margin: 6px 0 0;
       font-size: 16px;
-      font-weight: 700;
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
+      font-weight: 500;
+      color: #374151;
+    }
+
+    .contact-list {
+      list-style: none;
+      margin: 16px 0 0;
+      padding: 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 20px;
+    }
+
+    .contact-list li {
+      font-size: 13px;
       color: #1f2937;
     }
 
+    .contact-label {
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      margin-right: 4px;
+      color: #111827;
+    }
+
+    .contact-separator {
+      margin-right: 4px;
+      color: #6b7280;
+    }
+
+    .contact-value {
+      color: #1f2937;
+    }
+
+    section {
+      margin-bottom: 24px;
+    }
+
+    section:last-of-type {
+      margin-bottom: 0;
+    }
+
+    h2 {
+      margin: 0 0 10px;
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: #111827;
+    }
+
     ul {
-      list-style: disc;
+      list-style: none;
       margin: 0;
-      padding-left: 20px;
+      padding: 0;
       display: grid;
-      gap: 8px;
+      gap: 10px;
     }
 
     li {
@@ -69,27 +100,43 @@
       white-space: pre-wrap;
     }
 
-    .section-list--contact,
-    .section-list--summary,
+    .section-item--experience,
+    .section-item--education,
+    .section-item--other {
+      display: block;
+    }
+
+    .section-list--experience,
+    .section-list--education,
+    .section-list--other {
+      gap: 12px;
+    }
+
     .section-list--skills,
-    .section-list--certifications {
-      list-style: none;
-      padding-left: 0;
+    .section-list--certifications,
+    .section-list--summary,
+    .section-list--contact {
+      gap: 6px;
     }
 
-    .section-item--contact,
-    .section-item--summary,
+    .section-list--skills .bullet,
+    .section-list--certifications .bullet,
+    .section-list--summary .bullet,
+    .section-list--contact .bullet {
+      display: none;
+    }
+
     .section-item--skills,
-    .section-item--certifications {
+    .section-item--certifications,
+    .section-item--summary,
+    .section-item--contact {
       padding-left: 0;
     }
 
-    li strong {
+    .bullet,
+    .edu-bullet {
+      margin-right: 8px;
       color: #111827;
-    }
-
-    li em {
-      color: #4b5563;
     }
 
     @media print {
@@ -97,34 +144,68 @@
         padding: 0;
         background: #ffffff;
       }
+
       .page {
-        box-shadow: none;
         border: none;
+        box-shadow: none;
         padding: 32px 40px;
+      }
+
+      .contact-list {
+        gap: 6px 16px;
       }
     }
   </style>
 </head>
-<body>
+<body{{#if templateParams.atsMode}} data-ats-mode="true"{{/if}}>
   <div class="page">
     <header>
       <h1>{{name}}</h1>
-      <p>ATS Optimized Resume</p>
-    </header>
-    {{#each sections}}
-    <section class="{{sectionClass}}">
-      {{#if heading}}
-      <h2 class="{{headingClass}}">{{heading}}</h2>
+      {{#if templateParams.jobTitle}}
+      <p class="subtitle">{{templateParams.jobTitle}}</p>
+      {{else}}
+        {{#if templateParams.contact.jobTitle}}
+      <p class="subtitle">{{templateParams.contact.jobTitle}}</p>
+        {{else}}
+          {{#if contact.jobTitle}}
+      <p class="subtitle">{{contact.jobTitle}}</p>
+          {{/if}}
+        {{/if}}
       {{/if}}
-      {{#if items}}
-      <ul class="{{listClass}}">
-        {{#each items}}
-        <li class="{{../itemClass}}">{{{this}}}</li>
+      {{#if contact.entries.length}}
+      <ul class="contact-list">
+        {{#each contact.entries}}
+        <li>{{{html}}}</li>
         {{/each}}
       </ul>
+      {{else}}
+        {{#if contactLines.length}}
+      <ul class="contact-list">
+        {{#each contactLines}}
+        <li>{{this}}</li>
+        {{/each}}
+      </ul>
+        {{/if}}
       {{/if}}
-    </section>
-    {{/each}}
+    </header>
+    <main>
+      {{#each sections}}
+      <section class="section{{#if sectionClass}} {{sectionClass}}{{/if}}">
+        {{#if heading}}
+        <h2 class="section-heading{{#if headingClass}} {{headingClass}}{{/if}}">{{heading}}</h2>
+        {{/if}}
+        {{#if items}}
+        <ul class="section-list{{#if listClass}} {{listClass}}{{/if}}">
+          {{#each items}}
+          <li class="section-item{{#if ../itemClass}} {{../itemClass}}{{/if}}">
+            {{{this}}}
+          </li>
+          {{/each}}
+        </ul>
+        {{/if}}
+      </section>
+      {{/each}}
+    </main>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure ATS template mode is enforced when the ATS layout is requested so fallbacks stay single-column
- update the ATS HTML template with structured contact details and simplified styling for parser-friendly output

## Testing
- `npm test -- generatePdf` *(fails: Cannot find package '@babel/preset-env' imported from babel-virtual-resolve-base.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e68ed32c54832b831e47936b774606