### PR TITLE
Add template badges for resume selector

### DIFF
--- a/client/src/__tests__/AppTemplateSelection.test.jsx
+++ b/client/src/__tests__/AppTemplateSelection.test.jsx
@@ -6,11 +6,17 @@ import TemplateSelector from '../components/TemplateSelector.jsx'
 
 describe('TemplateSelector', () => {
   const options = [
-    { id: 'modern', name: 'Modern Minimal', description: 'Minimal layout with ATS-safe spacing.' },
+    {
+      id: 'modern',
+      name: 'Modern Minimal',
+      description: 'Minimal layout with ATS-safe spacing.',
+      badge: 'Best for Tech Roles'
+    },
     {
       id: 'professional',
       name: 'Professional Blue',
-      description: 'Conservative layout with blue dividers.'
+      description: 'Conservative layout with blue dividers.',
+      badge: 'Best for Sr Managers'
     }
   ]
 

--- a/client/src/components/TemplateSelector.jsx
+++ b/client/src/components/TemplateSelector.jsx
@@ -209,12 +209,21 @@ function TemplateSelector({
                 isSelected ? 'border-purple-500 ring-2 ring-purple-200' : 'border-purple-200 hover:border-purple-400 hover:shadow-md'
               } ${disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
             >
-              <div className="flex items-center justify-between gap-2">
+              <div className="flex items-start justify-between gap-2">
                 <span className="text-sm font-semibold text-purple-900">{option.name}</span>
-                {isSelected && !disabled && (
-                  <span className="rounded-full bg-purple-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-purple-700">
-                    Selected
-                  </span>
+                {(option.badge || (isSelected && !disabled)) && (
+                  <div className="flex flex-col items-end gap-1 text-right">
+                    {option.badge && (
+                      <span className="rounded-full bg-purple-50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-purple-700">
+                        {option.badge}
+                      </span>
+                    )}
+                    {isSelected && !disabled && (
+                      <span className="rounded-full bg-purple-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-purple-700">
+                        Selected
+                      </span>
+                    )}
+                  </div>
                 )}
               </div>
               <TemplatePreviewThumbnail variant={variant} testId={`${idPrefix}-preview-${option.id}`} />

--- a/client/src/components/__tests__/TemplateSelector.test.jsx
+++ b/client/src/components/__tests__/TemplateSelector.test.jsx
@@ -6,8 +6,18 @@ import TemplateSelector from '../TemplateSelector.jsx'
 
 describe('TemplateSelector', () => {
   const options = [
-    { id: 'modern', name: 'Modern Minimal', description: 'Two-column balance.' },
-    { id: 'professional', name: 'Professional Blue', description: 'Classic layout.' }
+    {
+      id: 'modern',
+      name: 'Modern Minimal',
+      description: 'Two-column balance.',
+      badge: 'Best for Tech Roles'
+    },
+    {
+      id: 'professional',
+      name: 'Professional Blue',
+      description: 'Classic layout.',
+      badge: 'Best for Sr Managers'
+    }
   ]
 
   it('renders options with previews and reflects the selected template', () => {
@@ -19,6 +29,7 @@ describe('TemplateSelector', () => {
     const modernOption = within(group).getByRole('radio', { name: /Modern Minimal/i })
     expect(modernOption).toHaveAttribute('aria-checked', 'true')
     expect(screen.getByTestId('template-selector-preview-modern')).toBeInTheDocument()
+    expect(within(modernOption).getByText(/Best for Tech Roles/i)).toBeInTheDocument()
     expect(screen.getByTestId('template-selector-selected-description')).toHaveTextContent(
       /Two-column balance\./i
     )
@@ -42,6 +53,7 @@ describe('TemplateSelector', () => {
     fireEvent.click(professionalOption)
 
     expect(handleSelect).toHaveBeenCalledWith('professional')
+    expect(within(professionalOption).getByText(/Best for Sr Managers/i)).toBeInTheDocument()
   })
 
   it('respects the disabled state', () => {

--- a/client/src/templateRegistry.js
+++ b/client/src/templateRegistry.js
@@ -24,12 +24,14 @@ export const BASE_TEMPLATE_OPTIONS = [
   {
     id: 'modern',
     name: 'Modern Minimal',
-    description: 'Sleek two-column layout with clean dividers and ATS-safe spacing.'
+    description: 'Sleek two-column layout with clean dividers and ATS-safe spacing.',
+    badge: 'Best for Tech Roles'
   },
   {
     id: 'professional',
     name: 'Professional Edge',
-    description: 'Refined corporate styling with confident headings and balanced whitespace.'
+    description: 'Refined corporate styling with confident headings and balanced whitespace.',
+    badge: 'Best for Sr Managers'
   },
   {
     id: 'classic',
@@ -39,7 +41,8 @@ export const BASE_TEMPLATE_OPTIONS = [
   {
     id: 'ats',
     name: 'ATS Optimized',
-    description: 'Single-column structure engineered for parsing accuracy.'
+    description: 'Single-column structure engineered for parsing accuracy.',
+    badge: 'High Impact/ATS'
   },
   {
     id: '2025',


### PR DESCRIPTION
## Summary
- add marketing badges to resume template registry entries for quick guidance
- render the optional badge inside the template selector UI next to each option
- update selector unit tests to cover the new badges

## Testing
- npm test *(fails: Cannot find package '@babel/preset-env' imported from /workspace/ResumeForge/babel-virtual-resolve-base.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e69147f604832bb981bba34b173a72